### PR TITLE
Threadsafe Timers

### DIFF
--- a/core/io_poller.c
+++ b/core/io_poller.c
@@ -49,7 +49,7 @@ on_io_poller_wakeup(struct io_poller *io,
                     enum io_poller_events events,
                     void *user_data)
 {
-    char buf[0x1000];
+    char buf[0x10000];
     (void)!read(io->wakeup_fds[0], buf, sizeof buf);
 }
 
@@ -65,6 +65,8 @@ io_poller_create(void)
             if (0 == pipe(io->wakeup_fds)) {
                 int flags = fcntl(io->wakeup_fds[0], F_GETFL);
                 fcntl(io->wakeup_fds[0], F_SETFL, flags | O_NONBLOCK);
+                flags = fcntl(io->wakeup_fds[1], F_GETFL);
+                fcntl(io->wakeup_fds[1], F_SETFL, flags | O_NONBLOCK);
 
                 io_poller_socket_add(io, io->wakeup_fds[0], IO_POLLER_IN,
                                      on_io_poller_wakeup, NULL);

--- a/include/discord-internal.h
+++ b/include/discord-internal.h
@@ -86,10 +86,15 @@ extern "C" {
 
 struct discord_timers {
     priority_queue *q;
+    struct io_poller *io;
     struct {
+        bool is_active;
+        pthread_t thread;
         struct discord_timer *timer;
         bool skip_update_phase;
     } active;
+    pthread_mutex_t lock;
+    pthread_cond_t cond;
 };
 
 /**
@@ -97,7 +102,7 @@ struct discord_timers {
  *
  * @param timers the 'struct discord_timers' to init
  */
-void discord_timers_init(struct discord_timers *timers);
+void discord_timers_init(struct discord_timers *timers, struct io_poller *io);
 
 /**
  * @brief Cleanup timers and call cancel any running ones

--- a/src/discord-client.c
+++ b/src/discord-client.c
@@ -12,9 +12,9 @@ static void
 _discord_init(struct discord *new_client)
 {
     ccord_global_init();
-    discord_timers_init(&new_client->timers.internal);
-    discord_timers_init(&new_client->timers.user);
     new_client->io_poller = io_poller_create();
+    discord_timers_init(&new_client->timers.internal, new_client->io_poller);
+    discord_timers_init(&new_client->timers.user, new_client->io_poller);
 
     new_client->workers = calloc(1, sizeof *new_client->workers);
     ASSERT_S(!pthread_mutex_init(&new_client->workers->lock, NULL),

--- a/src/discord-rest.c
+++ b/src/discord-rest.c
@@ -67,9 +67,9 @@ discord_rest_init(struct discord_rest *rest,
     else
         logconf_branch(&rest->conf, conf, "DISCORD_HTTP");
 
-    discord_timers_init(&rest->timers);
-
     rest->io_poller = io_poller_create();
+    discord_timers_init(&rest->timers, rest->io_poller);
+
     discord_requestor_init(&rest->requestor, &rest->conf, token);
     io_poller_curlm_add(rest->io_poller, rest->requestor.mhandle,
                         &_discord_on_rest_perform, rest);

--- a/src/discord-timer.c
+++ b/src/discord-timer.c
@@ -127,8 +127,9 @@ _discord_timer_ctl_no_lock(struct discord *client,
 
 #define UNLOCK_TIMERS(timers)                                                 \
     do {                                                                      \
-        if (!timers.active.is_active) io_poller_wakeup(timers.io);            \
+        bool should_wakeup = !timers.active.is_active;                        \
         pthread_mutex_unlock(&timers.lock);                                   \
+        if (should_wakeup) io_poller_wakeup(timers.io);                       \
     } while (0)
 
 unsigned


### PR DESCRIPTION
## What?
Make the discord_timer api thread safe.

## Why?
Any thread should be able to call discord_timer(...) and have it run the callback on the main thread

## How?
Using a non-recursive mutex, a conditionals, and io_poller to wake up the thread

## Testing?
Stress tested with many threads simultaneously creating 1000s of timers, and using valgrind to ensure no memory leaks.

