### PR TITLE
Fixed build on MacOS

### DIFF
--- a/include/osname.h
+++ b/include/osname.h
@@ -237,7 +237,7 @@ enum OSClass {
 #endif
 
 #if defined __EDC_LE
-#if not defined __VM__ || not defined __MVS__
+#if !defined __VM__ || !defined __MVS__
 #define OSNAME "VSE"
 #define OSCLASS S370
 #endif
@@ -253,9 +253,9 @@ enum OSClass {
 #define OSCLASS OTHER
 #endif
 
-#if defined __MACH__  
-#if not defined __APPLE__
-#if not defined __osf__ || not defined __osf
+#if defined __MACH__
+#if !defined __APPLE__
+#if !defined __osf__ || !defined __osf
 #define OSNAME "NeXTSTEP"
 #define OSCLASS UNIX
 #endif


### PR DESCRIPTION
Fixed build on MacOS

## What?
In `include/osname.h`, it uses the keyword `not` present when `iso646.h` is included. This is not included in the file making the project unable to compile on MacOS. 

## Why?
Evaluate tangible code changes - explain the reason for the PR.
Fixes compile error

## How?
Explain the solution carried by the PR.
Changing `not` to `!` (in `iso646.h`, `not` is defined as `!`)

## Testing?
Explain how you tested your changes - let the reviewer know of any untested 
conditions or edge cases, why they weren't tested, and how likely they are to
occur, and if so, any associated risks.
The project compiles perfectly with my change

## Screenshots (optional)
Screenshots that may be helpful further demonstrating your PR.

## Anything Else? (optional)
Delve into possible architecture changes - call out challenges, optimizations,
etc. Use this as a opportunity to call out setbacks encountered because of the
current codebase.
