### PR TITLE
Client disconnect on SIGINT

### DIFF
--- a/examples/audit-log.c
+++ b/examples/audit-log.c
@@ -4,7 +4,6 @@
 #include <limits.h>
 #include <string.h>
 #include <assert.h>
-#include <locale.h>
 
 #include "discord.h"
 
@@ -123,8 +122,6 @@ main(int argc, char *argv[])
         config_file = argv[1];
     else
         config_file = "../config.json";
-
-    setlocale(LC_ALL, "");
 
     ccord_global_init();
     struct discord *client = discord_config_init(config_file);

--- a/include/concord-once.h
+++ b/include/concord-once.h
@@ -12,7 +12,7 @@
  *
  * This global shall be set if a `SIGINT` is detected, running clients will
  *      then attempt to perform a clean disconnect, rather then just letting
- *      the program end abruply.
+ *      the program end abruptly.
  * @note client shall only attempt to disconnect if there aren't any active
  *      events waiting to be listened or reacted to
  */

--- a/include/concord-once.h
+++ b/include/concord-once.h
@@ -7,6 +7,18 @@
 #ifndef CONCORD_ONCE_H
 
 /**
+ * @brief If `SIGINT` is detected client(s) will be disconnected from their
+ *      on-going session
+ *
+ * This global shall be set if a `SIGINT` is detected, running clients will
+ *      then attempt to perform a clean disconnect, rather then just letting
+ *      the program end abruply.
+ * @note client shall only attempt to disconnect if there aren't any active
+ *      events waiting to be listened or reacted to
+ */
+extern int ccord_has_sigint;
+
+/**
  * @brief Initialize global shared-resources not API-specific
  *
  * @return CCORD_OK on success, CCORD_GLOBAL_INIT on error

--- a/include/discord-internal.h
+++ b/include/discord-internal.h
@@ -405,7 +405,7 @@ void discord_bucket_build(struct discord_adapter *adapter,
                           const char route[DISCORD_ROUTE_LEN],
                           struct ua_info *info);
 
-/** @} DIscordInternalAdapterRatelimit */
+/** @} DiscordInternalAdapterRatelimit */
 
 /** @} DiscordInternalAdapter */
 
@@ -498,7 +498,7 @@ struct discord_gateway_cbs {
     discord_ev_voice_server_update on_voice_server_update;
 };
 
-/** @defgroup DiscordInternalGatewaySessionStatus
+/** @defgroup DiscordInternalGatewaySessionStatus Client's session status
  * @brief Client's session status
  *  @{ */
 /** client is currently offline */

--- a/src/concord-once.c
+++ b/src/concord-once.c
@@ -14,27 +14,30 @@ static void
 sigint_handler(int signum)
 {
   (void)signum;
+  fputs("\nSIGINT: Disconnecting running concord client(s) ...\n", stderr);
   ccord_has_sigint = 1;
 }
 
 CCORDcode
 ccord_global_init()
 {
-    if (once) return CCORD_GLOBAL_INIT;
-
-    signal(SIGINT, &sigint_handler);
-
-    if (0 != curl_global_init(CURL_GLOBAL_DEFAULT)) {
-        fprintf(stderr, "Couldn't start libcurl's globals\n");
+    if (once) {
         return CCORD_GLOBAL_INIT;
     }
-    if (work_global_init()) {
-        fprintf(stderr, "Attempt duplicate global initialization\n");
-        return CCORD_GLOBAL_INIT;
+    else {
+        __sighandler_t prev = signal(SIGINT, &sigint_handler);
+        if (prev != SIG_DFL && prev != sigint_handler)
+            signal(SIGINT, prev);
+        if (0 != curl_global_init(CURL_GLOBAL_DEFAULT)) {
+            fputs("Couldn't start libcurl's globals\n", stderr);
+            return CCORD_GLOBAL_INIT;
+        }
+        if (work_global_init()) {
+            fputs("Attempt duplicate global initialization\n", stderr);
+            return CCORD_GLOBAL_INIT;
+        }
+        once = 1;
     }
-
-    once = 1;
-
     return CCORD_OK;
 }
 

--- a/src/concord-once.c
+++ b/src/concord-once.c
@@ -1,14 +1,28 @@
+#include <signal.h>
 #include <curl/curl.h>
 
 #include "error.h"
 #include "work.h"
 
+/* if set to 1 then client(s) will be disconnected */
+int ccord_has_sigint = 0;
+
 static int once;
+
+/* shutdown gracefully on SIGINT received */
+static void
+sigint_handler(int signum)
+{
+  (void)signum;
+  ccord_has_sigint = 1;
+}
 
 CCORDcode
 ccord_global_init()
 {
     if (once) return CCORD_GLOBAL_INIT;
+
+    signal(SIGINT, &sigint_handler);
 
     if (0 != curl_global_init(CURL_GLOBAL_DEFAULT)) {
         fprintf(stderr, "Couldn't start libcurl's globals\n");

--- a/src/discord-client.c
+++ b/src/discord-client.c
@@ -344,8 +344,9 @@ discord_run(struct discord *client)
             if (-1 == poll_result) {
                 /* TODO: handle poll error here */
             }
-            else if (0 == poll_result && client->on_idle) {
-                client->on_idle(client);
+            else if (0 == poll_result) {
+                if (ccord_has_sigint != 0) discord_shutdown(client);
+                if (client->on_idle) client->on_idle(client);
             }
 
             if (client->on_cycle) client->on_cycle(client);
@@ -387,7 +388,8 @@ discord_run(struct discord *client)
 void
 discord_shutdown(struct discord *client)
 {
-    discord_gateway_shutdown(&client->gw);
+    if (client->gw.session->status != DISCORD_SESSION_SHUTDOWN)
+        discord_gateway_shutdown(&client->gw);
 }
 
 void

--- a/test/async.c
+++ b/test/async.c
@@ -1,7 +1,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h> /* strcmp() */
-#include <signal.h>
 #include <pthread.h>
 #include <assert.h>
 
@@ -170,15 +169,6 @@ on_force_error(struct discord *client, const struct discord_message *msg)
                            });
 }
 
-/* shutdown gracefully on SIGINT received */
-void
-sigint_handler(int signum)
-{
-  (void)signum;
-  log_info("SIGINT received, shutting down ...");
-  discord_shutdown(client);
-}
-
 int
 main(int argc, char *argv[])
 {
@@ -188,7 +178,6 @@ main(int argc, char *argv[])
     else
         config_file = "../config.json";
 
-    signal(SIGINT, &sigint_handler);
     ccord_global_init();
 
     client = discord_config_init(config_file);

--- a/test/async.c
+++ b/test/async.c
@@ -6,8 +6,6 @@
 
 #include "discord.h"
 
-struct discord *client;
-
 struct user_cxt {
     u64snowflake channel_id;
     unsigned long long counter;
@@ -180,7 +178,7 @@ main(int argc, char *argv[])
 
     ccord_global_init();
 
-    client = discord_config_init(config_file);
+    struct discord *client = discord_config_init(config_file);
     assert(NULL != client && "Couldn't initialize client");
 
     struct user_cxt cxt = { 0 };


### PR DESCRIPTION
## What?
Disconnect client(s) from their on-going session if a `SIGINT` is received.

## Why?
* Abruptly ending the program means Discord would never be notified of the client's disconnect, thus keeping a lingering `online` status until it fails to receive a heartbeat payload.
* Ensure full cleanup of the API resources so that users may catch up their memory leaks, or incorrect cleanup from concord's side.

## How?
A `ccord_has_sigint` global is set once a SIGINT is detected, which will be checked against by all running clients and they will be prompted to call `discord_shutdown()`. 

## Testing?
Removed now outdated `test/async.c` logic that had a custom SIGINT handler for gracefully disconnecting, with this PR `Ctrl`+`C` for a clean disconnect still works just fine.

## Anything Else? (optional)
I haven't added any mutexes around the `ccord_has_sigint` global var, doing so is trivial but I couldn't think of a scenario where multiple `SIGINT` may be triggered in parallel.