### PR TITLE
fix(discord-client): timer causing busy loop

### DIFF
--- a/src/discord-client.c
+++ b/src/discord-client.c
@@ -344,9 +344,9 @@ discord_run(struct discord *client)
             if (priority_queue_peek(client->timers.user.q, &key, NULL)) {
                 key /= 1000;
                 if (key >= 0) {
-                    if (key >= now) {
+                    if (key <= now) {
                         poll_time = 0;
-                    } else if (key - now > poll_time) {
+                    } else if (key - now < poll_time) {
                         poll_time = (int)(key - now);
                     }
                 }


### PR DESCRIPTION
## What?
reverse improper comparison operators which were causing a busy loop by setting poll_time to 0 every time

