### PR TITLE
fix: improper conversion of iso8601 date to unix timestamp

### DIFF
--- a/cog-utils/cog-utils.c
+++ b/cog-utils/cog-utils.c
@@ -96,7 +96,7 @@ cog_iso8601_to_unix_ms(const char str[], size_t len, uint64_t *p_value)
   tm.tm_year -= 1900; /* struct tm takes years from 1900 */
 
   *p_value = (((uint64_t)mktime(&tm) + cog_timezone()) * 1000)
-             + (uint64_t)seconds * 1000.0;
+             + (uint64_t)(seconds * 1000.0);
 
   switch (tz_operator) {
   case '+': /* Add hours and minutes */


### PR DESCRIPTION
## What?
Fixes the ``cog_iso8601_to_unix_ms`` function to properly account for milliseconds in ISO8601 dates

## Why?
Previously, the function was broken because the double ``second`` field was being cast to a uint_64 **before** being multiplied by 1000, thus the decimal was being rounded For example, ``54.043`` was being cast to ``54`` before being multiplied by 1000, thus the result was 54000 instead of 54043

## How?
The solution was to add parenthesis so that the multiplication happens before the casting. 

## Testing?
I tested my changes by creating another bot in discord.js and comparing the timestamps there with the timestamps generated by concord.

## Screenshots (optional)
Here's what the behavior looked like **before** I made these changes (notice that Concord's timestamps are rounded to the nearest thousands):
![image](https://user-images.githubusercontent.com/65155829/158384475-3028416f-a3f7-4a9d-9a9b-a1ef8fc8c63a.png)
![image](https://user-images.githubusercontent.com/65155829/158384506-d2183899-a557-428e-9f8c-deb592b87f20.png)

Here's what the behavior is like **after** I made the changes:
![image](https://user-images.githubusercontent.com/65155829/158384612-46b7b18e-0f9a-401f-bd2f-2db365d43fdf.png)
