### PR TITLE
Fix `Makefile` not compiling the `oauth2` module

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -48,6 +48,7 @@ OBJS += concord-once.o             \
         guild_scheduled_event.o    \
         guild_template.o           \
         invite.o                   \
+        oauth2.o                   \
         user.o                     \
         voice.o                    \
         webhook.o


### PR DESCRIPTION
## What?
This pull request fixes a bug where `Makefile` would not compile the `oauth2` module in `src` directory when the `make` command is invoked.

## Why?

### Environment
```console
$ uname -srvmpio
Linux 5.10.16.3-microsoft-standard-WSL2 #1 SMP Fri Apr 2 22:23:49 UTC 2021 x86_64 x86_64 x86_64 GNU/Linux
```

### Description

1. Clone this repository and install the latest development version
```console 
$ git clone https://github.com/Cogmasters/concord && cd concord
$ git checkout dev 
$ make -j`nproc`
$ sudo make install
```

2. Build a small bot example that uses `discord_get_current_bot_application_information()`

```c
#include <string.h>

#include <concord/discord.h>
#include <concord/log.h>

#include <pthread.h>

#define CONFIG_PATH "res/config.json"

void on_complete(
    struct discord *client, 
    struct discord_response *resp, 
    const struct discord_application *ret
);

void *read_input(void *arg);

int main(int argc, char *argv[]) {
    ccord_global_init();

    struct discord *client = discord_config_init(
        (argc > 1) ? argv[1] : CONFIG_PATH
    );

    pthread_t thread;
    pthread_attr_t attr;

    pthread_attr_init(&attr);
    pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_DETACHED);

    pthread_create(&thread, &attr, &read_input, client);

    pthread_attr_destroy(&attr);

    discord_run(client);

    discord_cleanup(client);

    ccord_global_cleanup();
}

void on_complete(
    struct discord *client, 
    struct discord_response *resp, 
    const struct discord_application *ret
) {
    printf(
        "%s#%s\n", 
        ret->owner->username,
        ret->owner->discriminator
    );
}

void *read_input(void *arg) {
    struct discord *client = arg;

    char buffer[DISCORD_MAX_MESSAGE_LEN + 256];

    for (;;) {
        memset(buffer, 0, sizeof(buffer));

        fgets(buffer, sizeof(buffer), stdin);

        buffer[strcspn(buffer, "\r\n")] = 0;

        if (buffer[0] == '\0') continue;

        struct discord_ret_application ret = { 
            .done = on_complete
        };

        discord_get_current_bot_application_information(
            client, 
            &ret
        );
    }

    pthread_exit(NULL);
}
```

3. It won't compile!

```console
$ gcc src/main.o -o bin/c-lab -D_DEFAULT_SOURCE -g -Iinclude -Isrc/external \
-O2 -std=gnu99 -ldiscord -lcurl -lpthread

/usr/bin/ld: src/main.o: in function `read_input':
(...)/c-lab/src/main.c:93: undefined reference to `discord_get_current_bot_application_information'
collect2: error: ld returned 1 exit status
make: *** [Makefile:62: bin/c-lab] Error 1
```

## How?

[Like this!](https://github.com/Cogmasters/concord/commit/560b70c68a8597bd7a1a36983e8b49e69c826d06)

## Testing?

```console
$ cd c-lab
$ make clean && make
jdeokkim/c-lab: Cleaning up.
jdeokkim/c-lab: Using: 'gcc' to build this project.
jdeokkim/c-lab: Compiling: src/main.o (from src/main.c)
jdeokkim/c-lab: Linking: bin/c-lab
jdeokkim/c-lab: Build complete.
```