### PR TITLE
Gencodecs refactor

### DIFF
--- a/gencodecs/.gitignore
+++ b/gencodecs/.gitignore
@@ -2,7 +2,9 @@
 *
 # But these
 !api
+!api/*
 !recipes
+!recipes/*
 !*.PRE.h
 !gencodecs.h
 !gencodecs-pp.c

--- a/gencodecs/api/application.PRE.h
+++ b/gencodecs/api/application.PRE.h
@@ -18,6 +18,7 @@ PP_DEFINE(DISCORD_APPLICATION_GATEWAY_MESSAGE_CONTENT_LIMITED 1 << 19)
 /** @} DiscordApplicationFlags */
 
 /** @CCORD_pub_struct{discord_application} */
+#if GENCODECS_RECIPE & (DATA | JSON)
 PUB_STRUCT(discord_application)
   /** the ID of the app */
     FIELD_SNOWFLAKE(id)
@@ -69,11 +70,14 @@ PUB_STRUCT(discord_application)
   /** the application's public flags @see DiscordApplicationFlags */
     FIELD_BITMASK(flags)
 STRUCT_END
+#endif
 
 /** @CCORD_pub_struct{discord_install_params} */
+#if GENCODECS_RECIPE & (DATA | JSON)
 PUB_STRUCT(discord_install_params)
   /** the scopes to add the application to the server with */
     FIELD_STRUCT_PTR(scopes, strings, *)
   /** the permissions to request for the bot role */
     FIELD_BITMASK(permissions)
 STRUCT_END
+#endif

--- a/gencodecs/api/application_commands.PRE.h
+++ b/gencodecs/api/application_commands.PRE.h
@@ -2,6 +2,7 @@
  * Application Commands Datatypes
  * **************************************************************************/
 
+#if GENCODECS_RECIPE == DATA
 ENUM(discord_application_command_types)
   /** Slash commands: a text-based command that shows up when a user 
        types `/` */
@@ -13,7 +14,9 @@ ENUM(discord_application_command_types)
        right clicks or tap on a message */
     ENUMERATOR_LAST(DISCORD_APPLICATION_MESSAGE, = 3)
 ENUM_END
+#endif
 
+#if GENCODECS_RECIPE == DATA
 ENUM(discord_application_command_option_types)
     ENUMERATOR(DISCORD_APPLICATION_OPTION_SUB_COMMAND, = 1)
     ENUMERATOR(DISCORD_APPLICATION_OPTION_SUB_COMMAND_GROUP, = 2)
@@ -32,13 +35,17 @@ ENUM(discord_application_command_option_types)
   /** @ref discord_attachment object */
     ENUMERATOR_LAST(DISCORD_APPLICATION_OPTION_ATTACHMENT, = 11)
 ENUM_END
+#endif
 
+#if GENCODECS_RECIPE == DATA
 ENUM(discord_application_command_permission_types)
     ENUMERATOR(DISCORD_APPLICATION_PERMISSION_ROLE, = 1)
     ENUMERATOR(DISCORD_APPLICATION_PERMISSION_USER, = 2)
     ENUMERATOR_LAST(DISCORD_APPLICATION_PERMISSION_CHANNEL, = 3)
 ENUM_END
+#endif
 
+#if GENCODECS_RECIPE & (DATA | JSON)
 PUB_STRUCT(discord_application_command)
   /** unique ID of the command */
   COND_WRITE(self->id != 0)
@@ -90,11 +97,15 @@ PUB_STRUCT(discord_application_command)
     FIELD_SNOWFLAKE(version)
   COND_END
 STRUCT_END
+#endif
 
+#if GENCODECS_RECIPE & (DATA | JSON)
 PUB_LIST(discord_application_commands)
     LISTTYPE_STRUCT(discord_application_command)
 LIST_END
+#endif
 
+#if GENCODECS_RECIPE & (DATA | JSON)
 STRUCT(discord_application_command_option)
   /** value of application command option type */
     FIELD_ENUM(type, discord_application_command_option_types)
@@ -133,11 +144,15 @@ STRUCT(discord_application_command_option)
     FIELD(autocomplete, bool, false)
   COND_END
 STRUCT_END
+#endif
 
+#if GENCODECS_RECIPE & (DATA | JSON)
 LIST(discord_application_command_options)
     LISTTYPE_STRUCT(discord_application_command_option)
 LIST_END
+#endif
 
+#if GENCODECS_RECIPE & (DATA | JSON)
 STRUCT(discord_application_command_option_choice)
   /** 1-100 character choice name */
     FIELD_PTR(name, char, *)
@@ -145,11 +160,15 @@ STRUCT(discord_application_command_option_choice)
        string the value must be enclosed with escaped commas, ex: `\"hi\"` */
     FIELD_PTR(value, json_char, *)
 STRUCT_END
+#endif
 
+#if GENCODECS_RECIPE & (DATA | JSON)
 LIST(discord_application_command_option_choices)
     LISTTYPE_STRUCT(discord_application_command_option_choice)
 LIST_END
+#endif
 
+#if GENCODECS_RECIPE & (DATA | JSON)
 STRUCT(discord_application_command_interaction_data_option)
   /** the name of the parameter */
     FIELD_PTR(name, char, *)
@@ -167,11 +186,15 @@ STRUCT(discord_application_command_interaction_data_option)
   /** true if this option is the currently focused option for autocomplete */
     FIELD(focused, bool, false)
 STRUCT_END
+#endif
 
+#if GENCODECS_RECIPE & (DATA | JSON)
 LIST(discord_application_command_interaction_data_options)
     LISTTYPE_STRUCT(discord_application_command_interaction_data_option)
 LIST_END
+#endif
 
+#if GENCODECS_RECIPE & (DATA | JSON)
 STRUCT(discord_guild_application_command_permission)
   /** the ID of the command */
     FIELD_SNOWFLAKE(id)
@@ -182,11 +205,15 @@ STRUCT(discord_guild_application_command_permission)
   /** the permissions for the command in the guild */
     FIELD_STRUCT_PTR(permissions, discord_application_command_permissions, *)
 STRUCT_END
+#endif
 
+#if GENCODECS_RECIPE & (DATA | JSON)
 PUB_LIST(discord_guild_application_command_permissions)
     LISTTYPE_STRUCT(discord_guild_application_command_permission)
 LIST_END
+#endif
 
+#if GENCODECS_RECIPE & (DATA | JSON)
 PUB_STRUCT(discord_application_command_permission)
   /** the ID of the role or user */
     FIELD_SNOWFLAKE(id)
@@ -195,15 +222,19 @@ PUB_STRUCT(discord_application_command_permission)
   /** `true` to allow, `false` to disallow */
     FIELD(permission, bool, false)
 STRUCT_END
+#endif
 
+#if GENCODECS_RECIPE & (DATA | JSON)
 PUB_LIST(discord_application_command_permissions)
     LISTTYPE_STRUCT(discord_application_command_permission)
 LIST_END
+#endif
 
 /*****************************************************************************
  * Application Commands REST parameters
  * **************************************************************************/
 
+#if GENCODECS_RECIPE & (DATA | JSON)
 PUB_STRUCT(discord_create_global_application_command)
   /** 1-32 lowercase character name */
     FIELD_PTR(name, char, *)
@@ -229,7 +260,9 @@ PUB_STRUCT(discord_create_global_application_command)
     FIELD_ENUM(type, discord_application_command_types)
   COND_END
 STRUCT_END
+#endif
 
+#if GENCODECS_RECIPE & (DATA | JSON)
 PUB_STRUCT(discord_edit_global_application_command)
   /** 1-32 lowercase character name */
     FIELD_PTR(name, char, *)
@@ -251,7 +284,9 @@ PUB_STRUCT(discord_edit_global_application_command)
   /** @deprecated use `default_member_permissions` instead */
     FIELD(default_permission, bool, true)
 STRUCT_END
+#endif
 
+#if GENCODECS_RECIPE & (DATA | JSON)
 PUB_STRUCT(discord_create_guild_application_command)
   /** 1-32 lowercase character name */
     FIELD_PTR(name, char, *)
@@ -277,7 +312,9 @@ PUB_STRUCT(discord_create_guild_application_command)
     FIELD_ENUM(type, discord_application_command_types)
   COND_END
 STRUCT_END
+#endif
 
+#if GENCODECS_RECIPE & (DATA | JSON)
 PUB_STRUCT(discord_edit_guild_application_command)
   /** 1-32 lowercase character name */
     FIELD_PTR(name, char, *)
@@ -294,7 +331,9 @@ PUB_STRUCT(discord_edit_guild_application_command)
   /** @deprecated use `default_member_permissions` instead */
     FIELD(default_permission, bool, true)
 STRUCT_END
+#endif
 
+#if GENCODECS_RECIPE & (DATA | JSON)
 PUB_STRUCT(discord_bulk_overwrite_guild_application_commands)
   /** ID of the command, if known */
     FIELD_SNOWFLAKE(id)
@@ -326,10 +365,13 @@ PUB_STRUCT(discord_bulk_overwrite_guild_application_commands)
     FIELD_ENUM(type, discord_application_command_types)
   COND_END
 STRUCT_END
+#endif
 
+#if GENCODECS_RECIPE & (DATA | JSON)
 PUB_STRUCT(discord_edit_application_command_permissions)
   /** the permissions for the command in the guild */
   COND_WRITE(self->permissions != NULL)
     FIELD_STRUCT_PTR(permissions, discord_application_command_permissions, *)
   COND_END
 STRUCT_END
+#endif

--- a/gencodecs/api/audit_log.PRE.h
+++ b/gencodecs/api/audit_log.PRE.h
@@ -2,6 +2,7 @@
  * Audit Logs Datatypes
  * **************************************************************************/
 
+#if GENCODECS_RECIPE == DATA
 ENUM(discord_audit_log_events)
     ENUMERATOR(DISCORD_AUDIT_LOG_GUILD_UPDATE, = 1)
     ENUMERATOR(DISCORD_AUDIT_LOG_CHANNEL_CREATE, = 10)
@@ -56,8 +57,10 @@ ENUM(discord_audit_log_events)
     ENUMERATOR(DISCORD_AUDIT_LOG_AUTO_MODERATION_RULE_DELETE, = 142)
     ENUMERATOR_LAST(DISCORD_AUDIT_LOG_AUTO_MODERATION_BLOCK_MESSAGE, = 143)
 ENUM_END
+#endif
 
 /** @CCORD_pub_struct{discord_audit_log} */
+#if GENCODECS_RECIPE & (DATA | JSON)
 PUB_STRUCT(discord_audit_log)
   /** list of audit log entries */
   COND_WRITE(self->audit_log_entries != NULL)
@@ -84,7 +87,9 @@ PUB_STRUCT(discord_audit_log)
     FIELD_STRUCT_PTR(webhooks, discord_webhooks, *)
   COND_END
 STRUCT_END
+#endif
 
+#if GENCODECS_RECIPE & (DATA | JSON)
 STRUCT(discord_audit_log_entry)
   /** ID of the affected entity (webhook, user, role, etc.) */
     FIELD_SNOWFLAKE(target_id)
@@ -107,11 +112,15 @@ STRUCT(discord_audit_log_entry)
   /** the reason for the change (0-512) characters */
     FIELD_PTR(reason, char, *)
 STRUCT_END
+#endif
 
+#if GENCODECS_RECIPE & (DATA | JSON)
 LIST(discord_audit_log_entries)
     LISTTYPE_STRUCT(discord_audit_log_entry)
 LIST_END
+#endif
 
+#if GENCODECS_RECIPE & (DATA | JSON)
 STRUCT(discord_optional_audit_entry_info)
   /** channel in which the entities were targeted */
     FIELD_SNOWFLAKE(channel_id)
@@ -130,11 +139,15 @@ STRUCT(discord_optional_audit_entry_info)
   /** type of overwritten entity - 0 for role or 1 for \"member\" */
     FIELD_PTR(type, char, *)
 STRUCT_END
+#endif
 
+#if GENCODECS_RECIPE & (DATA | JSON)
 LIST(discord_optional_audit_entry_infos)
     LISTTYPE_STRUCT(discord_optional_audit_entry_info)
 LIST_END
+#endif
 
+#if GENCODECS_RECIPE & (DATA | JSON)
 STRUCT(discord_audit_log_change)
   /** new value of the key */
     FIELD_PTR(new_value, json_char, *)
@@ -143,16 +156,19 @@ STRUCT(discord_audit_log_change)
   /** name of audit log change key */
     FIELD_PTR(key, char, *)
 STRUCT_END
+#endif
 
+#if GENCODECS_RECIPE & (DATA | JSON)
 LIST(discord_audit_log_changes)
     LISTTYPE_STRUCT(discord_audit_log_change)
 LIST_END
+#endif
 
 /*****************************************************************************
  * Audit Logs REST parameters
  * **************************************************************************/
 
-#if defined(GENCODECS_ON_STRUCT)
+#if GENCODECS_RECIPE == DATA
 STRUCT(discord_get_guild_audit_log)
   /** filter the log for actions made by a user */
     FIELD_SNOWFLAKE(user_id)

--- a/gencodecs/api/auto_moderation.PRE.h
+++ b/gencodecs/api/auto_moderation.PRE.h
@@ -3,6 +3,7 @@
  * **************************************************************************/
 
 /** @brief Characterizes the type of content which can trigger the rule */
+#if GENCODECS_RECIPE == DATA
 ENUM(discord_auto_moderation_trigger_types)
   /**
    * check if content contains words from a user defined list of keywords
@@ -25,7 +26,9 @@ ENUM(discord_auto_moderation_trigger_types)
    */
     ENUMERATOR_LAST(DISCORD_AUTO_MODERATION_KEYWORD_PRESET, = 4)
 ENUM_END
+#endif
 
+#if GENCODECS_RECIPE == DATA
 ENUM(discord_auto_moderation_keyword_preset_types)
     /** words that may be considered forms of swearing or cursing */
     ENUMERATOR(DISCORD_AUTO_MODERATION_PROFANITY, = 1)
@@ -34,12 +37,16 @@ ENUM(discord_auto_moderation_keyword_preset_types)
     /** personal insults or words that may be considered hate speech */
     ENUMERATOR_LAST(DISCORD_AUTO_MODERATION_SLURS, = 3)
 ENUM_END
+#endif
 
+#if GENCODECS_RECIPE == DATA
 ENUM(discord_auto_moderation_event_types)
     /** when a member sends or edits a message in the guild */
     ENUMERATOR_LAST(DISCORD_AUTO_MODERATION_MESSAGE_SEND, = 1)
 ENUM_END
+#endif
 
+#if GENCODECS_RECIPE == DATA
 ENUM(discord_auto_moderation_action_types)
     /** blocks the content of a message according to the rule */
     ENUMERATOR(DISCORD_AUTO_MODERATION_ACTION_BLOCK_MESSAGE, = 1)
@@ -48,7 +55,9 @@ ENUM(discord_auto_moderation_action_types)
     /** timeout user for a specified duration */
     ENUMERATOR_LAST(DISCORD_AUTO_MODERATION_ACTION_TIMEOUT, = 3)
 ENUM_END
+#endif
 
+#if GENCODECS_RECIPE & (DATA | JSON)
 STRUCT(discord_auto_moderation_trigger_metadata)
   /**
    * substrings which will be searched for in content
@@ -62,7 +71,9 @@ STRUCT(discord_auto_moderation_trigger_metadata)
    */
     FIELD_STRUCT_PTR(presets, integers, *)
 STRUCT_END
+#endif
 
+#if GENCODECS_RECIPE & (DATA | JSON)
 STRUCT(discord_auto_moderation_action)
   /** the type of action */
   COND_WRITE(self->type != 0)
@@ -75,11 +86,15 @@ STRUCT(discord_auto_moderation_action)
     FIELD_STRUCT_PTR(metadata, discord_auto_moderation_action_metadata, *)
   COND_END
 STRUCT_END
+#endif
 
+#if GENCODECS_RECIPE & (DATA | JSON)
 LIST(discord_auto_moderation_actions)
     LISTTYPE_STRUCT(discord_auto_moderation_action)
 LIST_END
+#endif
 
+#if GENCODECS_RECIPE & (DATA | JSON)
 STRUCT(discord_auto_moderation_action_metadata)
   /** 
    * channel to which user content should be logged
@@ -97,10 +112,10 @@ STRUCT(discord_auto_moderation_action_metadata)
     FIELD(duration_seconds, int, 0)
   COND_END
 STRUCT_END
-
-#if !defined(GENCODECS_ON_JSON_ENCODER)
+#endif
 
 /** @CCORD_pub_struct{discord_auto_moderation_rule} */
+#if GENCODECS_RECIPE & (DATA | JSON_DECODER)
 PUB_STRUCT(discord_auto_moderation_rule)
   /** the ID of this rule */
     FIELD_SNOWFLAKE(id)
@@ -129,19 +144,21 @@ PUB_STRUCT(discord_auto_moderation_rule)
   /** the channel ids that should not be affected by the rule (Maximum of 50) */
     FIELD_STRUCT_PTR(exempt_channels, snowflakes, *)
 STRUCT_END
+#endif
 
 /** @CCORD_pub_list{discord_auto_moderation_rules} */
+#if GENCODECS_RECIPE & (DATA | JSON_DECODER)
 PUB_LIST(discord_auto_moderation_rules)
     LISTTYPE_STRUCT(discord_auto_moderation_rule)
 LIST_END
-
-#endif /* GENCODECS_ON_JSON_ENCODER */
+#endif
 
 /*****************************************************************************
  * Auto Moderation REST parameters
  * **************************************************************************/
 
 /** @CCORD_pub_struct{discord_create_auto_moderation_rule} */
+#if GENCODECS_RECIPE & (DATA | JSON)
 PUB_STRUCT(discord_create_auto_moderation_rule)
   /** the rule name */
     FIELD_PTR(name, char, *)
@@ -172,8 +189,10 @@ PUB_STRUCT(discord_create_auto_moderation_rule)
     FIELD_STRUCT_PTR(exempt_channels, snowflakes, *)
   COND_END
 STRUCT_END
+#endif
 
 /** @CCORD_pub_struct{discord_modify_auto_moderation_rule} */
+#if GENCODECS_RECIPE & (DATA | JSON)
 PUB_STRUCT(discord_modify_auto_moderation_rule)
   /** the rule name */
     FIELD_PTR(name, char, *)
@@ -200,3 +219,4 @@ PUB_STRUCT(discord_modify_auto_moderation_rule)
     FIELD_STRUCT_PTR(exempt_channels, snowflakes, *)
   COND_END
 STRUCT_END
+#endif

--- a/gencodecs/api/channel.PRE.h
+++ b/gencodecs/api/channel.PRE.h
@@ -31,6 +31,7 @@ PP_DEFINE(DISCORD_MESSAGE_FAILED_TO_MENTION_SOME_ROLES_IN_THREAD 1 << 8)
 
 /** @} DiscordAPIChannelMessageFlags */
 
+#if GENCODECS_RECIPE == DATA
 ENUM(discord_channel_types)
   /** a text channel within a server */
     ENUMERATOR(DISCORD_CHANNEL_GUILD_TEXT, = 0)
@@ -63,14 +64,18 @@ ENUM(discord_channel_types)
   /** a channel that can only contain threads */
     ENUMERATOR_LAST(DISCORD_CHANNEL_GUILD_FORUM, = 15)
 ENUM_END
+#endif
 
+#if GENCODECS_RECIPE == DATA
 ENUM(discord_video_quality_modes)
   /** Discord chooses the quality for optimal performance */
     ENUMERATOR(DISCORD_VIDEO_QUALITY_AUTO, = 1)
   /** 720p */
     ENUMERATOR_LAST(DISCORD_VIDEO_QUALITY_FULL, = 2)
 ENUM_END
+#endif
 
+#if GENCODECS_RECIPE == DATA
 ENUM(discord_message_types)
     ENUMERATOR(DISCORD_MESSAGE_DEFAULT, = 0)
     ENUMERATOR(DISCORD_MESSAGE_RECIPIENT_ADD, = 1)
@@ -96,15 +101,19 @@ ENUM(discord_message_types)
     ENUMERATOR(DISCORD_MESSAGE_GUILD_INVITE_REMINDER, = 22)
     ENUMERATOR_LAST(DISCORD_MESSAGE_CONTEXT_MENU_COMMAND, = 22)
 ENUM_END
+#endif
 
+#if GENCODECS_RECIPE == DATA
 ENUM(discord_message_activity_types)
     ENUMERATOR(DISCORD_MESSAGE_ACTIVITY_JOIN, = 1)
     ENUMERATOR(DISCORD_MESSAGE_ACTIVITY_SPECTATE, = 2)
     ENUMERATOR(DISCORD_MESSAGE_ACTIVITY_LISTEN, = 3)
     ENUMERATOR_LAST(DISCORD_MESSAGE_ACTIVITY_JOIN_REQUEST, = 5)
 ENUM_END
+#endif
 
 /** @CCORD_pub_struct{discord_channel} */
+#if GENCODECS_RECIPE & (DATA | JSON)
 PUB_STRUCT(discord_channel)
   /** the ID of this channel */
     FIELD_SNOWFLAKE(id)
@@ -173,13 +182,17 @@ PUB_STRUCT(discord_channel)
        on a application command interaction */
     FIELD_PTR(permissions, char, *)
 STRUCT_END
+#endif
 
 /** @CCORD_pub_list{discord_channels} */
+#if GENCODECS_RECIPE & (DATA | JSON)
 PUB_LIST(discord_channels)
     LISTTYPE_STRUCT(discord_channel)
 LIST_END
+#endif
 
 /** @CCORD_pub_struct{discord_message} */
+#if GENCODECS_RECIPE & (DATA | JSON)
 PUB_STRUCT(discord_message)
   /** ID of the message */
     FIELD_SNOWFLAKE(id)
@@ -249,19 +262,25 @@ PUB_STRUCT(discord_message)
   /** sent if the message contains stickers */
     FIELD_STRUCT_PTR(sticker_items, discord_sticker_items, *)
 STRUCT_END
+#endif
 
 /** @CCORD_pub_list{discord_messages} */
+#if GENCODECS_RECIPE & (DATA | JSON)
 PUB_LIST(discord_messages)
     LISTTYPE_STRUCT(discord_message)
 LIST_END
+#endif
 
+#if GENCODECS_RECIPE & (DATA | JSON)
 STRUCT(discord_message_activity)
   /** type of message activity */
     FIELD_ENUM(type, discord_message_activity_types)
   /** party_id from a Rich Presence event */
     FIELD_PTR(party_id, char, *)
 STRUCT_END
+#endif
 
+#if GENCODECS_RECIPE & (DATA | JSON)
 STRUCT(discord_message_reference)
   /** id of the originating message */
     FIELD_SNOWFLAKE(message_id)
@@ -273,15 +292,19 @@ STRUCT(discord_message_reference)
        instead of sending as normal (non-reply) message, default true */
     FIELD(fail_if_not_exists, bool, true)
 STRUCT_END
+#endif
 
 /** @CCORD_pub_struct{discord_followed_channel} */
+#if GENCODECS_RECIPE & (DATA | JSON)
 PUB_STRUCT(discord_followed_channel)
   /** source channel id */
     FIELD_SNOWFLAKE(channel_id)
   /** created target webhook id */
     FIELD_SNOWFLAKE(webhook_id)
 STRUCT_END
+#endif
 
+#if GENCODECS_RECIPE & (DATA | JSON)
 STRUCT(discord_reaction)
   /** times this emoji has been used to react */
     FIELD(count, int, 0)
@@ -290,11 +313,15 @@ STRUCT(discord_reaction)
   /** emoji information */
     FIELD_STRUCT_PTR(emoji, discord_emoji, *)
 STRUCT_END
+#endif
 
+#if GENCODECS_RECIPE & (DATA | JSON)
 LIST(discord_reactions)
     LISTTYPE_STRUCT(discord_reaction)
 LIST_END
+#endif
 
+#if GENCODECS_RECIPE & (DATA | JSON)
 STRUCT(discord_overwrite)
   /** role or user id */
     FIELD_SNOWFLAKE(id)
@@ -305,11 +332,15 @@ STRUCT(discord_overwrite)
   /** @ref DiscordPermissions bit set */
     FIELD_SNOWFLAKE(deny)
 STRUCT_END
+#endif
 
+#if GENCODECS_RECIPE & (DATA | JSON)
 LIST(discord_overwrites)
     LISTTYPE_STRUCT(discord_overwrite)
 LIST_END
+#endif
 
+#if GENCODECS_RECIPE & (DATA | JSON)
 STRUCT(discord_thread_metadata)
   /** whether the thread is archived */
     FIELD(archived, bool, false)
@@ -329,8 +360,10 @@ STRUCT(discord_thread_metadata)
        created after 2022-01-09 */
     FIELD_TIMESTAMP(create_timestamp)
 STRUCT_END
+#endif
 
 /** @CCORD_pub_struct{discord_thread_member} */
+#if GENCODECS_RECIPE & (DATA | JSON)
 PUB_STRUCT(discord_thread_member)
   /** the id of the thread */
     FIELD_SNOWFLAKE(id)
@@ -343,15 +376,19 @@ PUB_STRUCT(discord_thread_member)
   /** the id of the guild @note used at `Thread Member Update` */
     FIELD_SNOWFLAKE(guild_id)
 STRUCT_END
+#endif
 
 /** @CCORD_pub_list{discord_thread_members} */
+#if GENCODECS_RECIPE & (DATA | JSON)
 PUB_LIST(discord_thread_members)
     LISTTYPE_STRUCT(discord_thread_member)
 LIST_END
+#endif
 
+#if GENCODECS_RECIPE & (DATA | JSON)
 STRUCT(discord_attachment)
-#if !defined(GENCODECS_ON_JSON)
   /** the file contents */
+#if !(GENCODECS_RECIPE & JSON)
     FIELD_PTR(content, char, *)
 #endif
   /** attachment ID */
@@ -385,13 +422,17 @@ STRUCT(discord_attachment)
   /** whether this attachment is ephemeral */
     FIELD(ephemeral, bool, false)
 STRUCT_END
+#endif
 
 /** @CCORD_pub_list{discord_attachments} */
+#if GENCODECS_RECIPE & (DATA | JSON)
 PUB_LIST(discord_attachments)
     LISTTYPE_STRUCT(discord_attachment)
 LIST_END
+#endif
 
 /** @CCORD_pub_struct{discord_embed} */
+#if GENCODECS_RECIPE & (DATA | JSON)
 PUB_STRUCT(discord_embed)
   /** title of embed */
     FIELD_PTR(title, char, *)
@@ -435,13 +476,17 @@ PUB_STRUCT(discord_embed)
     FIELD_STRUCT_PTR(fields, discord_embed_fields, *)
   COND_END
 STRUCT_END
+#endif
 
 /** @CCORD_pub_list{discord_embeds} */
+#if GENCODECS_RECIPE & (DATA | JSON)
 PUB_LIST(discord_embeds)
     LISTTYPE_STRUCT(discord_embed)
 LIST_END
+#endif
 
 /** @CCORD_pub_struct{discord_embed_thumbnail} */
+#if GENCODECS_RECIPE & (DATA | JSON)
 PUB_STRUCT(discord_embed_thumbnail)
   /** source url of thumbnail (only supports http(s) and attachments) */
     FIELD_PTR(url, char, *)
@@ -458,8 +503,10 @@ PUB_STRUCT(discord_embed_thumbnail)
     FIELD(width, int, 0)
   COND_END
 STRUCT_END
+#endif
 
 /** @CCORD_pub_struct{discord_embed_video} */
+#if GENCODECS_RECIPE & (DATA | JSON)
 PUB_STRUCT(discord_embed_video)
   /** source url of video */
   COND_WRITE(self->url != NULL)
@@ -478,8 +525,10 @@ PUB_STRUCT(discord_embed_video)
     FIELD(width, int, 0)
   COND_END
 STRUCT_END
+#endif
 
 /** @CCORD_pub_struct{discord_embed_image} */
+#if GENCODECS_RECIPE & (DATA | JSON)
 PUB_STRUCT(discord_embed_image)
   /** source url of image (only supports http(s) and attachments) */
     FIELD_PTR(url, char, *)
@@ -496,8 +545,10 @@ PUB_STRUCT(discord_embed_image)
     FIELD(width, int, 0)
   COND_END
 STRUCT_END
+#endif
 
 /** @CCORD_pub_struct{discord_embed_provider} */
+#if GENCODECS_RECIPE & (DATA | JSON)
 PUB_STRUCT(discord_embed_provider)
   /** name of provider */
   COND_WRITE(self->name != NULL)
@@ -508,8 +559,10 @@ PUB_STRUCT(discord_embed_provider)
     FIELD_PTR(url, char, *)
   COND_END
 STRUCT_END
+#endif
 
 /** @CCORD_pub_struct{discord_embed_author} */
+#if GENCODECS_RECIPE & (DATA | JSON)
 PUB_STRUCT(discord_embed_author)
   /** name of author */
     FIELD_PTR(name, char, *)
@@ -526,8 +579,10 @@ PUB_STRUCT(discord_embed_author)
     FIELD_PTR(proxy_icon_url, char, *)
   COND_END
 STRUCT_END
+#endif
 
 /** @CCORD_pub_struct{discord_embed_footer} */
+#if GENCODECS_RECIPE & (DATA | JSON)
 PUB_STRUCT(discord_embed_footer)
   /** footer text */
     FIELD_PTR(text, char, *)
@@ -540,8 +595,10 @@ PUB_STRUCT(discord_embed_footer)
     FIELD_PTR(proxy_icon_url, char, *)
   COND_END
 STRUCT_END
+#endif
 
 /** @CCORD_pub_struct{discord_embed_field} */
+#if GENCODECS_RECIPE & (DATA | JSON)
 PUB_STRUCT(discord_embed_field)
   /** name of the field */
     FIELD_PTR(name, char, *)
@@ -552,12 +609,16 @@ PUB_STRUCT(discord_embed_field)
                  GENCODECS_JSON_ENCODER_bool, GENCODECS_JSON_DECODER_bool,
                  false)
 STRUCT_END
+#endif
 
 /** @CCORD_pub_list{discord_embed_fields} */
+#if GENCODECS_RECIPE & (DATA | JSON)
 PUB_LIST(discord_embed_fields)
     LISTTYPE_STRUCT(discord_embed_field)
 LIST_END
+#endif
 
+#if GENCODECS_RECIPE & (DATA | JSON)
 STRUCT(discord_channel_mention)
   /** ID of the channel */
     FIELD_SNOWFLAKE(id)
@@ -568,7 +629,9 @@ STRUCT(discord_channel_mention)
   /** the name of the channel */
     FIELD_PTR(name, char, *)
 STRUCT_END
+#endif
 
+#if GENCODECS_RECIPE & (DATA | JSON)
 STRUCT(discord_allowed_mention)
   /** An array of allowed mention tpes to parse from the content */
     FIELD_STRUCT_PTR(parse, strings, *)
@@ -580,8 +643,10 @@ STRUCT(discord_allowed_mention)
        replied to (default false) */
     FIELD(replied_user, bool, false)
 STRUCT_END
+#endif
 
 /** @CCORD_pub_struct{discord_thread_response_body} */
+#if GENCODECS_RECIPE & (DATA | JSON)
 PUB_STRUCT(discord_thread_response_body)
   /** the archived threads */
     FIELD_STRUCT_PTR(threads, discord_channels, *)
@@ -592,12 +657,14 @@ PUB_STRUCT(discord_thread_response_body)
        on a subsequent call */
     FIELD(has_more, bool, false)
 STRUCT_END
+#endif
 
 /*****************************************************************************
  * Channel REST parameters
  * **************************************************************************/
 
 /** @CCORD_pub_struct{discord_modify_channel} */
+#if GENCODECS_RECIPE & (DATA | JSON)
 PUB_STRUCT(discord_modify_channel)
   /** 1-100 character channel name */
     FIELD_PTR(name, char, *)
@@ -665,8 +732,9 @@ PUB_STRUCT(discord_modify_channel)
        available on private threads */
     FIELD(invitable, bool, false)
 STRUCT_END
+#endif
 
-#if defined(GENCODECS_ON_STRUCT)
+#if GENCODECS_RECIPE == DATA
 PUB_STRUCT(discord_get_channel_messages)
   /** get messages around this message ID */
   COND_WRITE(self->around != 0)
@@ -688,6 +756,7 @@ STRUCT_END
 #endif
 
 /** @CCORD_pub_struct{discord_create_message} */
+#if GENCODECS_RECIPE & (DATA | JSON)
 PUB_STRUCT(discord_create_message)
   /** the message contents (up to 2000 characters) */
     FIELD_PTR(content, char, *)
@@ -721,8 +790,9 @@ PUB_STRUCT(discord_create_message)
     FIELD_BITMASK(flags)
   COND_END
 STRUCT_END
+#endif
 
-#if defined(GENCODECS_ON_STRUCT)
+#if GENCODECS_RECIPE == DATA
 PUB_STRUCT(discord_get_reactions)
   /** get users after this user ID */
   COND_WRITE(self->after != 0)
@@ -736,6 +806,7 @@ STRUCT_END
 #endif
 
 /** @CCORD_pub_struct{discord_edit_message} */
+#if GENCODECS_RECIPE & (DATA | JSON)
 PUB_STRUCT(discord_edit_message)
   /** the message contents (up to 2000 characters) */
     FIELD_PTR(content, char, *)
@@ -759,14 +830,18 @@ PUB_STRUCT(discord_edit_message)
     FIELD_STRUCT_PTR(attachments, discord_attachments, *)
   COND_END
 STRUCT_END
+#endif
 
 /** @CCORD_pub_struct{discord_bulk_delete_messages} */
+#if GENCODECS_RECIPE & (DATA | JSON)
 PUB_STRUCT(discord_bulk_delete_messages)
   /** an array of message ids to delete (2-100) */
     FIELD_STRUCT_PTR(messages, snowflakes, *)
 STRUCT_END
+#endif
 
 /** @CCORD_pub_struct{discord_edit_channel_permissions} */
+#if GENCODECS_RECIPE & (DATA | JSON)
 PUB_STRUCT(discord_edit_channel_permissions)
   /** the bitwise value of all allowed permissions (default \"0\")
         @see @ref DiscordPermissions */
@@ -781,8 +856,10 @@ PUB_STRUCT(discord_edit_channel_permissions)
   /** 0 for a role or 1 for a member */
     FIELD(type, int, 0)
 STRUCT_END
+#endif
 
 /** @CCORD_pub_struct{discord_create_channel_invite} */
+#if GENCODECS_RECIPE & (DATA | JSON)
 PUB_STRUCT(discord_create_channel_invite)
   /** duration of invite in seconds before expiry, or 0 for never. between
        0 and 604800 (7 days) */
@@ -817,24 +894,30 @@ PUB_STRUCT(discord_create_channel_invite)
     FIELD_SNOWFLAKE(target_application_id)
   COND_END
 STRUCT_END
+#endif
 
 /** @CCORD_pub_struct{discord_follow_news_channel} */
+#if GENCODECS_RECIPE & (DATA | JSON)
 PUB_STRUCT(discord_follow_news_channel)
   /** id of target channel */
   COND_WRITE(self->webhook_channel_id != 0)
     FIELD_SNOWFLAKE(webhook_channel_id)
   COND_END
 STRUCT_END
+#endif
 
 /** @CCORD_pub_struct{discord_group_dm_add_recipient} */
+#if GENCODECS_RECIPE & (DATA | JSON)
 PUB_STRUCT(discord_group_dm_add_recipient)
   /** access token of a user that has granted your app the `gdm.join` scope */
     FIELD_PTR(access_token, char, *)
   /** nickname of the user being added */
     FIELD_PTR(nick, char, *)
 STRUCT_END
+#endif
 
 /** @CCORD_pub_struct{discord_start_thread_with_message} */
+#if GENCODECS_RECIPE & (DATA | JSON)
 PUB_STRUCT(discord_start_thread_with_message)
   /** 1-100 character channel name */
     FIELD_PTR(name, char, *)
@@ -850,8 +933,10 @@ PUB_STRUCT(discord_start_thread_with_message)
     FIELD(rate_limit_per_user, int, 0)
   COND_END
 STRUCT_END
+#endif
 
 /** @CCORD_pub_struct{discord_start_thread_without_message} */
+#if GENCODECS_RECIPE & (DATA | JSON)
 PUB_STRUCT(discord_start_thread_without_message)
   /** 1-100 character channel name */
     FIELD_PTR(name, char, *)
@@ -872,8 +957,10 @@ PUB_STRUCT(discord_start_thread_without_message)
     FIELD(rate_limit_per_user, int, 0)
   COND_END
 STRUCT_END
+#endif
 
 /** @CCORD_pub_struct{discord_list_active_threads} */
+#if GENCODECS_RECIPE & (DATA | JSON)
 PUB_STRUCT(discord_list_active_threads)
   /** the active threads */
   COND_WRITE(self->threads != NULL)
@@ -888,3 +975,4 @@ PUB_STRUCT(discord_list_active_threads)
        on a subsequent call */
     FIELD(has_more, bool, false)
 STRUCT_END
+#endif

--- a/gencodecs/api/custom.PRE.h
+++ b/gencodecs/api/custom.PRE.h
@@ -1,19 +1,27 @@
 /** @CCORD_pub_list{strings} */
+#if GENCODECS_RECIPE & (DATA | JSON)
 PUB_LIST(strings)
     LISTTYPE_PTR(char, *)
 LIST_END
+#endif
 
 /** @CCORD_pub_list{json_values} */
+#if GENCODECS_RECIPE & (DATA | JSON)
 PUB_LIST(json_values)
     LISTTYPE_PTR(json_char, *)
 LIST_END
+#endif
 
 /** @CCORD_pub_list{snowflakes} */
+#if GENCODECS_RECIPE & (DATA | JSON)
 PUB_LIST(snowflakes)
     LISTTYPE(u64snowflake)
 LIST_END
+#endif
 
 /** @CCORD_pub_list{integers} */
+#if GENCODECS_RECIPE & (DATA | JSON)
 PUB_LIST(integers)
     LISTTYPE(int)
 LIST_END
+#endif

--- a/gencodecs/api/emoji.PRE.h
+++ b/gencodecs/api/emoji.PRE.h
@@ -3,6 +3,7 @@
  * **************************************************************************/
 
 /** @CCORD_pub_struct{discord_emoji} */
+#if GENCODECS_RECIPE & (DATA | JSON)
 PUB_STRUCT(discord_emoji)
   /** emoji ID */
     FIELD_SNOWFLAKE(id)
@@ -26,17 +27,21 @@ PUB_STRUCT(discord_emoji)
        Boosts */
     FIELD(available, bool, false)
 STRUCT_END
+#endif
 
 /** @CCORD_pub_list{discord_emojis} */
+#if GENCODECS_RECIPE & (DATA | JSON)
 PUB_LIST(discord_emojis)
     LISTTYPE_STRUCT(discord_emoji)
 LIST_END
+#endif
 
 /*****************************************************************************
  * Emoji REST parameters
  * **************************************************************************/
 
 /** @CCORD_pub_struct{discord_create_guild_emoji} */
+#if GENCODECS_RECIPE & (DATA | JSON)
 PUB_STRUCT(discord_create_guild_emoji)
   /** name of the emoji */
     FIELD_PTR(name, char, *)
@@ -48,8 +53,10 @@ PUB_STRUCT(discord_create_guild_emoji)
     FIELD_STRUCT_PTR(roles, snowflakes, *)
   COND_END
 STRUCT_END
+#endif
 
 /** @CCORD_pub_struct{discord_modify_guild_emoji} */
+#if GENCODECS_RECIPE & (DATA | JSON)
 PUB_STRUCT(discord_modify_guild_emoji)
   /** name of the emoji */
     FIELD_PTR(name, char, *)
@@ -61,3 +68,4 @@ PUB_STRUCT(discord_modify_guild_emoji)
     FIELD_STRUCT_PTR(roles, snowflakes, *)
   COND_END
 STRUCT_END
+#endif

--- a/gencodecs/api/gateway.PRE.h
+++ b/gencodecs/api/gateway.PRE.h
@@ -42,6 +42,7 @@ PP_DEFINE(DISCORD_ACTIVITY_PARTY_PRIVACY_VOICE_CHANNEL 1 << 7)
 PP_DEFINE(DISCORD_ACTIVITY_EMBEDDED 1 << 8)
 /** @} DiscordActivityFlags */
 
+#if GENCODECS_RECIPE == DATA
 ENUM(discord_gateway_close_opcodes)
     ENUMERATOR(DISCORD_GATEWAY_CLOSE_REASON_UNKNOWN_ERROR, = 4000)
     ENUMERATOR(DISCORD_GATEWAY_CLOSE_REASON_UNKNOWN_OPCODE, = 4001)
@@ -59,7 +60,9 @@ ENUM(discord_gateway_close_opcodes)
     ENUMERATOR(DISCORD_GATEWAY_CLOSE_REASON_DISALLOWED_INTENTS, = 4014)
     ENUMERATOR_LAST(DISCORD_GATEWAY_CLOSE_REASON_RECONNECT, = 4900)
 ENUM_END
+#endif
 
+#if GENCODECS_RECIPE == DATA
 ENUM(discord_gateway_opcodes)
     ENUMERATOR(DISCORD_GATEWAY_DISPATCH, = 0)
     ENUMERATOR(DISCORD_GATEWAY_HEARTBEAT, = 1)
@@ -73,7 +76,9 @@ ENUM(discord_gateway_opcodes)
     ENUMERATOR(DISCORD_GATEWAY_HELLO, = 10)
     ENUMERATOR_LAST(DISCORD_GATEWAY_HEARTBEAT_ACK, = 11)
 ENUM_END
+#endif
 
+#if GENCODECS_RECIPE == DATA
 ENUM(discord_activity_types)
   /** Format: \"Playing {name}\" */
     ENUMERATOR(DISCORD_ACTIVITY_GAME, = 0)
@@ -88,7 +93,9 @@ ENUM(discord_activity_types)
   /** Format: \"Competing in {name}\" */
     ENUMERATOR_LAST(DISCORD_ACTIVITY_COMPETING, = 5)
 ENUM_END
+#endif
 
+#if GENCODECS_RECIPE & (DATA | JSON)
 STRUCT(discord_activity)
   /** the activity's name */
   COND_WRITE(self->name != NULL)
@@ -147,18 +154,24 @@ STRUCT(discord_activity)
     FIELD_STRUCT_PTR(buttons, discord_activity_buttons, *)
   COND_END
 STRUCT_END
+#endif
 
+#if GENCODECS_RECIPE & (DATA | JSON)
 LIST(discord_activities)
     LISTTYPE_STRUCT(discord_activity)
 LIST_END
+#endif
 
+#if GENCODECS_RECIPE & (DATA | JSON)
 STRUCT(discord_activity_timestamps)
   /** unix timestamp (in milliseconds)of when the activity started */
     FIELD_TIMESTAMP(start)
   /** unix timestamp (in milliseconds)of when the activity ends */
     FIELD_TIMESTAMP(end)
 STRUCT_END
+#endif
 
+#if GENCODECS_RECIPE & (DATA | JSON)
 STRUCT(discord_activity_emoji)
   /** the name of the emoji */
     FIELD_PTR(name, char, *)
@@ -167,7 +180,9 @@ STRUCT(discord_activity_emoji)
   /** whether this emoji is animated */
     FIELD(animated, bool, false)
 STRUCT_END
+#endif
 
+#if GENCODECS_RECIPE & (DATA | JSON)
 STRUCT(discord_activity_party)
   /** the ID of the party */
     FIELD_PTR(id, char, *)
@@ -175,7 +190,9 @@ STRUCT(discord_activity_party)
        integers (current_size, max_size) */
     FIELD_STRUCT_PTR(size, integers, *)
 STRUCT_END
+#endif
 
+#if GENCODECS_RECIPE & (DATA | JSON)
 STRUCT(discord_activity_assets)
   /** activity large asset image */
     FIELD_PTR(large_image, char, *)
@@ -186,7 +203,9 @@ STRUCT(discord_activity_assets)
   /** text displayed when hovering over the small image of the activity */
     FIELD_PTR(small_text, char, *)
 STRUCT_END
+#endif
 
+#if GENCODECS_RECIPE & (DATA | JSON)
 STRUCT(discord_activity_secrets)
   /** the secret for joining a party */
     FIELD_PTR(join, char, *)
@@ -195,19 +214,25 @@ STRUCT(discord_activity_secrets)
   /** the secret for a specific instanced match */
     FIELD_PTR(match, char, *)
 STRUCT_END
+#endif
 
+#if GENCODECS_RECIPE & (DATA | JSON)
 STRUCT(discord_activity_button)
   /** the text shown on the button (1-32 characters) */
     FIELD_PTR(label, char, *)
   /** the url opened when clicking the button (1-512 characters) */
     FIELD_PTR(url, char, *)
 STRUCT_END
+#endif
 
+#if GENCODECS_RECIPE & (DATA | JSON)
 LIST(discord_activity_buttons)
     LISTTYPE_STRUCT(discord_activity_button)
 LIST_END
+#endif
 
 /** @CCORD_pub_struct{discord_presence_update} */
+#if GENCODECS_RECIPE & (DATA | JSON)
 PUB_STRUCT(discord_presence_update)
   /** the user presence is being updated for */
   COND_WRITE(self->user != NULL)
@@ -237,7 +262,9 @@ PUB_STRUCT(discord_presence_update)
   /** whether or not the client is afk */
     FIELD(afk, bool, false)
 STRUCT_END
+#endif
 
+#if GENCODECS_RECIPE & (DATA | JSON)
 STRUCT(discord_client_status)
   /** the user's status set for an active desktop (Windows, Linux, Mac) 
    *    application session */
@@ -249,15 +276,18 @@ STRUCT(discord_client_status)
    *    application session */
     FIELD_PTR(web, char, *)
 STRUCT_END
+#endif
 
+#if GENCODECS_RECIPE & (DATA | JSON)
 LIST(discord_presence_updates)
     LISTTYPE_STRUCT(discord_presence_update)
 LIST_END
+#endif
 
-/* gateway command payloads only need to be encoded into JSON */
-#if !defined(GENCODECS_ON_JSON_DECODER)
+/* GATEWAY COMMAND PAYLOADS ONLY NEED TO BE ENCODED INTO JSON */
 
 /** @CCORD_pub_struct{discord_identify} */
+#if GENCODECS_RECIPE & (DATA | JSON_ENCODER)
 PUB_STRUCT(discord_identify)
   /** authentication token */
     FIELD_PTR(token, char, *)
@@ -280,7 +310,9 @@ PUB_STRUCT(discord_identify)
        @see @ref DiscordInternalGatewayIntents */
     FIELD_BITMASK(intents)
 STRUCT_END
+#endif
 
+#if GENCODECS_RECIPE & (DATA | JSON_ENCODER)
 STRUCT(discord_identify_connection)
   /** your operating system */
     FIELD_PTR(os, char, *)
@@ -289,8 +321,10 @@ STRUCT(discord_identify_connection)
   /** your library name */
     FIELD_PTR(device, char, *)
 STRUCT_END
+#endif
 
 /** @CCORD_pub_struct{discord_resume} */
+#if GENCODECS_RECIPE & (DATA | JSON_ENCODER)
 PUB_STRUCT(discord_resume)
   /** session token */
     FIELD_PTR(token, char, *)
@@ -299,8 +333,10 @@ PUB_STRUCT(discord_resume)
   /** last sequence number received */
     FIELD(seq, int, 0)
 STRUCT_END
+#endif
 
 /** @CCORD_pub_struct{discord_request_guild_members} */
+#if GENCODECS_RECIPE & (DATA | JSON_ENCODER)
 PUB_STRUCT(discord_request_guild_members)
   /** id of the guild to get members for */
     FIELD_SNOWFLAKE(guild_id)
@@ -321,8 +357,10 @@ PUB_STRUCT(discord_request_guild_members)
     FIELD_PTR(nonce, char, *)
   COND_END
 STRUCT_END
+#endif
 
 /** @CCORD_pub_struct{discord_update_voice_state} */
+#if GENCODECS_RECIPE & (DATA | JSON_ENCODER)
 PUB_STRUCT(discord_update_voice_state)
   /** ID of the guild */
     FIELD_SNOWFLAKE(guild_id)
@@ -333,13 +371,12 @@ PUB_STRUCT(discord_update_voice_state)
   /** is the client deafened */
     FIELD(self_deaf, bool, false)
 STRUCT_END
+#endif
 
-#endif /* GENCODECS_ON_JSON_DECODER */
-
-/* event payloads only need to be decoded into structs */
-#if !defined(GENCODECS_ON_JSON_ENCODER)
+/* EVENT PAYLOADS ONLY NEED TO BE DECODED INTO STRUCTS */
 
 /** @CCORD_pub_struct{discord_ready} */
+#if GENCODECS_RECIPE & (DATA | JSON_DECODER)
 PUB_STRUCT(discord_ready)
   /** gateway version */
     FIELD(v, int, 0)
@@ -355,8 +392,10 @@ PUB_STRUCT(discord_ready)
   /** contains `id` and `flags` */
     FIELD_STRUCT_PTR(application, discord_application, *)
 STRUCT_END
+#endif
 
 /** @CCORD_pub_struct{discord_auto_moderation_action_execution} */
+#if GENCODECS_RECIPE & (DATA | JSON_DECODER)
 PUB_STRUCT(discord_auto_moderation_action_execution)
   /** the id of the guild in which action was executed */
     FIELD_SNOWFLAKE(guild_id)
@@ -382,8 +421,10 @@ PUB_STRUCT(discord_auto_moderation_action_execution)
   /** the substring in content that triggered the rule */
     FIELD_PTR(matched_content, char, *)
 STRUCT_END
+#endif
 
 /** @CCORD_pub_struct{discord_thread_list_sync} */
+#if GENCODECS_RECIPE & (DATA | JSON_DECODER)
 PUB_STRUCT(discord_thread_list_sync)
   /** the id of the guild */
     FIELD_SNOWFLAKE(guild_id)
@@ -400,11 +441,13 @@ PUB_STRUCT(discord_thread_list_sync)
    *    indicating which threads the current user has been added to */
     FIELD_STRUCT_PTR(members, discord_thread_members, *)
 STRUCT_END
+#endif
 
 /** 
  * @CCORD_pub_struct{discord_thread_members_update}
  * @todo `added_members` may include guild_members and presence objects
  */
+#if GENCODECS_RECIPE & (DATA | JSON_DECODER)
 PUB_STRUCT(discord_thread_members_update)
   /** the id of the thread */
     FIELD_SNOWFLAKE(id)
@@ -417,8 +460,10 @@ PUB_STRUCT(discord_thread_members_update)
   /** the id of the users who were removed from the thread */
     FIELD_STRUCT_PTR(removed_member_ids, snowflakes, *)
 STRUCT_END
+#endif
 
 /** @CCORD_pub_struct{discord_channel_pins_update} */
+#if GENCODECS_RECIPE & (DATA | JSON_DECODER)
 PUB_STRUCT(discord_channel_pins_update)
   /** the id of the guild */
     FIELD_SNOWFLAKE(guild_id)
@@ -427,54 +472,68 @@ PUB_STRUCT(discord_channel_pins_update)
   /** the time at which the most recent pinned message was pinned */
     FIELD_TIMESTAMP(last_pin_timestamp)
 STRUCT_END
+#endif
 
 /** @CCORD_pub_struct{discord_guild_ban_add} */
+#if GENCODECS_RECIPE & (DATA | JSON_DECODER)
 PUB_STRUCT(discord_guild_ban_add)
   /** the id of the guild */
     FIELD_SNOWFLAKE(guild_id)
   /** the banned user */
     FIELD_STRUCT_PTR(user, discord_user, *)
 STRUCT_END
+#endif
 
 /** @CCORD_pub_struct{discord_guild_ban_remove} */
+#if GENCODECS_RECIPE & (DATA | JSON_DECODER)
 PUB_STRUCT(discord_guild_ban_remove)
   /** the id of the guild */
     FIELD_SNOWFLAKE(guild_id)
   /** the unbanned user */
     FIELD_STRUCT_PTR(user, discord_user, *)
 STRUCT_END
+#endif
 
 /** @CCORD_pub_struct{discord_guild_emojis_update} */
+#if GENCODECS_RECIPE & (DATA | JSON_DECODER)
 PUB_STRUCT(discord_guild_emojis_update)
   /** the id of the guild */
     FIELD_SNOWFLAKE(guild_id)
   /** array of emojis */
     FIELD_STRUCT_PTR(emojis, discord_emojis, *)
 STRUCT_END
+#endif
 
 /** @CCORD_pub_struct{discord_stickers_update} */
+#if GENCODECS_RECIPE & (DATA | JSON_DECODER)
 PUB_STRUCT(discord_guild_stickers_update)
   /** id of the guild */
     FIELD_SNOWFLAKE(guild_id)
   /** array of stickers */
     FIELD_STRUCT_PTR(stickers, discord_stickers, *)
 STRUCT_END
+#endif
 
 /** @CCORD_pub_struct{discord_guild_integrations_update} */
+#if GENCODECS_RECIPE & (DATA | JSON_DECODER)
 PUB_STRUCT(discord_guild_integrations_update)
   /** id of the guild whose integrations were updated */
     FIELD_SNOWFLAKE(guild_id)
 STRUCT_END
+#endif
 
 /** @CCORD_pub_struct{discord_guild_member_remove} */
+#if GENCODECS_RECIPE & (DATA | JSON_DECODER)
 PUB_STRUCT(discord_guild_member_remove)
   /** id of the guild */
     FIELD_SNOWFLAKE(guild_id)
   /** the user who was removed */
     FIELD_STRUCT_PTR(user, discord_user, *)
 STRUCT_END
+#endif
 
 /** @CCORD_pub_struct{discord_guild_member_update} */
+#if GENCODECS_RECIPE & (DATA | JSON_DECODER)
 PUB_STRUCT(discord_guild_member_update)
   /** id of the guild */
     FIELD_SNOWFLAKE(guild_id)
@@ -503,8 +562,10 @@ PUB_STRUCT(discord_guild_member_update)
    *    user is not timed out */
     FIELD_TIMESTAMP(communication_disabled_until)
 STRUCT_END
+#endif
 
 /** @CCORD_pub_struct{discord_guild_members_chunk} */
+#if GENCODECS_RECIPE & (DATA | JSON_DECODER)
 PUB_STRUCT(discord_guild_members_chunk)
   /** the id of the guild */
     FIELD_SNOWFLAKE(guild_id)
@@ -524,32 +585,40 @@ PUB_STRUCT(discord_guild_members_chunk)
   /** the nonce used in the `Guild Members Request` */
     FIELD_PTR(nonce, char, *)
 STRUCT_END
+#endif
 
 /** @CCORD_pub_struct{discord_guild_role_create} */
+#if GENCODECS_RECIPE & (DATA | JSON_DECODER)
 PUB_STRUCT(discord_guild_role_create)
   /** the id of the guild */
     FIELD_SNOWFLAKE(guild_id)
   /** the role created */
     FIELD_STRUCT_PTR(role, discord_role, *)
 STRUCT_END
+#endif
 
 /** @CCORD_pub_struct{discord_guild_role_update} */
+#if GENCODECS_RECIPE & (DATA | JSON_DECODER)
 PUB_STRUCT(discord_guild_role_update)
   /** the id of the guild */
     FIELD_SNOWFLAKE(guild_id)
   /** the role updated */
     FIELD_STRUCT_PTR(role, discord_role, *)
 STRUCT_END
+#endif
 
 /** @CCORD_pub_struct{discord_guild_role_delete} */
+#if GENCODECS_RECIPE & (DATA | JSON_DECODER)
 PUB_STRUCT(discord_guild_role_delete)
   /** the id of the guild */
     FIELD_SNOWFLAKE(guild_id)
   /** the id of the role */
     FIELD_SNOWFLAKE(role_id)
 STRUCT_END
+#endif
 
 /** @CCORD_pub_struct{discord_scheduled_event_user_add} */
+#if GENCODECS_RECIPE & (DATA | JSON_DECODER)
 PUB_STRUCT(discord_guild_scheduled_event_user_add)
   /** id of the guild scheduled event */
     FIELD_SNOWFLAKE(guild_scheduled_event_id)
@@ -558,8 +627,10 @@ PUB_STRUCT(discord_guild_scheduled_event_user_add)
   /** id of the guild */
     FIELD_SNOWFLAKE(guild_id)
 STRUCT_END
+#endif
 
 /** @CCORD_pub_struct{discord_scheduled_event_user_remove} */
+#if GENCODECS_RECIPE & (DATA | JSON_DECODER)
 PUB_STRUCT(discord_guild_scheduled_event_user_remove)
   /** id of the guild scheduled event */
     FIELD_SNOWFLAKE(guild_scheduled_event_id)
@@ -568,8 +639,10 @@ PUB_STRUCT(discord_guild_scheduled_event_user_remove)
   /** id of the guild */
     FIELD_SNOWFLAKE(guild_id)
 STRUCT_END
+#endif
 
 /** @CCORD_pub_struct{discord_integration_delete} */
+#if GENCODECS_RECIPE & (DATA | JSON_DECODER)
 PUB_STRUCT(discord_integration_delete)
   /** integration id */
     FIELD_SNOWFLAKE(id)
@@ -578,8 +651,10 @@ PUB_STRUCT(discord_integration_delete)
   /** id of the bot/OAuth2 application for this Discord integration */
     FIELD_SNOWFLAKE(application_id)
 STRUCT_END
+#endif
 
 /** @CCORD_pub_struct{discord_invite_create} */
+#if GENCODECS_RECIPE & (DATA | JSON_DECODER)
 PUB_STRUCT(discord_invite_create)
   /** the channel the invite is for */
     FIELD_SNOWFLAKE(channel_id)
@@ -608,8 +683,10 @@ PUB_STRUCT(discord_invite_create)
   /** how many times the invite has been used (always 0) */
     FIELD(uses, int, 0)
 STRUCT_END
+#endif
 
 /** @CCORD_pub_struct{discord_invite_delete} */
+#if GENCODECS_RECIPE & (DATA | JSON_DECODER)
 PUB_STRUCT(discord_invite_delete)
   /** the channel of the invite */
     FIELD_SNOWFLAKE(channel_id)
@@ -618,8 +695,10 @@ PUB_STRUCT(discord_invite_delete)
   /** the unique invite code */
     FIELD_PTR(code, char, *)
 STRUCT_END
+#endif
 
 /** @CCORD_pub_struct{discord_message_delete} */
+#if GENCODECS_RECIPE & (DATA | JSON_DECODER)
 PUB_STRUCT(discord_message_delete)
   /** the id of the message */
     FIELD_SNOWFLAKE(id)
@@ -628,8 +707,10 @@ PUB_STRUCT(discord_message_delete)
   /** the id of the guild */
     FIELD_SNOWFLAKE(guild_id)
 STRUCT_END
+#endif
 
 /** @CCORD_pub_struct{discord_message_delete_bulk} */
+#if GENCODECS_RECIPE & (DATA | JSON_DECODER)
 PUB_STRUCT(discord_message_delete_bulk)
   /** the ids of the messages */
     FIELD_STRUCT_PTR(ids, snowflakes, *)
@@ -638,8 +719,10 @@ PUB_STRUCT(discord_message_delete_bulk)
   /** the id of the guild */
     FIELD_SNOWFLAKE(guild_id)
 STRUCT_END
+#endif
 
 /** @CCORD_pub_struct{discord_message_reaction_add} */
+#if GENCODECS_RECIPE & (DATA | JSON_DECODER)
 PUB_STRUCT(discord_message_reaction_add)
   /** the id of the user */
     FIELD_SNOWFLAKE(user_id)
@@ -654,8 +737,10 @@ PUB_STRUCT(discord_message_reaction_add)
   /** the emoji used to react */
     FIELD_STRUCT_PTR(emoji, discord_emoji, *)
 STRUCT_END
+#endif
 
 /** @CCORD_pub_struct{discord_message_reaction_remove} */
+#if GENCODECS_RECIPE & (DATA | JSON_DECODER)
 PUB_STRUCT(discord_message_reaction_remove)
   /** the id of the user */
     FIELD_SNOWFLAKE(user_id)
@@ -668,8 +753,10 @@ PUB_STRUCT(discord_message_reaction_remove)
   /** the emoji used to react */
     FIELD_STRUCT_PTR(emoji, discord_emoji, *)
 STRUCT_END
+#endif
 
 /** @CCORD_pub_struct{discord_message_reaction_remove_all} */
+#if GENCODECS_RECIPE & (DATA | JSON_DECODER)
 PUB_STRUCT(discord_message_reaction_remove_all)
   /** the id of the channel */
     FIELD_SNOWFLAKE(channel_id)
@@ -678,8 +765,10 @@ PUB_STRUCT(discord_message_reaction_remove_all)
   /** the id of the guild */
     FIELD_SNOWFLAKE(guild_id)
 STRUCT_END
+#endif
 
 /** @CCORD_pub_struct{discord_message_reaction_remove_emoji} */
+#if GENCODECS_RECIPE & (DATA | JSON_DECODER)
 PUB_STRUCT(discord_message_reaction_remove_emoji)
   /** the id of the channel */
     FIELD_SNOWFLAKE(channel_id)
@@ -690,8 +779,10 @@ PUB_STRUCT(discord_message_reaction_remove_emoji)
   /** the emoji that was removed */
     FIELD_STRUCT_PTR(emoji, discord_emoji, *)
 STRUCT_END
+#endif
 
 /** @CCORD_pub_struct{discord_typing_start} */
+#if GENCODECS_RECIPE & (DATA | JSON_DECODER)
 PUB_STRUCT(discord_typing_start)
   /** id of the channel */
     FIELD_SNOWFLAKE(channel_id)
@@ -704,8 +795,10 @@ PUB_STRUCT(discord_typing_start)
   /** the member who started typing if this happened in a guild */
     FIELD_STRUCT_PTR(member, discord_guild_member, *)
 STRUCT_END
+#endif
 
 /** @CCORD_pub_struct{discord_voice_server_update} */
+#if GENCODECS_RECIPE & (DATA | JSON_DECODER)
 PUB_STRUCT(discord_voice_server_update)
   /** voice connection token */
     FIELD_PTR(token, char, *)
@@ -714,16 +807,20 @@ PUB_STRUCT(discord_voice_server_update)
   /** the voice server host */
     FIELD_PTR(endpoint, char, *)
 STRUCT_END
+#endif
 
 /** @CCORD_pub_struct{discord_webhooks_update} */
+#if GENCODECS_RECIPE & (DATA | JSON_DECODER)
 PUB_STRUCT(discord_webhooks_update)
   /** id of the guild */
     FIELD_SNOWFLAKE(guild_id)
   /** id of the channel */
     FIELD_SNOWFLAKE(channel_id)
 STRUCT_END
+#endif
 
 /** @CCORD_pub_struct{discord_session_start_limit} */
+#if GENCODECS_RECIPE & (DATA | JSON_DECODER)
 PUB_STRUCT(discord_session_start_limit)
   /** the total number of session starts the current user is allowed */
     FIELD(total, int, 0)
@@ -734,5 +831,4 @@ PUB_STRUCT(discord_session_start_limit)
   /** the number of identify requests allowed per 5 seconds */
     FIELD(max_concurrency, int, 0)
 STRUCT_END
-
-#endif /* GENCODECS_ON_JSON_ENCODER */
+#endif

--- a/gencodecs/api/guild.PRE.h
+++ b/gencodecs/api/guild.PRE.h
@@ -17,6 +17,7 @@ PP_DEFINE(DISCORD_SYSTEM_SUPPRESS_JOIN_NOTIFICATION_REPLIES 1 << 3)
 
 /** @} DiscordAPIGuildSystemChannelFlags */
 
+#if GENCODECS_RECIPE == DATA
 ENUM(discord_message_notification_level)
   /** members will receive notifications for all messages by default */
     ENUMERATOR(DISCORD_MESSAGE_NOTIFICATION_ALL_MESSAGES, = 0)
@@ -24,7 +25,9 @@ ENUM(discord_message_notification_level)
        them by default */
     ENUMERATOR_LAST(DISCORD_MESSAGE_NOTIFICATION_ONLY_MESSAGES, = 1)
 ENUM_END
+#endif
 
+#if GENCODECS_RECIPE == DATA
 ENUM(discord_explicit_content_filter_level)
   /** media content will not be scanned */
     ENUMERATOR(DISCORD_EXPLICIT_CONTENT_DISABLED, = 0)
@@ -33,14 +36,18 @@ ENUM(discord_explicit_content_filter_level)
   /** media content sent by all members will be scanned */
     ENUMERATOR_LAST(DISCORD_MESSAGE_NOTIFICATION_ALL_MEMBERS, = 2)
 ENUM_END
+#endif
 
+#if GENCODECS_RECIPE == DATA
 ENUM(discord_mfa_level)
   /** guild has no MFA/2FA requirement for moderation actions */
     ENUMERATOR(DISCORD_MFA_NONE, = 0)
   /** guild has a 2FA requirement for moderation actions */
     ENUMERATOR_LAST(DISCORD_MFA_ELEVATED, = 1)
 ENUM_END
+#endif
 
+#if GENCODECS_RECIPE == DATA
 ENUM(discord_verification_level)
   /** unrestricted */
     ENUMERATOR(DISCORD_VERIFICATION_NONE, = 0)
@@ -53,14 +60,18 @@ ENUM(discord_verification_level)
   /** must have a verified phone number */
     ENUMERATOR_LAST(DISCORD_VERIFICATION_VERY_HIGH, = 4)
 ENUM_END
+#endif
 
+#if GENCODECS_RECIPE == DATA
 ENUM(discord_guild_nsfw_level)
     ENUMERATOR(DISCORD_GUILD_NSFW_DEFAULT, = 0)
     ENUMERATOR(DISCORD_GUILD_NSFW_EXPLICIT, = 1)
     ENUMERATOR(DISCORD_GUILD_NSFW_SAFE, = 2)
     ENUMERATOR_LAST(DISCORD_GUILD_NSFW_AGE_RESTRICTED, = 3)
 ENUM_END
+#endif
 
+#if GENCODECS_RECIPE == DATA
 ENUM(discord_premium_tier)
   /** guild has not unlocked any Server Boost perks */
     ENUMERATOR(DISCORD_PREMIUM_TIER_NONE, = 0)
@@ -71,13 +82,17 @@ ENUM(discord_premium_tier)
   /** guild has unlocked Server Boost level 3 perks */
     ENUMERATOR_LAST(DISCORD_PREMIUM_TIER_3, = 3)
 ENUM_END
+#endif
 
+#if GENCODECS_RECIPE == DATA
 ENUM(discord_integration_expire_behaviors)
     ENUMERATOR(DISCORD_INTEGRATION_REMOVE_ROLE, = 0)
     ENUMERATOR_LAST(DISCORD_INTEGRATION_KICK, = 1)
 ENUM_END
+#endif
 
 /** @CCORD_pub_struct{discord_guild} */
+#if GENCODECS_RECIPE & (DATA | JSON)
 PUB_STRUCT(discord_guild)
   /** guild id */
     FIELD_SNOWFLAKE(id)
@@ -226,13 +241,17 @@ PUB_STRUCT(discord_guild)
   /** whether the guild has the boost progress bar enabled */
     FIELD(premium_progress_bar_enabled, bool, false)
 STRUCT_END
+#endif
 
 /** @CCORD_pub_list{discord_guilds} */
+#if GENCODECS_RECIPE & (DATA | JSON)
 PUB_LIST(discord_guilds)
     LISTTYPE_STRUCT(discord_guild)
 LIST_END
+#endif
 
 /** @CCORD_pub_struct{discord_guild_preview} */
+#if GENCODECS_RECIPE & (DATA | JSON)
 PUB_STRUCT(discord_guild_preview)
   /** guild id */
     FIELD_SNOWFLAKE(id)
@@ -257,16 +276,20 @@ PUB_STRUCT(discord_guild_preview)
   /** custom guild stickers */
     FIELD_STRUCT_PTR(stickers, discord_stickers, *)
 STRUCT_END
+#endif
 
 /** @CCORD_pub_struct{discord_guild_widget_settings} */
+#if GENCODECS_RECIPE & (DATA | JSON)
 PUB_STRUCT(discord_guild_widget_settings)
   /** whether the widget is enabled */
     FIELD(enabled, bool, false)
   /** the widget channel ID */
     FIELD_SNOWFLAKE(channel_id)
 STRUCT_END
+#endif
 
 /** @CCORD_pub_struct{discord_guild_widget} */
+#if GENCODECS_RECIPE & (DATA | JSON)
 PUB_STRUCT(discord_guild_widget)
   /** guild id */
     FIELD_SNOWFLAKE(id)
@@ -281,8 +304,10 @@ PUB_STRUCT(discord_guild_widget)
   /** number of online members in this guild */
     FIELD(presence_count, int, 0)
 STRUCT_END
+#endif
 
 /** @CCORD_pub_struct{discord_guild_member} */
+#if GENCODECS_RECIPE & (DATA | JSON)
 PUB_STRUCT(discord_guild_member)
   /** the user this guild member represents */
   COND_WRITE(self->user != NULL)
@@ -323,13 +348,17 @@ PUB_STRUCT(discord_guild_member)
   /** the guild id @note extra field for `Guild Member Add` event */
     FIELD_SNOWFLAKE(guild_id)
 STRUCT_END
+#endif
 
 /** @CCORD_pub_list{discord_guild_members} */
+#if GENCODECS_RECIPE & (DATA | JSON)
 PUB_LIST(discord_guild_members)
     LISTTYPE_STRUCT(discord_guild_member)
 LIST_END
+#endif
 
 /** @CCORD_pub_struct{discord_integration} */
+#if GENCODECS_RECIPE & (DATA | JSON)
 PUB_STRUCT(discord_integration)
   /** integration id */
     FIELD_SNOWFLAKE(id)
@@ -366,18 +395,24 @@ PUB_STRUCT(discord_integration)
    *    `Integration Create` or `Integration Update` */
     FIELD_SNOWFLAKE(guild_id)
 STRUCT_END
+#endif
 
+#if GENCODECS_RECIPE & (DATA | JSON)
 PUB_LIST(discord_integrations)
     LISTTYPE_STRUCT(discord_integration)
 LIST_END
+#endif
 
+#if GENCODECS_RECIPE & (DATA | JSON)
 STRUCT(discord_integration_account)
   /** id of the account */
     FIELD_PTR(id, char, *)
   /** name of the account */
     FIELD_PTR(name, char, *)
 STRUCT_END
+#endif
 
+#if GENCODECS_RECIPE & (DATA | JSON)
 STRUCT(discord_integration_application)
   /** the id of the app */
     FIELD_SNOWFLAKE(id)
@@ -394,21 +429,27 @@ STRUCT(discord_integration_application)
     FIELD_STRUCT_PTR(bot, discord_user, *)
   COND_END
 STRUCT_END
+#endif
 
 /** @CCORD_pub_struct{discord_ban} */
+#if GENCODECS_RECIPE & (DATA | JSON)
 PUB_STRUCT(discord_ban)
   /** the reason for the ban */
     FIELD_PTR(reason, char, *)
   /** the banned user */
     FIELD_STRUCT_PTR(user, discord_user, *)
 STRUCT_END
+#endif
 
 /** @CCORD_pub_list{discord_bans} */
+#if GENCODECS_RECIPE & (DATA | JSON)
 PUB_LIST(discord_bans)
     LISTTYPE_STRUCT(discord_ban)
 LIST_END
+#endif
 
 /** @CCORD_pub_struct{discord_welcome_screen} */
+#if GENCODECS_RECIPE & (DATA | JSON)
 PUB_STRUCT(discord_welcome_screen)
   /** the server description shown in the welcome screen */
     FIELD_PTR(description, char, *)
@@ -417,7 +458,9 @@ PUB_STRUCT(discord_welcome_screen)
     FIELD_STRUCT_PTR(welcome_channels, discord_welcome_screen_channels, *)
   COND_END
 STRUCT_END
+#endif
 
+#if GENCODECS_RECIPE & (DATA | JSON)
 STRUCT(discord_welcome_screen_channel)
   /** the channel's id */
     FIELD_SNOWFLAKE(channel_id)
@@ -429,21 +472,27 @@ STRUCT(discord_welcome_screen_channel)
        no emoji is set */
     FIELD_PTR(emoji_name, char, *)
 STRUCT_END
+#endif
 
+#if GENCODECS_RECIPE & (DATA | JSON)
 LIST(discord_welcome_screen_channels)
     LISTTYPE_STRUCT(discord_welcome_screen_channel)
 LIST_END
+#endif
 
 /** @CCORD_pub_struct{discord_prune_count} */
+#if GENCODECS_RECIPE & (DATA | JSON)
 PUB_STRUCT(discord_prune_count)
     FIELD(pruned, int, 0)
 STRUCT_END
+#endif
 
 /*****************************************************************************
  * Guild REST parameters
  * **************************************************************************/
 
 /** @CCORD_pub_struct{discord_create_guild} */
+#if GENCODECS_RECIPE & (DATA | JSON)
 PUB_STRUCT(discord_create_guild)
   /** name of the guild (2-100 charaters) */
     FIELD_PTR(name, char, *)
@@ -482,8 +531,10 @@ PUB_STRUCT(discord_create_guild)
   /** @ref DiscordAPIGuildSystemChannelFlags */
     FIELD_BITMASK(system_channel_flags)
 STRUCT_END
+#endif
 
 /** @CCORD_pub_struct{discord_modify_guild} */
+#if GENCODECS_RECIPE & (DATA | JSON)
 PUB_STRUCT(discord_modify_guild)
   /** guild name */
     FIELD_PTR(name, char, *)
@@ -532,8 +583,10 @@ PUB_STRUCT(discord_modify_guild)
   /** whether the guild's boost progress bar should be enabled */
     FIELD(premium_progress_bar_enabled, bool, false)
 STRUCT_END
+#endif
 
 /** @CCORD_pub_struct{discord_create_guild_channel} */
+#if GENCODECS_RECIPE & (DATA | JSON)
 PUB_STRUCT(discord_create_guild_channel)
   /** channel name (1-100 characters) */
     FIELD_PTR(name, char, *)
@@ -564,7 +617,9 @@ PUB_STRUCT(discord_create_guild_channel)
   /** whether the channel is nsfw */
     FIELD(nsfw, bool, false)
 STRUCT_END
+#endif
 
+#if GENCODECS_RECIPE & (DATA | JSON)
 STRUCT(discord_modify_guild_channel_position)
   /** channel ID */
     FIELD_SNOWFLAKE(id)
@@ -580,13 +635,17 @@ STRUCT(discord_modify_guild_channel_position)
     FIELD_SNOWFLAKE(parent_id)
   COND_END
 STRUCT_END
+#endif
 
 /** @CCORD_pub_list{discord_modify_guild_channel_positions} */
+#if GENCODECS_RECIPE & (DATA | JSON)
 PUB_LIST(discord_modify_guild_channel_positions)
     LISTTYPE_STRUCT(discord_modify_guild_channel_position)
 LIST_END
+#endif
 
 /** @CCORD_pub_struct{discord_list_active_guild_threads} */
+#if GENCODECS_RECIPE & (DATA | JSON)
 PUB_STRUCT(discord_list_active_guild_threads)
   /** the active threads */
     FIELD_STRUCT_PTR(threads, discord_channels, *)
@@ -594,8 +653,9 @@ PUB_STRUCT(discord_list_active_guild_threads)
        joined */
     FIELD_STRUCT_PTR(members, discord_thread_members, *)
 STRUCT_END
+#endif
 
-#if defined(GENCODECS_ON_STRUCT)
+#if GENCODECS_RECIPE == DATA
 STRUCT(discord_list_guild_members)
   /** max number of members to return (1-1000) */
     FIELD(limit, int, 0)
@@ -604,7 +664,7 @@ STRUCT(discord_list_guild_members)
 STRUCT_END
 #endif
 
-#if defined(GENCODECS_ON_STRUCT)
+#if GENCODECS_RECIPE == DATA
 STRUCT(discord_search_guild_members)
   /** query string to match username(s) and nickname(s) against */
     FIELD_PTR(query, char, *)
@@ -614,6 +674,7 @@ STRUCT_END
 #endif
 
 /** @CCORD_pub_struct{discord_add_guild_member} */
+#if GENCODECS_RECIPE & (DATA | JSON)
 PUB_STRUCT(discord_add_guild_member)
   /** an oauth2 access token granted with the `guild.join` to the bot's
        application for the user you want to add in the guild */
@@ -627,8 +688,10 @@ PUB_STRUCT(discord_add_guild_member)
   /** whether the user is deafened in voice channels */
     FIELD(deaf, bool, false)
 STRUCT_END
+#endif
 
 /** @CCORD_pub_struct{discord_modify_guild_member} */
+#if GENCODECS_RECIPE & (DATA | JSON)
 PUB_STRUCT(discord_modify_guild_member)
   /** value to set user's nickname to */
     FIELD_PTR(nick, char, *)
@@ -652,24 +715,30 @@ PUB_STRUCT(discord_modify_guild_member)
     FIELD_TIMESTAMP(communication_disabled_until)
   COND_END
 STRUCT_END
+#endif
 
 /** @CCORD_pub_struct{discord_modify_current_member} */
+#if GENCODECS_RECIPE & (DATA | JSON)
 PUB_STRUCT(discord_modify_current_member)
   /** value to set user's nickname to */
   COND_WRITE(self->nick != NULL)
     FIELD_PTR(nick, char, *)
   COND_END
 STRUCT_END
+#endif
 
 /** @CCORD_pub_struct{discord_modify_current_user_nick} */
+#if GENCODECS_RECIPE & (DATA | JSON)
 PUB_STRUCT(discord_modify_current_user_nick)
   /** value to set user's nickname to */
   COND_WRITE(self->nick != NULL)
     FIELD_PTR(nick, char, *)
   COND_END
 STRUCT_END
+#endif
 
 /** @CCORD_pub_struct{discord_create_guild_ban} */
+#if GENCODECS_RECIPE & (DATA | JSON)
 PUB_STRUCT(discord_create_guild_ban)
   /** number of days to delete messages for (0-7) */
   COND_WRITE(self->delete_message_days >= 0 && self->delete_message_days <= 7)
@@ -680,8 +749,10 @@ PUB_STRUCT(discord_create_guild_ban)
     FIELD_PTR(reason, char, *)
   COND_END
 STRUCT_END
+#endif
 
 /** @CCORD_pub_struct{discord_create_guild_role} */
+#if GENCODECS_RECIPE & (DATA | JSON)
 PUB_STRUCT(discord_create_guild_role)
   /** name of the role */
     FIELD_PTR(name, char, *)
@@ -699,7 +770,9 @@ PUB_STRUCT(discord_create_guild_role)
   /** whether the role should be mentionable */
     FIELD(mentionable, bool, false)
 STRUCT_END
+#endif
 
+#if GENCODECS_RECIPE & (DATA | JSON)
 STRUCT(discord_modify_guild_role_position)
   /** role */
     FIELD_SNOWFLAKE(id)
@@ -708,13 +781,17 @@ STRUCT(discord_modify_guild_role_position)
     FIELD(position, int, 0)
   COND_END
 STRUCT_END
+#endif
 
 /** @CCORD_pub_list{discord_modify_guild_role_positions} */
+#if GENCODECS_RECIPE & (DATA | JSON)
 PUB_LIST(discord_modify_guild_role_positions)
     LISTTYPE_STRUCT(discord_modify_guild_role_position)
 LIST_END
+#endif
 
 /** @CCORD_pub_struct{discord_modify_guild_role} */
+#if GENCODECS_RECIPE & (DATA | JSON)
 PUB_STRUCT(discord_modify_guild_role)
   /** name of the role */
     FIELD_PTR(name, char, *)
@@ -732,8 +809,9 @@ PUB_STRUCT(discord_modify_guild_role)
   /** whether the role should be mentionable */
     FIELD(mentionable, bool, false)
 STRUCT_END
+#endif
 
-#if defined(GENCODECS_ON_STRUCT)
+#if GENCODECS_RECIPE == DATA
 STRUCT(discord_get_guild_prune_count)
   /** number of days to count prune for (1-30) */
   COND_WRITE(self->days >= 1 && self->days <= 30)
@@ -745,6 +823,7 @@ STRUCT_END
 #endif
 
 /** @CCORD_pub_struct{discord_begin_guild_prune} */
+#if GENCODECS_RECIPE & (DATA | JSON)
 PUB_STRUCT(discord_begin_guild_prune)
   /** number of days to prune */
   COND_WRITE(self->days != 0)
@@ -759,8 +838,9 @@ PUB_STRUCT(discord_begin_guild_prune)
     FIELD_PTR(reason, char, *)
   COND_END
 STRUCT_END
+#endif
 
-#if defined(GENCODECS_ON_STRUCT)
+#if GENCODECS_RECIPE == DATA
 STRUCT(discord_get_guild_widget_image)
   /** style of the widget image returned
        @see https://discord.com/developers/docs/resources/guild#membership-screening-object-widget-style-options */
@@ -771,6 +851,7 @@ STRUCT_END
 #endif
 
 /** @CCORD_pub_struct{discord_modify_guild_welcome_screen} */
+#if GENCODECS_RECIPE & (DATA | JSON)
 PUB_STRUCT(discord_modify_guild_welcome_screen)
   /** whether the welcome screen is enabled */
     FIELD(enabled, bool, false)
@@ -781,8 +862,10 @@ PUB_STRUCT(discord_modify_guild_welcome_screen)
     FIELD_PTR(description, char, *)
   COND_END
 STRUCT_END
+#endif
 
 /** @CCORD_pub_struct{discord_modify_current_user_voice_state} */
+#if GENCODECS_RECIPE & (DATA | JSON)
 PUB_STRUCT(discord_modify_current_user_voice_state)
   /** the ID of the channel the user is currently in */
     FIELD_SNOWFLAKE(channel_id)
@@ -794,11 +877,14 @@ PUB_STRUCT(discord_modify_current_user_voice_state)
     FIELD_TIMESTAMP(request_to_speak_timestamp)
   COND_END
 STRUCT_END
+#endif
 
 /** @CCORD_pub_struct{discord_modify_user_voice_state} */
+#if GENCODECS_RECIPE & (DATA | JSON)
 PUB_STRUCT(discord_modify_user_voice_state)
   /** the ID of the channel the user is currently in */
     FIELD_SNOWFLAKE(channel_id)
   /** toggles the user's suppress state */
     FIELD(suppress, bool, false)
 STRUCT_END
+#endif

--- a/gencodecs/api/guild_scheduled_event.PRE.h
+++ b/gencodecs/api/guild_scheduled_event.PRE.h
@@ -2,25 +2,32 @@
  * Guild Scheduled Event Datatypes
  * **************************************************************************/
 
+#if GENCODECS_RECIPE == DATA
 ENUM(discord_guild_scheduled_event_privacy_level)
   /** the scheduled event is only accessible to guild members */
     ENUMERATOR_LAST(DISCORD_GUILD_SCHEDULED_EVENT_GUILD_ONLY, = 2)
 ENUM_END
+#endif
 
+#if GENCODECS_RECIPE == DATA
 ENUM(discord_guild_scheduled_event_entity_types)
     ENUMERATOR(DISCORD_GUILD_SCHEDULED_EVENT_ENTITY_STAGE_INSTANCE, = 1)
     ENUMERATOR(DISCORD_GUILD_SCHEDULED_EVENT_ENTITY_VOICE, = 2)
     ENUMERATOR_LAST(DISCORD_GUILD_SCHEDULED_EVENT_ENTITY_EXTERNAL, = 3)
 ENUM_END
+#endif
 
+#if GENCODECS_RECIPE == DATA
 ENUM(discord_guild_scheduled_event_status)
     ENUMERATOR(DISCORD_GUILD_SCHEDULED_EVENT_SCHEDULED, = 1)
     ENUMERATOR(DISCORD_GUILD_SCHEDULED_EVENT_ACTIVE, = 2)
     ENUMERATOR(DISCORD_GUILD_SCHEDULED_EVENT_COMPLETED, = 3)
     ENUMERATOR_LAST(DISCORD_GUILD_SCHEDULED_EVENT_CANCELED, = 4)
 ENUM_END
+#endif
 
 /** @CCORD_pub_struct{discord_guild_scheduled_event} */
+#if GENCODECS_RECIPE & (DATA | JSON)
 PUB_STRUCT(discord_guild_scheduled_event)
   /** the ID of the scheduled event */
     FIELD_SNOWFLAKE(id)
@@ -67,19 +74,25 @@ PUB_STRUCT(discord_guild_scheduled_event)
   /** the cover image hashof the scheduled event */
     FIELD_PTR(image, char, *)
 STRUCT_END
+#endif
 
+#if GENCODECS_RECIPE & (DATA | JSON)
 STRUCT(discord_guild_scheduled_event_entity_metadata)
   /** location of the event (1-100 characters) */
   COND_WRITE(self->location != NULL)
     FIELD_PTR(location, char, *)
   COND_END
 STRUCT_END
+#endif
 
 /** @CCORD_pub_list{discord_guild_scheduled_events} */
+#if GENCODECS_RECIPE & (DATA | JSON)
 PUB_LIST(discord_guild_scheduled_events)
     LISTTYPE_STRUCT(discord_guild_scheduled_event)
 LIST_END
+#endif
 
+#if GENCODECS_RECIPE & (DATA | JSON)
 STRUCT(discord_guild_scheduled_event_user)
   /** the scheduled event ID which the user subscribed to */
     FIELD_SNOWFLAKE(guild_scheduled_event_id)
@@ -93,17 +106,20 @@ STRUCT(discord_guild_scheduled_event_user)
     FIELD_STRUCT_PTR(member, discord_guild_member, *)
   COND_END
 STRUCT_END
+#endif
 
 /** @CCORD_pub_list{discord_guild_scheduled_event_users} */
+#if GENCODECS_RECIPE & (DATA | JSON)
 PUB_LIST(discord_guild_scheduled_event_users)
     LISTTYPE_STRUCT(discord_guild_scheduled_event_user)
 LIST_END
+#endif
 
 /*****************************************************************************
  * Guild Scheduled Event REST parameters
  * **************************************************************************/
 
-#if defined(GENCODECS_ON_STRUCT)
+#if GENCODECS_RECIPE == DATA
 STRUCT(discord_list_guild_scheduled_events)
   /** include number of users subscribed to each event */
     FIELD(with_user_count, bool, false)
@@ -111,6 +127,7 @@ STRUCT_END
 #endif
 
 /** @CCORD_pub_struct{discord_create_guild_scheduled_event} */
+#if GENCODECS_RECIPE & (DATA | JSON)
 PUB_STRUCT(discord_create_guild_scheduled_event)
   /** the channel ID of the scheduled event */
   COND_WRITE(self->channel_id != 0)
@@ -147,8 +164,9 @@ PUB_STRUCT(discord_create_guild_scheduled_event)
     FIELD_PTR(image, char, *)
   COND_END
 STRUCT_END
+#endif
 
-#if defined(GENCODECS_ON_STRUCT)
+#if GENCODECS_RECIPE == DATA
 STRUCT(discord_get_guild_scheduled_event)
   /** include number of users subscribed to each event */
     FIELD(with_user_count, bool, false)
@@ -156,6 +174,7 @@ STRUCT_END
 #endif
 
 /** @CCORD_pub_struct{discord_modify_guild_scheduled_event} */
+#if GENCODECS_RECIPE & (DATA | JSON)
 PUB_STRUCT(discord_modify_guild_scheduled_event)
   /** the channel ID of the scheduled event */
   COND_WRITE(self->channel_id != 0)
@@ -192,8 +211,9 @@ PUB_STRUCT(discord_modify_guild_scheduled_event)
     FIELD_PTR(image, char, *)
   COND_END
 STRUCT_END
+#endif
 
-#if defined(GENCODECS_ON_STRUCT)
+#if GENCODECS_RECIPE == DATA
 STRUCT(discord_get_guild_scheduled_event_users)
   /** number of users to return (up to maximum of 100) */
     FIELD(limit, int, 0)

--- a/gencodecs/api/guild_template.PRE.h
+++ b/gencodecs/api/guild_template.PRE.h
@@ -3,6 +3,7 @@
  * **************************************************************************/
 
 /** @CCORD_pub_struct{discord_guild_template} */
+#if GENCODECS_RECIPE & (DATA | JSON)
 PUB_STRUCT(discord_guild_template)
   /** the template code (unique ID) */
     FIELD_PTR(code, char, *)
@@ -27,17 +28,21 @@ PUB_STRUCT(discord_guild_template)
   /** whether the template has unsynced changes */
     FIELD(is_dirty, bool, false)
 STRUCT_END
+#endif
 
 /** @CCORD_pub_list{discord_guild_templates} */
+#if GENCODECS_RECIPE & (DATA | JSON)
 PUB_LIST(discord_guild_templates)
     LISTTYPE_STRUCT(discord_guild_template)
 LIST_END
+#endif
 
 /*****************************************************************************
  * Guild Template REST parameters
  * **************************************************************************/
 
 /** @CCORD_pub_struct{discord_create_guild_from_guild_template} */
+#if GENCODECS_RECIPE & (DATA | JSON)
 PUB_STRUCT(discord_create_guild_from_guild_template)
   /** name of the guild (2-100 characters) */
     FIELD_PTR(name, char, *)
@@ -46,8 +51,10 @@ PUB_STRUCT(discord_create_guild_from_guild_template)
     FIELD_PTR(icon, char, *)
   COND_END
 STRUCT_END
+#endif
 
 /** @CCORD_pub_struct{discord_create_guild_template} */
+#if GENCODECS_RECIPE & (DATA | JSON)
 PUB_STRUCT(discord_create_guild_template)
   /** name of the template (1-100 characters) */
     FIELD_PTR(name, char, *)
@@ -56,8 +63,10 @@ PUB_STRUCT(discord_create_guild_template)
     FIELD_PTR(description, char, *)
   COND_END
 STRUCT_END
+#endif
 
 /** @CCORD_pub_struct{discord_modify_guild_template} */
+#if GENCODECS_RECIPE & (DATA | JSON)
 PUB_STRUCT(discord_modify_guild_template)
   /** name of the template (1-100 characters) */
   COND_WRITE(self->name != NULL)
@@ -68,3 +77,4 @@ PUB_STRUCT(discord_modify_guild_template)
     FIELD_PTR(description, char, *)
   COND_END
 STRUCT_END
+#endif

--- a/gencodecs/api/interactions.PRE.h
+++ b/gencodecs/api/interactions.PRE.h
@@ -2,6 +2,7 @@
  * Interactions Datatypes
  * **************************************************************************/
 
+#if GENCODECS_RECIPE == DATA
 ENUM(discord_interaction_types)
     ENUMERATOR(DISCORD_INTERACTION_PING, = 1)
     ENUMERATOR(DISCORD_INTERACTION_APPLICATION_COMMAND, = 2)
@@ -9,7 +10,9 @@ ENUM(discord_interaction_types)
     ENUMERATOR(DISCORD_INTERACTION_APPLICATION_COMMAND_AUTOCOMPLETE, = 4)
     ENUMERATOR_LAST(DISCORD_INTERACTION_MODAL_SUBMIT, = 5)
 ENUM_END
+#endif
 
+#if GENCODECS_RECIPE == DATA
 ENUM(discord_interaction_callback_types)
   /** ACK a @ref DISCORD_INTERACTION_PING */
     ENUMERATOR(DISCORD_INTERACTION_PONG, = 1)
@@ -28,8 +31,10 @@ ENUM(discord_interaction_callback_types)
   /** respond to an interaction with a popup modal */
     ENUMERATOR_LAST(DISCORD_INTERACTION_MODAL, = 9)
 ENUM_END
+#endif
 
 /** @CCORD_pub_struct{discord_interaction} */
+#if GENCODECS_RECIPE & (DATA | JSON)
 PUB_STRUCT(discord_interaction)
   /** ID of the interaction */
     FIELD_SNOWFLAKE(id)
@@ -58,7 +63,9 @@ PUB_STRUCT(discord_interaction)
   /** the guild preferred locale, if invoked in a guild */
     FIELD_PTR(guild_locale, char, *)
 STRUCT_END
+#endif
 
+#if GENCODECS_RECIPE & (DATA | JSON)
 STRUCT(discord_interaction_data)
   /** the ID of the invoked command */
     FIELD_SNOWFLAKE(id)
@@ -81,7 +88,9 @@ STRUCT(discord_interaction_data)
   /** the values submitted by the user */
     FIELD_STRUCT_PTR(components, discord_components, *)
 STRUCT_END
+#endif
 
+#if GENCODECS_RECIPE & (DATA | JSON)
 STRUCT(discord_resolved_data)
   /** the IDs and @ref discord_user datatypes */
     FIELD_STRUCT_PTR(users, snowflakes, *)
@@ -96,7 +105,9 @@ STRUCT(discord_resolved_data)
   /** the IDs and partial @ref discord_attachment datatypes */
     FIELD_STRUCT_PTR(attachments, snowflakes, *)
 STRUCT_END
+#endif
 
+#if GENCODECS_RECIPE & (DATA | JSON)
 STRUCT(discord_message_interaction)
   /** ID of the interaction */
     FIELD_SNOWFLAKE(id)
@@ -109,8 +120,10 @@ STRUCT(discord_message_interaction)
   /** the member who invoked the interaction in the guild */
     FIELD_STRUCT_PTR(member, discord_guild_member, *)
 STRUCT_END
+#endif
 
 /** @CCORD_pub_struct{discord_interaction_response} */
+#if GENCODECS_RECIPE & (DATA | JSON)
 PUB_STRUCT(discord_interaction_response)
   /** interaction callback type */
     FIELD_ENUM(type, discord_interaction_callback_types)
@@ -119,7 +132,9 @@ PUB_STRUCT(discord_interaction_response)
     FIELD_STRUCT_PTR(data, discord_interaction_callback_data, *)
   COND_END
 STRUCT_END
+#endif
 
+#if GENCODECS_RECIPE & (DATA | JSON)
 STRUCT(discord_interaction_callback_data)
   /** message components */
   COND_WRITE(self->components != NULL)
@@ -157,19 +172,20 @@ STRUCT(discord_interaction_callback_data)
   /** the title of the popup modal */
     FIELD_PTR(title, char, *)
 STRUCT_END
+#endif
 
 /*****************************************************************************
  * Interactions REST parameters
  * **************************************************************************/
 
 /** @CCORD_pub_struct{discord_edit_original_interaction_response} */
+#if GENCODECS_RECIPE & (DATA | JSON)
 PUB_STRUCT(discord_edit_original_interaction_response)
   /* QUERY FIELDS */
-#if !defined(GENCODECS_ON_JSON)
+#if !(GENCODECS_RECIPE & JSON)
   /** id of the thread the message is in */
     FIELD_SNOWFLAKE(thread_id)
 #endif
-
   /* JSON FIELDS */
   /** the message contents (up to 2000 characters) */
     FIELD_PTR(content, char, *)
@@ -190,11 +206,13 @@ PUB_STRUCT(discord_edit_original_interaction_response)
     FIELD_STRUCT_PTR(attachments, discord_attachments, *)
   COND_END
 STRUCT_END
+#endif
 
 /** @CCORD_pub_struct{discord_create_followup_message} */
+#if GENCODECS_RECIPE & (DATA | JSON)
 PUB_STRUCT(discord_create_followup_message)
   /* QUERY FIELDS */
-#if !defined(GENCODECS_ON_JSON)
+#if !(GENCODECS_RECIPE & JSON)
   /** waits for server confirmation of message send before response, and
        returns the created message body (defaults to `false`; when `false` a
        message that is not saved does not return an error) */
@@ -203,7 +221,6 @@ PUB_STRUCT(discord_create_followup_message)
        thread will automatically be unarchived */
     FIELD_SNOWFLAKE(thread_id)
 #endif
-
   /* JSON FIELDS */
   /** override the default avatar of the webhook */
     FIELD_PTR(avatar_url, char, *)
@@ -231,15 +248,16 @@ PUB_STRUCT(discord_create_followup_message)
     FIELD_BITMASK(flags)
   COND_END
 STRUCT_END
+#endif
 
 /** @CCORD_pub_struct{discord_edit_followup_message} */
+#if GENCODECS_RECIPE & (DATA | JSON)
 PUB_STRUCT(discord_edit_followup_message)
   /* QUERY FIELDS */
-#if !defined(GENCODECS_ON_JSON)
+#if !(GENCODECS_RECIPE & JSON)
   /** id of the thread the message is in */
     FIELD_SNOWFLAKE(thread_id)
 #endif
-
   /* JSON FIELDS */
   /** the message contents (up to 2000 characters) */
     FIELD_PTR(content, char, *)
@@ -260,3 +278,4 @@ PUB_STRUCT(discord_edit_followup_message)
     FIELD_STRUCT_PTR(attachments, discord_attachments, *)
   COND_END
 STRUCT_END
+#endif

--- a/gencodecs/api/invite.PRE.h
+++ b/gencodecs/api/invite.PRE.h
@@ -2,12 +2,15 @@
  * Invite Datatypes
  * **************************************************************************/
 
+#if GENCODECS_RECIPE == DATA
 ENUM(discord_invite_target_types)
     ENUMERATOR(DISCORD_INVITE_TARGET_STREAM, = 1)
     ENUMERATOR_LAST(DISCORD_INVITE_TARGET_EMBEDDED_APPLICATION, = 2)
 ENUM_END
+#endif
 
 /** @CCORD_pub_struct{discord_invite} */
+#if GENCODECS_RECIPE & (DATA | JSON)
 PUB_STRUCT(discord_invite)
   /** the invite code (unique ID) */
     FIELD_PTR(code, char, *)
@@ -54,12 +57,16 @@ PUB_STRUCT(discord_invite)
     FIELD_STRUCT_PTR(guild_scheduled_event, discord_guild_scheduled_event, *)
   COND_END
 STRUCT_END
+#endif
 
 /** @CCORD_pub_list{discord_invites} */
+#if GENCODECS_RECIPE & (DATA | JSON)
 PUB_LIST(discord_invites)
     LISTTYPE_STRUCT(discord_invite)
 LIST_END
+#endif
 
+#if GENCODECS_RECIPE & (DATA | JSON)
 STRUCT(discord_invite_metadata)
   /** number of times this invite has been used */
     FIELD(uses, int, 0)
@@ -74,7 +81,9 @@ STRUCT(discord_invite_metadata)
     FIELD_TIMESTAMP(created_at)
   COND_END
 STRUCT_END
+#endif
 
+#if GENCODECS_RECIPE & (DATA | JSON)
 STRUCT(discord_invite_stage_instance)
   /** the members speaking in the Stage */
   COND_WRITE(self->members != NULL)
@@ -87,12 +96,14 @@ STRUCT(discord_invite_stage_instance)
   /** the topic of the Stage instance (1-120 characters) */
     FIELD_PTR(topic, char, *)
 STRUCT_END
+#endif
 
 /*****************************************************************************
  * Invite REST parameters
  * **************************************************************************/
 
 /** @CCORD_pub_struct{discord_get_invite} */
+#if GENCODECS_RECIPE & (DATA | JSON)
 PUB_STRUCT(discord_get_invite)
   /** whether the invite should contain approximate member counts */
     FIELD(with_counts, bool, false)
@@ -103,3 +114,4 @@ PUB_STRUCT(discord_get_invite)
     FIELD_SNOWFLAKE(guild_scheduled_event_id)
   COND_END
 STRUCT_END
+#endif

--- a/gencodecs/api/message_components.PRE.h
+++ b/gencodecs/api/message_components.PRE.h
@@ -2,6 +2,7 @@
  * Message Components Datatypes
  * **************************************************************************/
 
+#if GENCODECS_RECIPE == DATA
 ENUM(discord_component_types)
   /** a container for the other components */
     ENUMERATOR(DISCORD_COMPONENT_ACTION_ROW, = 1)
@@ -12,7 +13,9 @@ ENUM(discord_component_types)
   /** a text input object */
     ENUMERATOR_LAST(DISCORD_COMPONENT_TEXT_INPUT, = 4)
 ENUM_END
+#endif
 
+#if GENCODECS_RECIPE == DATA
 ENUM(discord_component_styles)
   /* button styles */
   /** blurple */
@@ -31,8 +34,10 @@ ENUM(discord_component_styles)
   /** a multi-line input */
     ENUMERATOR_LAST(DISCORD_TEXT_PARAGRAPH, = 2)
 ENUM_END
+#endif
 
 /** @CCORD_pub_struct{discord_component} */
+#if GENCODECS_RECIPE & (DATA | JSON)
 PUB_STRUCT(discord_component)
   /** component type */
   COND_WRITE(self->type != 0)
@@ -82,12 +87,16 @@ PUB_STRUCT(discord_component)
   /** a pre-filled value for this component */
     FIELD_PTR(value, char, *)
 STRUCT_END
+#endif
 
 /** @CCORD_pub_list{discord_components} */
+#if GENCODECS_RECIPE & (DATA | JSON)
 PUB_LIST(discord_components)
     LISTTYPE_STRUCT(discord_component)
 LIST_END
+#endif
 
+#if GENCODECS_RECIPE & (DATA | JSON)
 STRUCT(discord_select_option)
   /** the user-facing name of the option, max 100 characters */
     FIELD_PTR(label, char, *)
@@ -104,8 +113,11 @@ STRUCT(discord_select_option)
                  CLEANUP_BLANK, GENCODECS_JSON_ENCODER_bool, 
                  GENCODECS_JSON_DECODER_bool, false)
 STRUCT_END
+#endif
 
 /** @CCORD_pub_list{discord_select_options} */
+#if GENCODECS_RECIPE & (DATA | JSON)
 PUB_LIST(discord_select_options)
     LISTTYPE_STRUCT(discord_select_option)
 LIST_END
+#endif

--- a/gencodecs/api/oauth2.PRE.h
+++ b/gencodecs/api/oauth2.PRE.h
@@ -3,6 +3,7 @@
  * **************************************************************************/
 
 /** @CCORD_pub_struct{discord_auth_response} */
+#if GENCODECS_RECIPE & (DATA | JSON)
 PUB_STRUCT(discord_auth_response)
   /** the current application */
     FIELD_STRUCT_PTR(application, discord_application, *)
@@ -14,4 +15,4 @@ PUB_STRUCT(discord_auth_response)
    *    `identify` scope */
     FIELD_STRUCT_PTR(user, discord_user, *)
 STRUCT_END
-
+#endif

--- a/gencodecs/api/permissions.PRE.h
+++ b/gencodecs/api/permissions.PRE.h
@@ -101,6 +101,7 @@ PP_DEFINE(DISCORD_PERM_MODERATE_MEMBERS 1 << 40)
 /** @} DiscordPermissions */
 
 /** @CCORD_pub_struct{discord_role} */
+#if GENCODECS_RECIPE & (DATA | JSON)
 PUB_STRUCT(discord_role)
   /** role id */
     FIELD_SNOWFLAKE(id)
@@ -131,12 +132,16 @@ PUB_STRUCT(discord_role)
     FIELD_STRUCT_PTR(tags, discord_role_tag, *)
   COND_END
 STRUCT_END
+#endif
 
 /** @CCORD_pub_list{discord_roles} */
+#if GENCODECS_RECIPE & (DATA | JSON)
 PUB_LIST(discord_roles)
     LISTTYPE_STRUCT(discord_role)
 LIST_END
+#endif
 
+#if GENCODECS_RECIPE & (DATA | JSON)
 STRUCT(discord_role_tag)
   /** the id of the bot this role belongs to */
   COND_WRITE(self->bot_id != 0)
@@ -149,3 +154,4 @@ STRUCT(discord_role_tag)
   /** whether this is the guild's premium subscribe role */
     FIELD(premium_subscribe, bool, false)
 STRUCT_END
+#endif

--- a/gencodecs/api/stage_instance.PRE.h
+++ b/gencodecs/api/stage_instance.PRE.h
@@ -2,14 +2,17 @@
  * Stage Instance Datatypes
  * **************************************************************************/
 
+#if GENCODECS_RECIPE == DATA
 ENUM(discord_privacy_level)
   /** the stage instance is visible publicly @deprecated deprecated value */
     ENUMERATOR(DISCORD_PRIVACY_PUBLIC, = 1)
   /** the stage instance is visible to only guild members */
     ENUMERATOR_LAST(DISCORD_PRIVACY_GUILD_ONLY, = 2)
 ENUM_END
+#endif
 
 /** @CCORD_pub_struct{discord_stage_instance} */
+#if GENCODECS_RECIPE & (DATA | JSON)
 PUB_STRUCT(discord_stage_instance)
   /** the ID of this stage instance */
     FIELD_SNOWFLAKE(id)
@@ -26,17 +29,20 @@ PUB_STRUCT(discord_stage_instance)
   /** whether or not stage discovery is disabled @deprecated deprecated field */
     FIELD(discoverable_disabled, bool, false)
 STRUCT_END
+#endif
 
+#if GENCODECS_RECIPE & (DATA | JSON)
 LIST(discord_stage_instances)
     LISTTYPE_STRUCT(discord_stage_instance)
 LIST_END
+#endif
 
 /*****************************************************************************
  * Stage Instance REST parameters
  * **************************************************************************/
 
 /** @CCORD_pub_struct{discord_create_stage_instance} */
-#if !defined(GENCODECS_ON_JSON_ENCODER)
+#if GENCODECS_RECIPE & (DATA | JSON_DECODER)
 PUB_STRUCT(discord_create_stage_instance)
   /** the ID of the stage channel */
     FIELD_SNOWFLAKE(channel_id)
@@ -50,7 +56,7 @@ STRUCT_END
 #endif
 
 /** @CCORD_pub_struct{discord_modify_stage_instance} */
-#if !defined(GENCODECS_ON_JSON_ENCODER)
+#if GENCODECS_RECIPE & (DATA | JSON_DECODER)
 PUB_STRUCT(discord_modify_stage_instance)
   /** the topic of the Stage instance (1-120 characters) */
     FIELD_PTR(topic, char, *)

--- a/gencodecs/api/sticker.PRE.h
+++ b/gencodecs/api/sticker.PRE.h
@@ -2,6 +2,7 @@
  * Sticker Datatypes
  * **************************************************************************/
 
+#if GENCODECS_RECIPE == DATA
 ENUM(discord_sticker_types)
   /** an official sticker in a pack, part of Nitro or in a removed
        purchasable pack */
@@ -9,14 +10,18 @@ ENUM(discord_sticker_types)
   /** a sticker uploaded to a Boosted guild for the guild's members */
     ENUMERATOR_LAST(DISCORD_STICKER_GUILD, = 2)
 ENUM_END
+#endif
 
+#if GENCODECS_RECIPE == DATA
 ENUM(discord_sticker_format_types)
     ENUMERATOR(DISCORD_STICKER_FORMAT_PNG, = 1)
     ENUMERATOR(DISCORD_STICKER_FORMAT_APNG, = 2)
     ENUMERATOR_LAST(DISCORD_STICKER_FORMAT_LOTTIE, = 3)
 ENUM_END
+#endif
 
 /** @CCORD_pub_struct{discord_sticker} */
+#if GENCODECS_RECIPE & (DATA | JSON)
 PUB_STRUCT(discord_sticker)
   /** ID of the sticker */
     FIELD_SNOWFLAKE(id)
@@ -52,14 +57,16 @@ PUB_STRUCT(discord_sticker)
   /** the standard sticker's sort order within its pack */
     FIELD(sort_value, int, 0)
 STRUCT_END
+#endif
 
 /** @CCORD_pub_list{discord_stickers} */
-#if !defined(GENCODECS_ON_JSON_DECODING)
+#if GENCODECS_RECIPE & (DATA | JSON)
 PUB_LIST(discord_stickers)
     LISTTYPE_STRUCT(discord_sticker)
 LIST_END
 #endif
 
+#if GENCODECS_RECIPE & (DATA | JSON)
 STRUCT(discord_sticker_item)
   /** ID of the sticker */
     FIELD_SNOWFLAKE(id)
@@ -70,11 +77,15 @@ STRUCT(discord_sticker_item)
     FIELD_ENUM(format_type, discord_sticker_format_types)
   COND_END
 STRUCT_END
+#endif
 
+#if GENCODECS_RECIPE & (DATA | JSON)
 LIST(discord_sticker_items)
     LISTTYPE_STRUCT(discord_sticker_item)
 LIST_END
+#endif
 
+#if GENCODECS_RECIPE & (DATA | JSON)
 STRUCT(discord_sticker_pack)
   /** ID of the sticker */
     FIELD_SNOWFLAKE(id)
@@ -97,9 +108,10 @@ STRUCT(discord_sticker_pack)
     FIELD_SNOWFLAKE(banner_asset_id)
   COND_END
 STRUCT_END
+#endif
 
 /** @CCORD_pub_struct{discord_list_nitro_sticker_packs} */
-#if !defined(GENCODECS_ON_JSON_DECODING)
+#if GENCODECS_RECIPE & (DATA | JSON)
 PUB_LIST(discord_sticker_packs)
     LISTTYPE_STRUCT(discord_sticker_pack)
 LIST_END
@@ -110,14 +122,14 @@ LIST_END
  * **************************************************************************/
 
 /** @CCORD_pub_struct{discord_list_nitro_sticker_packs} */
-#if !defined(GENCODECS_ON_JSON_ENCODING)
+#if GENCODECS_RECIPE & (DATA | JSON_DECODER)
 PUB_STRUCT(discord_list_nitro_sticker_packs)
   /** array of sticker pack objects */
     FIELD_STRUCT_PTR(sticker_packs, discord_sticker_packs, *)
 STRUCT_END
 #endif
 
-#if defined(GENCODECS_ON_STRUCT)
+#if GENCODECS_RECIPE == DATA
 STRUCT(discord_create_guild_sticker)
   /** name of the sticker (2-30 characters) */
     FIELD_PTR(name, char, *)
@@ -132,6 +144,7 @@ STRUCT_END
 #endif
 
 /** @CCORD_pub_struct{discord_modify_guild_sticker} */
+#if GENCODECS_RECIPE & (DATA | JSON)
 PUB_STRUCT(discord_modify_guild_sticker)
   /** name of the sticker (2-30 characters) */
     FIELD_PTR(name, char, *)
@@ -140,3 +153,4 @@ PUB_STRUCT(discord_modify_guild_sticker)
   /** autocomplete/suggestion tags for the sticker (max 200 characters) */
     FIELD_PTR(tags, char, *)
 STRUCT_END
+#endif

--- a/gencodecs/api/teams.PRE.h
+++ b/gencodecs/api/teams.PRE.h
@@ -2,12 +2,15 @@
  * Teams Datatypes
  * **************************************************************************/
 
+#if GENCODECS_RECIPE == DATA
 ENUM(discord_membership_state)
     ENUMERATOR(DISCORD_MEMBERSHIP_INVITED, = 1)
     ENUMERATOR_LAST(DISCORD_MEMBERSHIP_ACCEPTED, = 2)
 ENUM_END
+#endif
 
 /** @CCORD_pub_struct{discord_team} */
+#if GENCODECS_RECIPE & (DATA | JSON)
 PUB_STRUCT(discord_team)
   /** a hash image of the team's icon */
     FIELD_PTR(icon, char, *)
@@ -22,7 +25,9 @@ PUB_STRUCT(discord_team)
   /** the user ID of the current team owner */
     FIELD_SNOWFLAKE(owner_user_id)
 STRUCT_END
+#endif
 
+#if GENCODECS_RECIPE & (DATA | JSON)
 STRUCT(discord_team_member)
   /** the user's membership state on the team */
     FIELD_ENUM(membership_state, discord_membership_state)
@@ -37,7 +42,10 @@ STRUCT(discord_team_member)
     FIELD_STRUCT_PTR(user, discord_user, *)
   COND_END
 STRUCT_END
+#endif
 
+#if GENCODECS_RECIPE & (DATA | JSON)
 LIST(discord_team_members)
     LISTTYPE_STRUCT(discord_team_member)
 LIST_END
+#endif

--- a/gencodecs/api/user.PRE.h
+++ b/gencodecs/api/user.PRE.h
@@ -40,20 +40,25 @@ PP_DEFINE(DISCORD_USER_BOT_HTTP_INTERACTIONS 1 << 19)
 
 /** @} DiscordAPIUserFlags */
 
+#if GENCODECS_RECIPE == DATA
 ENUM(discord_premium_types)
     ENUMERATOR(DISCORD_PREMIUM_NONE, = 0)
     ENUMERATOR(DISCORD_PREMIUM_NITRO_CLASSIC, = 1)
     ENUMERATOR_LAST(DISCORD_PREMIUM_NITRO, = 2)
 ENUM_END
+#endif
 
+#if GENCODECS_RECIPE == DATA
 ENUM(discord_visibility_types)
   /** invisible to everyone except the user themselves */
     ENUMERATOR(DISCORD_VISIBILITY_NONE, = 0)
   /** visible to everyone */
     ENUMERATOR_LAST(DISCORD_VISIBILITY_EVERYONE, = 1)
 ENUM_END
+#endif
 
 /** @CCORD_pub_struct{discord_user} */
+#if GENCODECS_RECIPE & (DATA | JSON)
 PUB_STRUCT(discord_user)
   /** the user's ID */
     FIELD_SNOWFLAKE(id)
@@ -90,12 +95,16 @@ PUB_STRUCT(discord_user)
   /** the public @ref DiscordAPIUserFlags on a user's account */
     FIELD_BITMASK(public_flags)
 STRUCT_END
+#endif
 
 /** @CCORD_pub_list{discord_users} */
+#if GENCODECS_RECIPE & (DATA | JSON)
 PUB_LIST(discord_users)
     LISTTYPE_STRUCT(discord_user)
 LIST_END
+#endif
 
+#if GENCODECS_RECIPE & (DATA | JSON)
 STRUCT(discord_connection)
   /** ID of the connection account */
     FIELD_SNOWFLAKE(id)
@@ -119,17 +128,21 @@ STRUCT(discord_connection)
   /** visibility of this connection */
     FIELD_ENUM(visibility, discord_visibility_types)
 STRUCT_END
+#endif
 
 /** @CCORD_pub_list{discord_connections} */
+#if GENCODECS_RECIPE & (DATA | JSON)
 PUB_LIST(discord_connections)
     LISTTYPE_STRUCT(discord_connection)
 LIST_END
+#endif
 
 /*****************************************************************************
  * User REST parameters
  * **************************************************************************/
 
 /** @CCORD_pub_struct{discord_modify_current_user} */
+#if GENCODECS_RECIPE & (DATA | JSON)
 PUB_STRUCT(discord_modify_current_user)
   /** user's username, if changed may cause the user's discriminator to be
        randomized */
@@ -141,8 +154,9 @@ PUB_STRUCT(discord_modify_current_user)
     FIELD_PTR(avatar, char, *)
   COND_END
 STRUCT_END
+#endif
 
-#if defined(GENCODECS_ON_STRUCT)
+#if GENCODECS_RECIPE == DATA
 STRUCT(discord_get_current_user_guilds)
   /** get guilds before this guild ID */
   COND_WRITE(self->before != 0)
@@ -160,14 +174,17 @@ STRUCT_END
 #endif
 
 /** @CCORD_pub_struct{discord_create_dm} */
+#if GENCODECS_RECIPE & (DATA | JSON)
 PUB_STRUCT(discord_create_dm)
   /** the recipient to open a DM channel with */
   COND_WRITE(self->recipient_id != 0)
     FIELD_SNOWFLAKE(recipient_id)
   COND_END
 STRUCT_END
+#endif
 
 /** @CCORD_pub_struct{discord_create_group_dm} */
+#if GENCODECS_RECIPE & (DATA | JSON)
 PUB_STRUCT(discord_create_group_dm)
   /** access tokens of users that have grantes your app `gdm.join` scope */
   COND_WRITE(self->access_tokens != NULL)
@@ -178,3 +195,4 @@ PUB_STRUCT(discord_create_group_dm)
     FIELD_STRUCT_PTR(nicks, strings, *)
   COND_END
 STRUCT_END
+#endif

--- a/gencodecs/api/voice.PRE.h
+++ b/gencodecs/api/voice.PRE.h
@@ -3,6 +3,7 @@
  * **************************************************************************/
 
 /** @CCORD_pub_struct{discord_voice_state} */
+#if GENCODECS_RECIPE & (DATA | JSON)
 PUB_STRUCT(discord_voice_state)
   /** the guild ID this voice state is for */
     FIELD_SNOWFLAKE(guild_id)
@@ -34,12 +35,16 @@ PUB_STRUCT(discord_voice_state)
     FIELD_TIMESTAMP(request_to_speak_timestamp)
   COND_END
 STRUCT_END
+#endif
 
 /** @CCORD_pub_list{discord_voice_states} */
+#if GENCODECS_RECIPE & (DATA | JSON)
 PUB_LIST(discord_voice_states)
     LISTTYPE_STRUCT(discord_voice_state)
 LIST_END
+#endif
 
+#if GENCODECS_RECIPE & (DATA | JSON)
 STRUCT(discord_voice_region)
   /** unique ID for the region */
     FIELD_PTR(id, char, *)
@@ -52,8 +57,11 @@ STRUCT(discord_voice_region)
   /** whether this is a custom voice region (used for events/etc) */
     FIELD(custom, bool, false)
 STRUCT_END
+#endif
 
 /** @CCORD_pub_list{discord_voice_regions} */
+#if GENCODECS_RECIPE & (DATA | JSON)
 PUB_LIST(discord_voice_regions)
     LISTTYPE_STRUCT(discord_voice_region)
 LIST_END
+#endif

--- a/gencodecs/api/voice_connections.PRE.h
+++ b/gencodecs/api/voice_connections.PRE.h
@@ -15,6 +15,7 @@ PP_DEFINE(DISCORD_VOICE_PRIORITY 1 << 2)
 
 /** @} DiscordVoiceSpeakingFlags */
 
+#if GENCODECS_RECIPE == DATA
 ENUM(discord_voice_close_opcodes)
   /** You sent an invalid opcode */
     ENUMERATOR(DISCORD_VOICE_CLOSE_REASON_UNKNOWN_OPCODE, = 4001)
@@ -42,7 +43,9 @@ ENUM(discord_voice_close_opcodes)
   /** Discord didn't recognize the encryption */
     ENUMERATOR_LAST(DISCORD_VOICE_CLOSE_REASON_UNKNOWN_ENCRYPTION_MODE, = 4016)
 ENUM_END
+#endif
 
+#if GENCODECS_RECIPE == DATA
 ENUM(discord_voice_opcodes)
   /** Begin a voice websocket connection */
     ENUMERATOR(DISCORD_VOICE_IDENTIFY, = 0)
@@ -68,3 +71,4 @@ ENUM(discord_voice_opcodes)
     ENUMERATOR(DISCORD_VOICE_CLIENT_DISCONNECT, = 13)
     ENUMERATOR_LAST(DISCORD_VOICE_CODEC, = 14)
 ENUM_END
+#endif

--- a/gencodecs/api/webhook.PRE.h
+++ b/gencodecs/api/webhook.PRE.h
@@ -2,6 +2,7 @@
  * Webhook Datatypes
  * **************************************************************************/
 
+#if GENCODECS_RECIPE == DATA
 ENUM(discord_webhook_types)
   /** Incoming Webhooks can post messages to channels with a generated token */
     ENUMERATOR(DISCORD_WEBHOOK_INCOMING, = 1)
@@ -11,8 +12,10 @@ ENUM(discord_webhook_types)
   /** Application webhooks are webhooks used with Interactions */
     ENUMERATOR_LAST(DISCORD_WEBHOOK_APPLICATION, = 3)
 ENUM_END
+#endif
 
 /** @CCORD_pub_struct{discord_webhook} */
+#if GENCODECS_RECIPE & (DATA | JSON)
 PUB_STRUCT(discord_webhook)
   /** the ID of the webhook */
     FIELD_SNOWFLAKE(id)
@@ -44,17 +47,21 @@ PUB_STRUCT(discord_webhook)
        OAuth2 flow */
     FIELD_PTR(url, char, *)
 STRUCT_END
+#endif
 
 /** @CCORD_pub_list{discord_webhooks} */
+#if GENCODECS_RECIPE & (DATA | JSON)
 PUB_LIST(discord_webhooks)
     LISTTYPE_STRUCT(discord_webhook)
 LIST_END
+#endif
 
 /*****************************************************************************
  * Webhook REST parameters
  * **************************************************************************/
 
 /** @CCORD_pub_struct{discord_create_webhook} */
+#if GENCODECS_RECIPE & (DATA | JSON)
 PUB_STRUCT(discord_create_webhook)
   /** name of the webhook (1-80 characters) */
     FIELD_PTR(name, char, *)
@@ -64,8 +71,10 @@ PUB_STRUCT(discord_create_webhook)
     FIELD_PTR(avatar, char, *)
   COND_END
 STRUCT_END
+#endif
 
 /** @CCORD_pub_struct{discord_modify_webhook} */
+#if GENCODECS_RECIPE & (DATA | JSON)
 PUB_STRUCT(discord_modify_webhook)
   /** the default name of the webhook */
     FIELD_PTR(name, char, *)
@@ -77,8 +86,10 @@ PUB_STRUCT(discord_modify_webhook)
   /** the new channel ID for this webhook should be moved to */
     FIELD_SNOWFLAKE(channel_id)
 STRUCT_END
+#endif
 
 /** @CCORD_pub_struct{discord_modify_webhook_with_token} */
+#if GENCODECS_RECIPE & (DATA | JSON)
 PUB_STRUCT(discord_modify_webhook_with_token)
   /** the default name of the webhook */
     FIELD_PTR(name, char, *)
@@ -88,11 +99,13 @@ PUB_STRUCT(discord_modify_webhook_with_token)
     FIELD_PTR(avatar, char, *)
   COND_END
 STRUCT_END
+#endif
 
 /** @CCORD_pub_struct{discord_execute_webhook} */
+#if GENCODECS_RECIPE & (DATA | JSON)
 PUB_STRUCT(discord_execute_webhook)
   /* QUERY FIELDS */
-#if !defined(GENCODECS_ON_JSON)
+#if !(GENCODECS_RECIPE & JSON)
   /** waits for server confirmation of message send before response, and
        returns the created message body (defaults to `false`; when `false` a
        message that is not saved does not return an error) */
@@ -101,7 +114,6 @@ PUB_STRUCT(discord_execute_webhook)
        thread will automatically be unarchived */
     FIELD_SNOWFLAKE(thread_id)
 #endif
-
   /* JSON FIELDS */
   /** the message contents (up to 2000 characters) */
     FIELD_PTR(content, char, *)
@@ -133,8 +145,9 @@ PUB_STRUCT(discord_execute_webhook)
     FIELD_BITMASK(flags)
   COND_END
 STRUCT_END
+#endif
 
-#if defined(GENCODECS_ON_STRUCT)
+#if GENCODECS_RECIPE == DATA
 STRUCT(discord_get_webhook_message)
   /** ID of the thread the message is in */
   COND_WRITE(self->thread_id != 0)
@@ -144,13 +157,13 @@ STRUCT_END
 #endif
 
 /** @CCORD_pub_struct{discord_edit_webhook_message} */
+#if GENCODECS_RECIPE & (DATA | JSON)
 PUB_STRUCT(discord_edit_webhook_message)
   /* QUERY FIELDS */
-#if !defined(GENCODECS_ON_JSON)
+#if !(GENCODECS_RECIPE & JSON)
   /** id of the thread the message is in */
     FIELD_SNOWFLAKE(thread_id)
 #endif
-
   /* JSON FIELDS */
   /** the message contents (up to 2000 characters) */
     FIELD_PTR(content, char, *)
@@ -171,8 +184,9 @@ PUB_STRUCT(discord_edit_webhook_message)
     FIELD_STRUCT_PTR(attachments, discord_attachments, *)
   COND_END
 STRUCT_END
+#endif
 
-#if defined(GENCODECS_ON_STRUCT)
+#if GENCODECS_RECIPE == DATA
 STRUCT(discord_delete_webhook_message)
   /** ID of the thread the message is in */
   COND_WRITE(self->thread_id != 0)

--- a/gencodecs/gencodecs-process.PRE.h
+++ b/gencodecs/gencodecs-process.PRE.h
@@ -1,21 +1,27 @@
 #ifndef GENCODECS_READ
-
-#   error "Missing GENCODECS_READ definition"
-
+#error "Missing GENCODECS_READ definition"
 #else
 
-#   define GENCODECS_ON_STRUCT
-#       include "recipes/struct.h"
-#   undef GENCODECS_ON_STRUCT
+#define DATA         (1 << 1)
+#define JSON_DECODER (1 << 2)
+#define JSON_ENCODER (1 << 3)
+#define JSON         (JSON_DECODER | JSON_ENCODER)
 
-#   define GENCODECS_ON_JSON
-#       define GENCODECS_ON_JSON_DECODER
-#           include "recipes/json-decoder.h"
-#       undef GENCODECS_ON_JSON_DECODER
+#define GENCODECS_RECIPE DATA
+#include "recipes/struct.h"
+#undef GENCODECS_RECIPE
 
-#       define GENCODECS_ON_JSON_ENCODER
-#           include "recipes/json-encoder.h"
-#       undef GENCODECS_ON_JSON_ENCODER
-#   undef GENCODECS_ON_JSON
+#define GENCODECS_RECIPE JSON_DECODER
+#include "recipes/json-decoder.h"
+#undef GENCODECS_RECIPE
+
+#define GENCODECS_RECIPE JSON_ENCODER
+#include "recipes/json-encoder.h"
+#undef GENCODECS_RECIPE
+
+#undef DATA
+#undef JSON_DECODER
+#undef JSON_ENCODER
+#undef JSON
 
 #endif /* GENCODECS_READ */


### PR DESCRIPTION
## What?
Improve readability of gencodecs

## Why?
As anything that relies exclusively on the C preprocessor, Gencodecs is a bit hard to follow, this PR aims to enforce some "rules" to the gencodecs syntax to make its comprehension easier

## How?
Add an env variable `GENCODECS_RECIPE` that keeps track of which generating recipe is currently being processed

## Testing?
Concord successfully generates its datatypes and compiles
