### PR TITLE
Fix io poller

### DIFF
--- a/core/io_poller.h
+++ b/core/io_poller.h
@@ -10,7 +10,7 @@ typedef void (*io_poller_cb)(void *user_data, int events);
 struct io_poller *io_poller_create(void);
 void io_poller_destroy(struct io_poller *io);
 int io_poller_poll(struct io_poller *io, int milliseconds);
-void io_poller_perform(struct io_poller *io);
+int io_poller_perform(struct io_poller *io);
 
 bool io_poller_fd_add(struct io_poller *io,
                       int fd,
@@ -19,11 +19,12 @@ bool io_poller_fd_add(struct io_poller *io,
                       void *user_data);
 bool io_poller_fd_del(struct io_poller *io, int fd);
 
-typedef void (*io_poller_curl_cb)(CURLM *multi, void *user_data);
+typedef int (*io_poller_curl_cb)(CURLM *multi, void *user_data);
 bool io_poller_curlm_add(struct io_poller *io,
                          CURLM *multi,
                          io_poller_curl_cb cb,
                          void *user_data);
 bool io_poller_curlm_del(struct io_poller *io, CURLM *multi);
+bool io_poller_curlm_enable_perform(struct io_poller *io, CURLM *multi);
 
 #endif // CONCORD_IO_POLLER_H

--- a/src/adapter.c
+++ b/src/adapter.c
@@ -27,11 +27,11 @@ setopt_cb(struct ua_conn *conn, void *p_token)
 #endif
 }
 
-static void
+static int
 on_io_poller_curl(CURLM *mhandle, void *user_data)
 {
     (void)mhandle;
-    discord_adapter_perform(user_data);
+    return discord_adapter_perform(user_data);
 }
 
 void
@@ -613,6 +613,8 @@ _discord_adapter_run_async(struct discord_adapter *adapter,
 
     if (req->ret.data)
         discord_refcount_incr(adapter, req->ret.data, req->ret.cleanup);
+
+    io_poller_curlm_enable_perform(CLIENT(adapter, adapter)->io_poller, adapter->mhandle);
 
     return CCORD_OK;
 }

--- a/src/client.c
+++ b/src/client.c
@@ -256,7 +256,8 @@ discord_run(struct discord *client)
         while (1) {
             io_poller_poll(client->io_poller,
                            client->gw.cmds.cbs.on_idle ? 1 : 1000);
-            io_poller_perform(client->io_poller);
+            if (CCORD_OK != (code = io_poller_perform(client->io_poller)))
+                break;
 
             now = time(NULL);
             if (last != now) {
@@ -266,11 +267,11 @@ discord_run(struct discord *client)
                 last = now;
             }
 
-            if (CCORD_OK != (code = discord_adapter_perform(&client->adapter)))
-                break;
-
             if (client->gw.cmds.cbs.on_idle)
                 client->gw.cmds.cbs.on_idle(client);
+            
+            if (CCORD_OK != (code = io_poller_perform(client->io_poller)))
+                break;
         }
 
         if (true == discord_gateway_end(&client->gw)) {

--- a/src/gateway.c
+++ b/src/gateway.c
@@ -49,6 +49,7 @@ discord_gateway_send_presence_update(struct discord_gateway *gw)
     ASSERT_S(len < sizeof(buf), "Out of bounds write attempt");
 
     ws_send_text(gw->ws, &info, buf, len);
+    io_poller_curlm_enable_perform(CLIENT(gw, gw)->io_poller, gw->mhandle);
 
     logconf_info(
         &gw->conf,
@@ -91,6 +92,7 @@ send_resume(struct discord_gateway *gw)
     }
 
     ws_send_text(gw->ws, &info, buf, b.pos);
+    io_poller_curlm_enable_perform(CLIENT(gw, gw)->io_poller, gw->mhandle);
 
     logconf_info(
         &gw->conf,
@@ -125,6 +127,7 @@ send_identify(struct discord_gateway *gw)
     ASSERT_S(len < sizeof(buf), "Out of bounds write attempt");
 
     ws_send_text(gw->ws, &info, buf, len);
+    io_poller_curlm_enable_perform(CLIENT(gw, gw)->io_poller, gw->mhandle);
 
     logconf_info(
         &gw->conf,
@@ -156,6 +159,7 @@ send_heartbeat(struct discord_gateway *gw)
     }
 
     ws_send_text(gw->ws, &info, buf, b.pos);
+    io_poller_curlm_enable_perform(CLIENT(gw, gw)->io_poller, gw->mhandle);
 
     logconf_info(
         &gw->conf,
@@ -1217,11 +1221,11 @@ default_scheduler_cb(struct discord *a,
     return DISCORD_EVENT_MAIN_THREAD;
 }
 
-static void
+static int
 on_io_poller_curl(CURLM *mhandle, void *user_data)
 {
     (void)mhandle;
-    discord_gateway_perform(user_data);
+    return discord_gateway_perform(user_data);
 }
 
 void


### PR DESCRIPTION
Remove the requirement for calling the adapter in the main loop.

Hopefully this also fixes reconnect reason 4900 which was most likely caused by the ping not being sent immediately. If this is not the case, consider reducing ping interval from discord's recommended by 3000ms just to be safe.