### PR TITLE
io_poller docs, and features.

### DIFF
--- a/core/io_poller.h
+++ b/core/io_poller.h
@@ -4,38 +4,107 @@
 #include <stdbool.h>
 #include <curl/curl.h>
 
+/**
+ * @brief The flags to poll for
+ */
 enum io_poller_events {
   IO_POLLER_IN  = 1 << 0,
   IO_POLLER_OUT = 1 << 1,
 };
 
+/**
+ * @brief a socket or file descriptor
+ */
 typedef int io_poller_socket;
 
+/**
+ * @brief handle for watching file descriptors, sockets, and curl multis
+ */
 struct io_poller;
+
+/**
+ * @brief callback for when an event is triggered by the socket
+ */
 typedef void (*io_poller_cb)(struct io_poller *io,
                              enum io_poller_events events,
                              void *user_data);
 
 struct io_poller *io_poller_create(void);
 void io_poller_destroy(struct io_poller *io);
+
+/**
+ * @brief wait for events to be triggered
+ * @param io the io_poller to poll on
+ * @param milliseconds -1 for infinity, or ms to poll for
+ * @return -1 for error, or number of sockets that have events waiting
+ */
 int io_poller_poll(struct io_poller *io, int milliseconds);
+
+/**
+ * @brief performs any actions needed and clears events set by io_poller_poll
+ * @param io the io_poller to perform on
+ * @return 0 on success
+ */
 int io_poller_perform(struct io_poller *io);
 
+/**
+ * @brief adds or modifies a socket or file descriptor to watch list
+ * @param io the io_poller to add socket to
+ * @param sock the file descriptor or socket to handle
+ * @param events the events to watch for
+ * @param cb the callback for when any event is triggered
+ * @param user_data custom user data
+ * @return true on success
+ */
 bool io_poller_socket_add(struct io_poller *io,
                           io_poller_socket sock,
                           enum io_poller_events events,
                           io_poller_cb cb,
                           void *user_data);
+
+/**
+ * @brief removes a socket or file descriptor from watch list
+ * @param io the io_poller to remove the socket from
+ * @param sock the file descriptor or socket to remove
+ * @return true on success
+ */
 bool io_poller_socket_del(struct io_poller *io, io_poller_socket sock);
 
+/**
+ * @brief callback for when curl multi should be performed on
+ */
 typedef int (*io_poller_curl_cb)(struct io_poller *io,
                                  CURLM *multi,
                                  void *user_data);
+
+/**
+ * @brief add or modifies a curl multi to watch list
+ * @param io the io_poller to add curl multi to
+ * @param multi the curl multi to add or modify
+ * @param cb the callback for when curl multi should be performed on
+ * @param user_data custom user data
+ * @return true on success
+ */
 bool io_poller_curlm_add(struct io_poller *io,
                          CURLM *multi,
                          io_poller_curl_cb cb,
                          void *user_data);
+
+/**
+ * @brief remove curl multi from watch list
+ * @param io the io_poller to remove curl multi from
+ * @param multi the curl multi to remove
+ * @return true on success
+ */
 bool io_poller_curlm_del(struct io_poller *io, CURLM *multi);
+
+/**
+ * @brief this multi should be performed on next cycle
+ * causing poll to return immediately
+ * @param io the io_poller to enable perform on
+ * @param multi the multi that should be performed
+ * @return true on success
+ */
 bool io_poller_curlm_enable_perform(struct io_poller *io, CURLM *multi);
 
 #endif // CONCORD_IO_POLLER_H

--- a/core/io_poller.h
+++ b/core/io_poller.h
@@ -5,8 +5,8 @@
 #include <curl/curl.h>
 
 enum io_poller_events {
-  IO_POLLER_IN = 1,
-  IO_POLLER_OUT = 2,
+  IO_POLLER_IN  = 1 << 0,
+  IO_POLLER_OUT = 1 << 1,
 };
 
 typedef int io_poller_socket;

--- a/core/io_poller.h
+++ b/core/io_poller.h
@@ -12,7 +12,9 @@ enum io_poller_events {
 typedef int io_poller_socket;
 
 struct io_poller;
-typedef void (*io_poller_cb)(void *user_data, enum io_poller_events events);
+typedef void (*io_poller_cb)(struct io_poller *io,
+                             enum io_poller_events events,
+                             void *user_data);
 
 struct io_poller *io_poller_create(void);
 void io_poller_destroy(struct io_poller *io);
@@ -20,13 +22,15 @@ int io_poller_poll(struct io_poller *io, int milliseconds);
 int io_poller_perform(struct io_poller *io);
 
 bool io_poller_socket_add(struct io_poller *io,
-                      io_poller_socket sock,
-                      enum io_poller_events events,
-                      io_poller_cb cb,
-                      void *user_data);
+                          io_poller_socket sock,
+                          enum io_poller_events events,
+                          io_poller_cb cb,
+                          void *user_data);
 bool io_poller_socket_del(struct io_poller *io, io_poller_socket sock);
 
-typedef int (*io_poller_curl_cb)(CURLM *multi, void *user_data);
+typedef int (*io_poller_curl_cb)(struct io_poller *io,
+                                 CURLM *multi,
+                                 void *user_data);
 bool io_poller_curlm_add(struct io_poller *io,
                          CURLM *multi,
                          io_poller_curl_cb cb,

--- a/include/discord.h
+++ b/include/discord.h
@@ -18,6 +18,7 @@
 #include "error.h"
 #include "types.h"
 #include "concord-once.h"
+#include "io_poller.h"
 
 #define DISCORD_API_BASE_URL       "https://discord.com/api/v9"
 #define DISCORD_GATEWAY_URL_SUFFIX "?v=9&encoding=json"
@@ -264,6 +265,14 @@ uint64_t discord_timestamp(struct discord *client);
  * @return the client's logging module
  */
 struct logconf *discord_get_logconf(struct discord *client);
+
+/**
+ * @brief get the io_poller used by the discord client
+ * 
+ * @param client the client created with discord_init()
+ * @return struct io_poller* 
+ */
+struct io_poller *discord_get_io_poller(struct discord *client);
 
 /** @} Discord */
 

--- a/src/discord-adapter.c
+++ b/src/discord-adapter.c
@@ -30,8 +30,9 @@ setopt_cb(struct ua_conn *conn, void *p_token)
 }
 
 static int
-on_io_poller_curl(CURLM *mhandle, void *user_data)
+on_io_poller_curl(struct io_poller *io, CURLM *mhandle, void *user_data)
 {
+    (void)io;
     (void)mhandle;
     return discord_adapter_perform(user_data);
 }

--- a/src/discord-client.c
+++ b/src/discord-client.c
@@ -690,3 +690,9 @@ discord_get_logconf(struct discord *client)
 {
     return &client->conf;
 }
+
+struct io_poller *
+discord_get_io_poller(struct discord *client)
+{
+    return client->io_poller;
+}

--- a/src/discord-gateway.c
+++ b/src/discord-gateway.c
@@ -1460,8 +1460,9 @@ default_scheduler_cb(struct discord *a,
 }
 
 static int
-on_io_poller_curl(CURLM *mhandle, void *user_data)
+on_io_poller_curl(struct io_poller *io, CURLM *mhandle, void *user_data)
 {
+    (void)io;
     (void)mhandle;
     return discord_gateway_perform(user_data);
 }


### PR DESCRIPTION
## What?
Changes all relate to io_poller
Added documentation, extra param `struct io_poller *io` to io_poller_callbacks and a new function discord_get_io_poller()

## Why?
Eliminate the requirement for the user to have a separate thread when they want to poll their own file descriptors

simple example using stdin
```c
static void
on_stdin(struct io_poller *io, enum io_poller_events events, void *data) {
  struct discord *client = data;
  char buf[4096];
  int n = read(STDIN_FILENO, buf, sizeof buf);
  write(STDOUT_FILENO, buf, n);
}

int
main(void) {
  struct discord *client = discord_config_init("config.json");
  struct io_poller *io = discord_get_io_poller(client);
  io_poller_socket_add(io, STDIN_FILENO, IO_POLLER_IN, on_stdin, client);
  discord_run(client);
}

```
