### PR TITLE
refactor(discord-timers): change discord_timer interface

### DIFF
--- a/examples/timers.c
+++ b/examples/timers.c
@@ -14,12 +14,12 @@ on_sigint(int sig) {
 }
 
 static void
-one_shot_timer_cb(struct discord *client, struct discord_timer *timer) {
+one_shot_timer_cb(struct discord *client, struct discord_ev_timer *ev) {
   printf("one_shot_timer_cb %u triggered with flags %i\n",
-         timer->id, timer->flags);
+         ev->id, ev->timer.flags);
 
   //DO NOT IGNORE CANCELATION
-  if (timer->flags & DISCORD_TIMER_CANCELED) {
+  if (ev->timer.flags & DISCORD_TIMER_CANCELED) {
       puts("Timer has been canceled");
       return;
   }
@@ -27,16 +27,16 @@ one_shot_timer_cb(struct discord *client, struct discord_timer *timer) {
       puts("Shutdown Canceled");
       return;
   }
-  puts(timer->data);
+  puts(ev->timer.data);
   discord_shutdown(client);
 }
 
 static void
-repeating_timer_cb(struct discord *client, struct discord_timer *timer) {
+repeating_timer_cb(struct discord *client, struct discord_ev_timer *ev) {
   printf("repeating_timer_cb %u triggered with flags %i\n",
-         timer->id, timer->flags);
-  printf("%"PRIi64", %"PRIi64"\n", timer->interval, timer->repeat);
-  if (timer->repeat == 0)
+         ev->id, ev->timer.flags);
+  printf("%i %i\n", ev->timer.interval, ev->timer.repeat);
+  if (ev->timer.repeat == 0)
       puts("Shutting down soon, press ctrl + c to cancel");
 }
 
@@ -54,8 +54,7 @@ main(int argc, char *argv[])
     unsigned one_shot_timer_id =
         discord_timer(client, one_shot_timer_cb, "Shutting Down", 5000);
     
-    discord_timer_ctl(client, &(struct discord_timer) {
-        .id = 0, /* 0 to create a new timer */
+    discord_timer_ctl(client, 0, &(struct discord_timer) {
         .cb = repeating_timer_cb,
         .data = &one_shot_timer_id,
         .delay = 0, /* start right away */

--- a/include/discord-internal.h
+++ b/include/discord-internal.h
@@ -726,6 +726,7 @@ void discord_timers_run(struct discord *client, struct discord_timers *timers);
 unsigned _discord_timer_ctl(
     struct discord *client,
     struct discord_timers *timers,
+    discord_timer_id timer_id,
     struct discord_timer *timer);
 
 /** @} DiscordInternalTimer */

--- a/include/discord.h
+++ b/include/discord.h
@@ -286,15 +286,18 @@ struct io_poller *discord_get_io_poller(struct discord *client);
  * @brief Schedule callbacks to be called in the future
  *  @{ */
 
+typedef unsigned discord_timer_id;
+
 /* forward declaration */
 struct discord_timer;
 /**/
+struct discord_ev_timer;
 
 /**
  * @brief callback to be used with struct discord_timer
  */
 typedef void (*discord_ev_timer)
-    (struct discord *client, struct discord_timer *ev);
+    (struct discord *client, struct discord_ev_timer *ev);
 
 /**
  * @brief flags used to change behaviour of timer
@@ -316,20 +319,23 @@ enum discord_timer_flags {
  * @brief struct used for modifying, and getting info about a timer
  */
 struct discord_timer {
-    /** the identifier used for the timer. 0 creates a new timer */
-    unsigned id;
-    /** the flags used to manipulate the timer */
-    enum discord_timer_flags flags;
     /** the callback that should be called when timer triggers */
     discord_ev_timer cb;
     /** user data */
     void *data;
     /** delay before timer should start */
-    int64_t delay;
+    int delay;
     /** interval that the timer should repeat at. must be > 1 */
-    int64_t interval;
+    int interval;
     /** how many times a timer should repeat (-1 == infinity) */
-    int64_t repeat;
+    int repeat;
+    /** the flags used to manipulate the timer */
+    enum discord_timer_flags flags;
+};
+
+struct discord_ev_timer {
+    discord_timer_id id;
+    struct discord_timer timer;
 };
 
 /**
@@ -339,7 +345,9 @@ struct discord_timer {
  * @param timer the timer that should be modified
  * @return unsigned the id of the timer
  */
-unsigned discord_timer_ctl(struct discord *client, struct discord_timer *timer);
+discord_timer_id discord_timer_ctl(struct discord *client,
+                                   discord_timer_id timer_id,
+                                   struct discord_timer *timer);
 
 /**
  * @brief creates a one shot timer that automatically
@@ -351,8 +359,8 @@ unsigned discord_timer_ctl(struct discord *client, struct discord_timer *timer);
  * @param delay delay before timer should start in milliseconds
  * @return unsigned 
  */
-unsigned discord_timer(struct discord *client, discord_ev_timer cb,
-                       void *data, int64_t delay);
+discord_timer_id discord_timer(struct discord *client, discord_ev_timer cb,
+                               void *data, int delay);
 
 /** @example timers.c
  * Demonstrates the Timer API for callback scheduling */


### PR DESCRIPTION
## What?
remove id field from struct discord_timer
convert delay, interval, and repeat to integers

## Why?
save memory
make interface easier to program

## Testing?
not fully done yet
