### PR TITLE
Use resume gateway url for session resuming

### DIFF
--- a/include/discord-internal.h
+++ b/include/discord-internal.h
@@ -656,6 +656,8 @@ struct discord_gateway_session {
     int shards;
     /** the session base url */
     char base_url[256];
+    /** the base url for resuming */
+    char resume_url[256];
     /** session limits */
     struct discord_session_start_limit start_limit;
     /** active concurrent sessions */


### PR DESCRIPTION
Discord will be using a different URL for resuming purposes, this commit
implements that

## What?
Use Discord `resume gateway url` for session resuming

## Why?
In the future it is expected this URL to be used for resuming session purposes

## How?
The URL is parsed and kept internally, and the client should attempt to reconnect to that URL if it wants to resume to the previous session.

## Testing?
The client has been shutdown without sending a WebSockets `CLOSE` opcode to Discord, and then managed to resume to the ongoing session.