### PR TITLE
Ratelimiting refactor

### DIFF
--- a/cog-utils/chash.h
+++ b/cog-utils/chash.h
@@ -111,7 +111,8 @@
 do {                                                                        \
   CHASH_COUNTER_TYPE __CHASH_INDEX = 0;                                     \
   namespace ## _BUCKET *__CHASH_BUCKETS = NULL;                             \
-  int __CHASH_NEXT_SIZE = CHASH_RESIZE((hashtable)->capacity);              \
+  CHASH_COUNTER_TYPE __CHASH_NEXT_SIZE = (CHASH_COUNTER_TYPE)               \
+                          CHASH_RESIZE((hashtable)->capacity);              \
                                                                             \
   if((namespace ## _HEAP) == 0) {                                           \
     if((hashtable)->length != (hashtable)->capacity) {                      \
@@ -128,9 +129,11 @@ do {                                                                        \
     break;                                                                  \
                                                                             \
   __CHASH_BUCKETS = malloc(__CHASH_NEXT_SIZE                                \
-                           * sizeof(namespace ## _BUCKET));                 \
+                           * ((CHASH_COUNTER_TYPE)                          \
+                               sizeof(namespace ## _BUCKET)));              \
   memset(__CHASH_BUCKETS, 0, __CHASH_NEXT_SIZE                              \
-                           * sizeof(namespace ## _BUCKET));                 \
+                           * ((CHASH_COUNTER_TYPE)                          \
+                           sizeof(namespace ## _BUCKET)));                  \
                                                                             \
   for(__CHASH_INDEX = 0; __CHASH_INDEX < (hashtable)->capacity;             \
                                                          __CHASH_INDEX++) { \

--- a/cog-utils/chash.h
+++ b/cog-utils/chash.h
@@ -128,12 +128,12 @@ do {                                                                        \
      (double) (hashtable)->capacity < CHASH_LOAD_THRESHOLD)                 \
     break;                                                                  \
                                                                             \
-  __CHASH_BUCKETS = malloc(__CHASH_NEXT_SIZE                                \
+  __CHASH_BUCKETS = malloc((size_t) (__CHASH_NEXT_SIZE                      \
                            * ((CHASH_COUNTER_TYPE)                          \
-                               sizeof(namespace ## _BUCKET)));              \
-  memset(__CHASH_BUCKETS, 0, __CHASH_NEXT_SIZE                              \
+                               sizeof(namespace ## _BUCKET))));             \
+  memset(__CHASH_BUCKETS, 0, ((size_t) (__CHASH_NEXT_SIZE                   \
                            * ((CHASH_COUNTER_TYPE)                          \
-                           sizeof(namespace ## _BUCKET)));                  \
+                           sizeof(namespace ## _BUCKET)))));                \
                                                                             \
   for(__CHASH_INDEX = 0; __CHASH_INDEX < (hashtable)->capacity;             \
                                                          __CHASH_INDEX++) { \

--- a/cog-utils/logconf.c
+++ b/cog-utils/logconf.c
@@ -287,8 +287,9 @@ logconf_branch(struct logconf *branch, struct logconf *orig, const char id[])
                  "Out of bounds write attempt");
     }
     branch->pid = getpid();
-
+#if 0
     module_is_disabled(branch);
+#endif
 }
 
 void

--- a/include/discord-internal.h
+++ b/include/discord-internal.h
@@ -124,7 +124,7 @@ struct discord_request {
 
 /** URL endpoint threshold length */
 #define DISCORD_ENDPT_LEN 512
-/** Bucket's route threshold length */
+/** Route's unique key threshold length */
 #define DISCORD_ROUTE_LEN 256
 
 /**
@@ -136,7 +136,7 @@ struct discord_context {
     struct discord_request req;
 
     /** the request's bucket */
-    struct discord_bucket *bucket;
+    struct discord_bucket *b;
 
     /** request body handle @note buffer is kept and recycled */
     struct {
@@ -150,8 +150,8 @@ struct discord_context {
     enum http_method method;
     /** the request's endpoint */
     char endpoint[DISCORD_ENDPT_LEN];
-    /** the request's route */
-    char route[DISCORD_ROUTE_LEN];
+    /** the request bucket's key */
+    char key[DISCORD_ROUTE_LEN];
     /** the connection handler assigned */
     struct ua_conn *conn;
     /** the request bucket's queue entry */
@@ -174,20 +174,9 @@ struct discord_adapter {
      * @todo replace with priority_queue.h
      */
     struct discord_refcount *refcounts;
-    /** routes discovered (declared at discord-adapter_ratelimit.c) */
-    struct _discord_routes_ht *routes;
-    /** buckets discovered (declared at discord-adapter_ratelimit.c) */
-    struct _discord_buckets_ht *buckets;
 
-    /* client-wide ratelimiting timeout */
-    struct {
-        /** global ratelimit */
-        u64unix_ms wait_ms;
-        /** global rwlock  */
-        pthread_rwlock_t rwlock;
-        /** global lock */
-        pthread_mutex_t lock;
-    } * global;
+    /** buckets discovered (declared at discord-adapter_ratelimit.c) */
+    struct discord_ratelimiter *ratelimiter;
 
     /** idle request handles */
     QUEUE(struct discord_context) * idleq;
@@ -200,7 +189,7 @@ struct discord_adapter {
  * @brief Initialize the fields of a Discord Adapter handle
  *
  * @param adapter a pointer to the http handle
- * @param conf optional pointer to a pre-initialized logconf
+ * @param conf optional pointer to a parent logconf
  * @param token the bot token
  */
 void discord_adapter_init(struct discord_adapter *adapter,
@@ -245,20 +234,12 @@ CCORDcode discord_adapter_run(struct discord_adapter *adapter,
 CCORDcode discord_adapter_perform(struct discord_adapter *adapter);
 
 /**
- * @brief Get global timeout timestamp
- *
- * @param adapter the handle initialized with discord_adapter_init()
- * @return the most recent global timeout timestamp
- */
-u64unix_ms discord_adapter_get_global_wait(struct discord_adapter *adapter);
-
-/**
- * @brief Stop all on-going, pending and timed-out requests
+ * @brief Stop all bucket's on-going, pending and timed-out requests
  *
  * The requests will be moved over to client's 'idleq' queue
  * @param adapter the handle initialized with discord_adapter_init()
  */
-void discord_adapter_stop_all(struct discord_adapter *adapter);
+void discord_adapter_stop_buckets(struct discord_adapter *adapter);
 
 /**
  * @brief Naive garbage collector to cleanup user arbitrary data
@@ -305,10 +286,9 @@ void discord_refcount_decr(struct discord_adapter *adapter, void *data);
  * @brief Enforce ratelimiting per the official Discord Documentation
  *  @{ */
 
-/** @brief The bucket struct for handling ratelimiting */
 struct discord_bucket {
-    /** the hash associated with this bucket */
-    char key[64];
+    /** the hash associated with the bucket's ratelimiting group */
+    char hash[64];
     /** maximum connections this bucket can handle before ratelimit */
     long limit;
     /** connections this bucket can do before waiting for cooldown */
@@ -321,93 +301,124 @@ struct discord_bucket {
     QUEUE(struct discord_context) waitq;
     /** busy requests */
     QUEUE(struct discord_context) busyq;
-
-    int state;
-    void *value;
 };
-
-/**
- * @brief Initialize buckets and routes respective hashtables
- *
- * Hashtables shall be used for storage and retrieval of discovered routes and
- *      buckets
- * @param adapter the handle initialized with discord_adapter_init()
- */
-void discord_buckets_init(struct discord_adapter *adapter);
-
-/**
- * @brief Cleanup all buckets and routes that have been discovered
- *
- * @param adapter the handle initialized with discord_adapter_init()
- */
-void discord_buckets_cleanup(struct discord_adapter *adapter);
-
-/**
- * @brief Iterate and call `iter` callback for each discovered bucket
- *
- * @param adapter the handle initialized with discord_adapter_init()
- * @param iter the user callback to be called per bucket
- */
-void discord_buckets_foreach(struct discord_adapter *adapter,
-                             void (*iter)(struct discord_adapter *adapter,
-                                          struct discord_bucket *b));
 
 /**
  * @brief Return bucket timeout timestamp
  *
- * @param adapter the handle initialized with discord_adapter_init()
- * @param b the bucket to be checked for time out
+ * @param rl the handle initialized with discord_ratelimiter_init()
+ * @param bucket the bucket to be checked for time out
  * @return the timeout timestamp
  */
-u64unix_ms discord_bucket_get_timeout(struct discord_adapter *adapter,
-                                      struct discord_bucket *b);
+u64unix_ms discord_bucket_get_timeout(struct discord_ratelimiter *rl,
+                                      struct discord_bucket *bucket);
 
 /**
- * @brief Get bucket pending cooldown time in milliseconds
+ * @brief Sleep for bucket's cooldown time
+ * @note this **WILL** block the bucket's execution thread
  *
- * @param adapter the handle initialized with discord_adapter_init()
- * @param the bucket to wait on cooldown
- * @return amount to sleep for in milliseconds
+ * @param rl the handle initialized with discord_ratelimiter_init()
+ * @param bucket the bucket to wait on cooldown
  */
-int64_t discord_bucket_get_wait(struct discord_adapter *adapter,
-                                struct discord_bucket *bucket);
+void discord_bucket_try_sleep(struct discord_ratelimiter *rl,
+                              struct discord_bucket *bucket);
 
 /**
- * @brief Get `route` from HTTP method and endpoint
+ * @brief Get a `struct discord_bucket` assigned to `key`
+ *
+ * @param rl the handle initialized with discord_ratelimiter_init()
+ * @param key obtained from discord_ratelimiter_get_key()
+ * @return bucket matched to `key`
+ */
+struct discord_bucket *discord_bucket_get(struct discord_ratelimiter *rl,
+                                          const char key[DISCORD_ROUTE_LEN]);
+
+/** @brief The ratelimiter struct for handling ratelimiting */
+struct discord_ratelimiter {
+    /** DISCORD_RATELIMIT logging module */
+    struct logconf conf;
+
+    int length;
+    int capacity;
+    struct _discord_route *buckets;
+
+    /** singleton for routes that have not yet been assigned to a bucket */
+    struct discord_bucket *null;
+
+    /* client-wide ratelimiting timeout */
+    struct {
+        /** global ratelimit */
+        u64unix_ms wait_ms;
+        /** global rwlock  */
+        pthread_rwlock_t rwlock;
+        /** global lock */
+        pthread_mutex_t lock;
+    } global;
+};
+
+/**
+ * @brief Initialize ratelimiter handle
+ *
+ * A hashtable shall be used for storage and retrieval of discovered buckets
+ * @param conf optional pointer to a parent logconf
+ * @return the ratelimiter handle
+ */
+struct discord_ratelimiter *discord_ratelimiter_init(struct logconf *conf);
+
+/**
+ * @brief Cleanup all buckets that have been discovered
+ *
+ * @note pending requests will be moved to `adapter.idleq`
+ * @param rl the handle initialized with discord_ratelimiter_init()
+ */
+void discord_ratelimiter_cleanup(struct discord_ratelimiter *rl);
+
+/**
+ * @brief Iterate and call `iter` callback for each discovered bucket
+ *
+ * @param rl the handle initialized with discord_ratelimiter_init()
+ * @param adapter the handle initialized with discord_adapter_init()
+ * @param iter the user callback to be called per bucket
+ */
+void discord_ratelimiter_foreach(struct discord_ratelimiter *rl,
+                                 struct discord_adapter *adapter,
+                                 void (*iter)(struct discord_adapter *adapter,
+                                              struct discord_bucket *b));
+
+/**
+ * @brief Build unique key from the HTTP `route` (method and endpoint)
  *
  * @param method the request method
- * @param route buffer filled with generated route
+ * @param key buffer filled obtained from original route
  * @param endpoint_fmt the printf-like endpoint formatting string
  * @param args variadic arguments matched to `endpoint_fmt`
  */
-void discord_bucket_get_route(enum http_method method,
-                              char route[DISCORD_ROUTE_LEN],
-                              const char endpoint_fmt[],
-                              va_list args);
+void discord_ratelimiter_build_key(enum http_method method,
+                                   char key[DISCORD_ROUTE_LEN],
+                                   const char endpoint_fmt[],
+                                   va_list args);
 
 /**
- * @brief Get a `struct discord_bucket` assigned to `route`
+ * @brief Get global timeout timestamp
  *
- * @param adapter the handle initialized with discord_adapter_init()
- * @param route route obtained from discord_bucket_get_route()
- * @return bucket assigned to `route` or `adapter->b_null` if no match found
+ * @param rl the handle initialized with discord_ratelimiter_init()
+ * @return the most recent global timeout timestamp
  */
-struct discord_bucket *discord_bucket_get(struct discord_adapter *adapter,
-                                          const char route[DISCORD_ROUTE_LEN]);
+u64unix_ms discord_ratelimiter_get_global_wait(struct discord_ratelimiter *rl);
 
 /**
  * @brief Update the bucket with response header data
  *
- * @param adapter the handle initialized with discord_adapter_init()
+ * @param rl the handle initialized with discord_ratelimiter_init()
  * @param bucket NULL when bucket is first discovered
- * @param route route obtained from discord_bucket_get_route()
+ * @param key obtained from discord_ratelimiter_get_key()
  * @param info informational struct containing details on the current transfer
  * @note If the bucket was just discovered it will be created here.
  */
-void discord_bucket_build(struct discord_adapter *adapter,
-                          struct discord_bucket *bucket,
-                          const char route[DISCORD_ROUTE_LEN],
-                          struct ua_info *info);
+void discord_ratelimiter_build(struct discord_ratelimiter *rl,
+                               struct discord_bucket *bucket,
+                               const char key[DISCORD_ROUTE_LEN],
+                               struct ua_info *info);
 
 /** @} DiscordInternalAdapterRatelimit */
 
@@ -631,14 +642,14 @@ struct discord_event {
     /** the event unique id value */
     enum discord_gateway_events event;
     /** the event callback */
-    void (*on_event)(struct discord_gateway * gw);
+    void (*on_event)(struct discord_gateway *gw);
 };
 
 /**
  * @brief Initialize the fields of Discord Gateway handle
  *
  * @param gw the gateway handle to be initialized
- * @param conf optional pointer to a initialized logconf
+ * @param conf optional pointer to a parent logconf
  * @param token the bot token
  */
 void discord_gateway_init(struct discord_gateway *gw,

--- a/src/discord-adapter.c
+++ b/src/discord-adapter.c
@@ -62,14 +62,7 @@ discord_adapter_init(struct discord_adapter *adapter,
     io_poller_curlm_add(CLIENT(adapter, adapter)->io_poller, adapter->mhandle,
                         on_io_poller_curl, adapter);
 
-    /* global ratelimiting resources */
-    adapter->global = calloc(1, sizeof *adapter->global);
-    if (pthread_rwlock_init(&adapter->global->rwlock, NULL))
-        ERR("Couldn't initialize pthread rwlock");
-    if (pthread_mutex_init(&adapter->global->lock, NULL))
-        ERR("Couldn't initialize pthread mutex");
-
-    discord_buckets_init(adapter);
+    adapter->ratelimiter = discord_ratelimiter_init(&adapter->conf);
 
     /* idleq is malloc'd to guarantee a client cloned by discord_clone() will
      * share the same queue with the original */
@@ -99,15 +92,10 @@ discord_adapter_cleanup(struct discord_adapter *adapter)
     io_poller_curlm_del(CLIENT(adapter, adapter)->io_poller, adapter->mhandle);
     curl_multi_cleanup(adapter->mhandle);
 
-    /* move pending requests to idle */
-    discord_adapter_stop_all(adapter);
-
-    discord_buckets_cleanup(adapter);
-
-    /* cleanup global resources */
-    pthread_rwlock_destroy(&adapter->global->rwlock);
-    pthread_mutex_destroy(&adapter->global->lock);
-    free(adapter->global);
+    /* move pending requests to idleq */
+    discord_adapter_stop_buckets(adapter);
+    /* cleanup discovered buckets */
+    discord_ratelimiter_cleanup(adapter->ratelimiter);
 
     /* cleanup idle requests queue */
     QUEUE_MOVE(adapter->idleq, &queue);
@@ -126,14 +114,14 @@ static CCORDcode _discord_adapter_run_sync(struct discord_adapter *adapter,
                                            struct sized_buffer *body,
                                            enum http_method method,
                                            char endpoint[DISCORD_ENDPT_LEN],
-                                           char route[DISCORD_ROUTE_LEN]);
+                                           char key[DISCORD_ROUTE_LEN]);
 
 static CCORDcode _discord_adapter_run_async(struct discord_adapter *adapter,
                                             struct discord_request *req,
                                             struct sized_buffer *body,
                                             enum http_method method,
                                             char endpoint[DISCORD_ENDPT_LEN],
-                                            char route[DISCORD_ROUTE_LEN]);
+                                            char key[DISCORD_ROUTE_LEN]);
 
 /* template function for performing requests */
 CCORDcode
@@ -146,7 +134,7 @@ discord_adapter_run(struct discord_adapter *adapter,
 {
     static struct discord_request blank_req = { 0 };
     char endpoint[DISCORD_ENDPT_LEN];
-    char route[DISCORD_ROUTE_LEN];
+    char key[DISCORD_ROUTE_LEN];
     va_list args;
     int len;
 
@@ -159,9 +147,9 @@ discord_adapter_run(struct discord_adapter *adapter,
     ASSERT_NOT_OOB(len, sizeof(endpoint));
     va_end(args);
 
-    /* build the ratelimiting route */
+    /* build the bucket's key */
     va_start(args, endpoint_fmt);
-    discord_bucket_get_route(method, route, endpoint_fmt, args);
+    discord_ratelimiter_build_key(method, key, endpoint_fmt, args);
     va_end(args);
 
     if (req->ret.sync) { /* perform blocking request */
@@ -169,12 +157,12 @@ discord_adapter_run(struct discord_adapter *adapter,
             req->gnrc.data = req->ret.sync;
 
         return _discord_adapter_run_sync(adapter, req, body, method, endpoint,
-                                         route);
+                                         key);
     }
 
     /* enqueue asynchronous request */
     return _discord_adapter_run_async(adapter, req, body, method, endpoint,
-                                      route);
+                                      key);
 }
 
 static void
@@ -291,6 +279,7 @@ _discord_adapter_get_info(struct discord_adapter *adapter,
         }
 
         *wait_ms = (int64_t)(1000 * retry_after);
+        if (*wait_ms < 0) *wait_ms = 0;
 
         logconf_warn(&adapter->conf,
                      "429 %s RATELIMITING (wait: %" PRId64 " ms) : %.*s",
@@ -316,7 +305,7 @@ _discord_adapter_run_sync(struct discord_adapter *adapter,
                           struct sized_buffer *body,
                           enum http_method method,
                           char endpoint[DISCORD_ENDPT_LEN],
-                          char route[DISCORD_ROUTE_LEN])
+                          char key[DISCORD_ROUTE_LEN])
 {
     struct ua_conn_attr conn_attr = { method, body, endpoint, NULL };
     /* throw-away for ua_conn_set_mime() */
@@ -327,7 +316,7 @@ _discord_adapter_run_sync(struct discord_adapter *adapter,
     bool retry;
     CCORDcode code;
 
-    b = discord_bucket_get(adapter, route);
+    b = discord_bucket_get(adapter->ratelimiter, key);
     conn = ua_conn_start(adapter->ua);
 
     if (HTTP_MIMEPOST == method) {
@@ -345,17 +334,7 @@ _discord_adapter_run_sync(struct discord_adapter *adapter,
 
     pthread_mutex_lock(&b->lock);
     do {
-        int64_t wait_ms = discord_bucket_get_wait(adapter, b);
-
-        if (wait_ms > 0) {
-            /* block thread's runtime for delay amount */
-            logconf_info(&adapter->conf,
-                         "[%.4s] RATELIMITING (wait %" PRId64 " ms)", b->key,
-                         wait_ms);
-            cog_sleep_ms(wait_ms);
-
-            wait_ms = 0LL; /* reset */
-        }
+        discord_bucket_try_sleep(adapter->ratelimiter, b);
 
         /* perform blocking request, and check results */
         switch (code = ua_conn_easy_perform(conn)) {
@@ -363,6 +342,7 @@ _discord_adapter_run_sync(struct discord_adapter *adapter,
             struct discord *client = CLIENT(adapter, adapter);
             struct ua_info info = { 0 };
             struct sized_buffer resp;
+            int64_t wait_ms = 0;
 
             ua_info_extract(conn, &info);
             retry = _discord_adapter_get_info(adapter, &info, &wait_ms);
@@ -389,9 +369,8 @@ _discord_adapter_run_sync(struct discord_adapter *adapter,
              * TODO: create discord_timestamp_update() */
             ws_timestamp_update(client->gw.ws);
 
-            discord_bucket_build(adapter, b, route, &info);
-
-            if (wait_ms > 0) cog_sleep_ms(wait_ms);
+            discord_ratelimiter_build(adapter->ratelimiter, b, key, &info);
+            cog_sleep_ms(wait_ms);
 
             ua_info_cleanup(&info);
         } break;
@@ -455,11 +434,11 @@ _discord_context_reset(struct discord_context *cxt)
 {
     ua_conn_stop(cxt->conn);
 
-    cxt->bucket = NULL;
+    cxt->b = NULL;
     cxt->body.buf.size = 0;
     cxt->method = 0;
     *cxt->endpoint = '\0';
-    *cxt->route = '\0';
+    *cxt->key = '\0';
     cxt->conn = NULL;
     cxt->retry_attempt = 0;
     discord_attachments_cleanup(&cxt->req.attachments);
@@ -474,7 +453,7 @@ _discord_context_populate(struct discord_context *cxt,
                           struct sized_buffer *body,
                           enum http_method method,
                           char endpoint[DISCORD_ENDPT_LEN],
-                          char route[DISCORD_ROUTE_LEN])
+                          char key[DISCORD_ROUTE_LEN])
 {
     cxt->method = method;
 
@@ -497,12 +476,10 @@ _discord_context_populate(struct discord_context *cxt,
 
     /* copy endpoint over to cxt */
     memcpy(cxt->endpoint, endpoint, sizeof(cxt->endpoint));
-
-    /* copy bucket route */
-    memcpy(cxt->route, route, DISCORD_ROUTE_LEN);
-
-    /* bucket pertaining to the request */
-    cxt->bucket = discord_bucket_get(adapter, route);
+    /* copy bucket's key */
+    memcpy(cxt->key, key, sizeof(cxt->key));
+    /* route pertaining to the request */
+    cxt->b = discord_bucket_get(adapter->ratelimiter, key);
 }
 
 /* enqueue a request to be executed asynchronously */
@@ -512,30 +489,26 @@ _discord_adapter_run_async(struct discord_adapter *adapter,
                            struct sized_buffer *body,
                            enum http_method method,
                            char endpoint[DISCORD_ENDPT_LEN],
-                           char route[DISCORD_ROUTE_LEN])
+                           char key[DISCORD_ROUTE_LEN])
 {
     struct discord_context *cxt;
 
-    if (QUEUE_EMPTY(adapter->idleq)) {
-        /* create new request handler */
+    if (QUEUE_EMPTY(adapter->idleq)) { /* create new request handler */
         cxt = calloc(1, sizeof(struct discord_context));
     }
-    else {
-        /* get from idle requests queue */
+    else { /* get context from idleq */
         QUEUE(struct discord_context) *qelem = QUEUE_HEAD(adapter->idleq);
         QUEUE_REMOVE(qelem);
-
         cxt = QUEUE_DATA(qelem, struct discord_context, entry);
     }
     QUEUE_INIT(&cxt->entry);
 
-    _discord_context_populate(cxt, adapter, req, body, method, endpoint,
-                              route);
+    _discord_context_populate(cxt, adapter, req, body, method, endpoint, key);
 
     if (req->ret.high_p)
-        QUEUE_INSERT_HEAD(&cxt->bucket->waitq, &cxt->entry);
+        QUEUE_INSERT_HEAD(&cxt->b->waitq, &cxt->entry);
     else
-        QUEUE_INSERT_TAIL(&cxt->bucket->waitq, &cxt->entry);
+        QUEUE_INSERT_TAIL(&cxt->b->waitq, &cxt->entry);
 
     if (req->ret.data)
         discord_refcount_incr(adapter, req->ret.data, req->ret.cleanup);
@@ -587,7 +560,7 @@ _discord_adapter_send(struct discord_adapter *adapter,
     io_poller_curlm_enable_perform(CLIENT(adapter, adapter)->io_poller,
                                    adapter->mhandle);
 
-    QUEUE_INSERT_TAIL(&cxt->bucket->busyq, &cxt->entry);
+    QUEUE_INSERT_TAIL(&cxt->b->busyq, &cxt->entry);
 
     return mcode ? CCORD_CURLM_INTERNAL : CCORD_OK;
 }
@@ -614,11 +587,11 @@ static void
 _discord_adapter_try_send(struct discord_adapter *adapter,
                           struct discord_bucket *b)
 {
-    /* skip busy and non-pending buckets */
+    /* skip busy and non-pending routes */
     if (!QUEUE_EMPTY(&b->busyq) || QUEUE_EMPTY(&b->waitq)) {
         return;
     }
-    /* if bucket is outdated then its necessary to send a single
+    /* if route is outdated then its necessary to send a single
      *      request to fetch updated values */
     if (b->reset_tstamp < NOW(adapter)) {
         _discord_adapter_send(adapter, b);
@@ -632,7 +605,8 @@ _discord_adapter_try_send(struct discord_adapter *adapter,
 static CCORDcode
 _discord_adapter_check_pending(struct discord_adapter *adapter)
 {
-    discord_buckets_foreach(adapter, &_discord_adapter_try_send);
+    discord_ratelimiter_foreach(adapter->ratelimiter, adapter,
+                                &_discord_adapter_try_send);
     return CCORD_OK;
 }
 
@@ -685,7 +659,8 @@ _discord_adapter_check_action(struct discord_adapter *adapter,
 
         code = info.code;
 
-        discord_bucket_build(adapter, cxt->bucket, cxt->route, &info);
+        discord_ratelimiter_build(adapter->ratelimiter, cxt->b, cxt->key,
+                                  &info);
         ua_info_cleanup(&info);
     } break;
     case CURLE_READ_ERROR:
@@ -714,7 +689,7 @@ _discord_adapter_check_action(struct discord_adapter *adapter,
         ua_conn_reset(cxt->conn);
 
         if (wait_ms <= 0) {
-            QUEUE_INSERT_HEAD(&cxt->bucket->waitq, &cxt->entry);
+            QUEUE_INSERT_HEAD(&cxt->b->waitq, &cxt->entry);
         }
     }
     else {
@@ -757,8 +732,8 @@ discord_adapter_perform(struct discord_adapter *adapter)
 }
 
 static void
-_discord_adapter_stop(struct discord_adapter *adapter,
-                      struct discord_bucket *b)
+_discord_adapter_stop_bucket(struct discord_adapter *adapter,
+                             struct discord_bucket *b)
 {
     QUEUE(struct discord_context) * qelem;
     struct discord_context *cxt;
@@ -784,7 +759,8 @@ _discord_adapter_stop(struct discord_adapter *adapter,
 }
 
 void
-discord_adapter_stop_all(struct discord_adapter *adapter)
+discord_adapter_stop_buckets(struct discord_adapter *adapter)
 {
-    discord_buckets_foreach(adapter, &_discord_adapter_stop);
+    discord_ratelimiter_foreach(adapter->ratelimiter, adapter,
+                                &_discord_adapter_stop_bucket);
 }

--- a/src/discord-client.c
+++ b/src/discord-client.c
@@ -288,9 +288,9 @@ discord_set_event_scheduler(struct discord *client,
     client->gw.cmds.scheduler = callback;
 }
 
-
 static void
-discord_wake_timer_cb(struct discord *client, struct discord_timer *timer) {
+discord_wake_timer_cb(struct discord *client, struct discord_timer *timer)
+{
     if (~timer->flags & DISCORD_TIMER_CANCELED && client->wakeup_timer.cb)
         client->wakeup_timer.cb(client);
 }
@@ -298,12 +298,12 @@ discord_wake_timer_cb(struct discord *client, struct discord_timer *timer) {
 void
 discord_set_next_wakeup(struct discord *client, int64_t delay)
 {
-    unsigned id = discord_internal_timer_ctl(client, 
-        &(struct discord_timer) {
-            .id = client->wakeup_timer.id,
-            .cb = discord_wake_timer_cb,
-            .delay = delay,
-        });
+    unsigned id =
+        discord_internal_timer_ctl(client, &(struct discord_timer){
+                                               .id = client->wakeup_timer.id,
+                                               .cb = discord_wake_timer_cb,
+                                               .delay = delay,
+                                           });
     client->wakeup_timer.id = id;
 }
 
@@ -312,12 +312,11 @@ discord_set_on_wakeup(struct discord *client, discord_ev_idle callback)
 {
     client->wakeup_timer.cb = callback;
     if (client->wakeup_timer.id) {
-        discord_internal_timer_ctl(client, 
-            &(struct discord_timer) {
-                .id = client->wakeup_timer.id,
-                .cb = discord_wake_timer_cb,
-                .delay = -1,
-            });
+        discord_internal_timer_ctl(client, &(struct discord_timer){
+                                               .id = client->wakeup_timer.id,
+                                               .cb = discord_wake_timer_cb,
+                                               .delay = -1,
+                                           });
     }
 }
 
@@ -354,11 +353,11 @@ discord_run(struct discord *client)
 
             now = (int64_t)cog_timestamp_ms();
 
-            if (!client->on_idle) 
+            if (!client->on_idle)
                 poll_time = now < next_run ? (int)(next_run - now) : 0;
 
-            struct discord_timers *const timers[] =
-                { &client->timers.internal, &client->timers.user };
+            struct discord_timers *const timers[] = { &client->timers.internal,
+                                                      &client->timers.user };
             for (unsigned i = 0; i < sizeof timers / sizeof *timers; i++) {
                 int64_t trigger_us, trigger_ms;
                 if (priority_queue_peek(timers[i]->q, &trigger_us, NULL)) {
@@ -366,13 +365,14 @@ discord_run(struct discord *client)
                     if (trigger_us >= 0) {
                         if (trigger_ms <= now) {
                             poll_time = 0;
-                        } else if (trigger_ms - now < poll_time) {
+                        }
+                        else if (trigger_ms - now < poll_time) {
                             poll_time = (int)(trigger_ms - now);
                         }
                     }
                 }
             }
-            
+
             poll_result = io_poller_poll(client->io_poller, poll_time);
             if (-1 == poll_result) {
                 /* TODO: handle poll error here */
@@ -402,9 +402,9 @@ discord_run(struct discord *client)
             }
         }
 
-        /* stop all pending requests in case of connection shutdown */
+        /* stop all pending bucket's requests in case of connection shutdown */
         if (true == discord_gateway_end(&client->gw)) {
-            discord_adapter_stop_all(&client->adapter);
+            discord_adapter_stop_buckets(&client->adapter);
             break;
         }
     }


### PR DESCRIPTION
## What?
Create a `struct discord_ratelimiter` datatype to encompass all ratelimiting related data, and replace hard to read dependencies (uthash.h).

1. Reorganize and modularize `discord-adapter_ratelimit.c`
2. Replace uthash.h with chash.h

## Why?
Improve comprehension and readability.