### PR TITLE
Reference-counter allows N claims to the same resource

### DIFF
--- a/include/discord-internal.h
+++ b/include/discord-internal.h
@@ -982,24 +982,30 @@ void discord_refcounter_cleanup(struct discord_refcounter *rc);
  * @see discord_refcounter_unclaim()
  *
  * After ownership is claimed `data` will no longer be cleaned automatically,
- *      instead shall be cleaned only when discord_refcounter_unclaim() is
- *      called
+ *      instead shall be cleaned only when the same amount of
+ *      discord_refcounter_unclaim() have been called
  * @param rc the handle initialized with discord_refcounter_init()
  * @param data the data to have its ownership claimed
- * @return `true` if `data` was found and claimed
+ * @retval CCORD_OK counter for `data` has been incremented
+ * @retval CCORD_UNAVAILABLE couldn't find a match to `data`
  */
-bool discord_refcounter_claim(struct discord_refcounter *rc, const void *data);
+CCORDcode discord_refcounter_claim(struct discord_refcounter *rc,
+                                   const void *data);
 
 /**
  * @brief Unclaim ownership of `data`
  * @see discord_refcounter_claim()
  *
- * This function will have `data` cleanup method be called immediately
+ * This will make the resource eligible for cleanup, so this should only be
+ *      called when you no longer plan to use it
  * @param rc the handle initialized with discord_refcounter_init()
  * @param data the data to have its ownership unclaimed
- * @return `true` if `data` was found, unclaimed, and free'd
+ * @retval CCORD_OK counter for `data` has been decremented
+ * @retval CCORD_UNAVAILABLE couldn't find a match to `data`
+ * @retval CCORD_OWNERSHIP `data` has never been discord_claim() 'd
  */
-bool discord_refcounter_unclaim(struct discord_refcounter *rc, void *data);
+CCORDcode discord_refcounter_unclaim(struct discord_refcounter *rc,
+                                     void *data);
 
 /**
  * @brief Increment the reference counter for `ret->data`
@@ -1009,8 +1015,6 @@ bool discord_refcounter_unclaim(struct discord_refcounter *rc, void *data);
  * @param data the data to have its reference counter incremented
  * @retval CCORD_OK counter for `data` has been incremented
  * @retval CCORD_UNAVAILABLE couldn't find a match to `data`
- * @retval CCORD_OWNERSHIP `data` has been claimed by client with
- * discord_claim()
  */
 CCORDcode discord_refcounter_incr(struct discord_refcounter *rc, void *data);
 
@@ -1024,8 +1028,7 @@ CCORDcode discord_refcounter_incr(struct discord_refcounter *rc, void *data);
  * @param data the data to have its reference counter decremented
  * @retval CCORD_OK counter for `data` has been decremented
  * @retval CCORD_UNAVAILABLE couldn't find a match to `data`
- * @retval CCORD_OWNERSHIP `data` has been claimed by client with
- * discord_claim()
+ * @retval CCORD_OWNERSHIP caught attempt to cleanup a claimed resource
  */
 CCORDcode discord_refcounter_decr(struct discord_refcounter *rc, void *data);
 

--- a/include/discord.h
+++ b/include/discord.h
@@ -158,24 +158,24 @@ const char *discord_strerror(CCORDcode code, struct discord *client);
 #include "discord-events.h"
 
 /**
- * @brief Claim ownership of a function parameter provided by Concord
+ * @brief Claim ownership of a resource provided by Concord
  * @see discord_unclaim()
  *
  * @param client the client initialized with discord_init()
- * @param param a function parameter provided by Concord
- * @return pointer to `param` (for one-liners)
+ * @param data a resource provided by Concord
+ * @return pointer to `data` (for one-liners)
  */
-#define discord_claim(client, param) (__discord_claim(client, param), param)
+#define discord_claim(client, data) (__discord_claim(client, data), data)
 void __discord_claim(struct discord *client, const void *data);
 
 /**
- * @brief Unclaim ownership of a function parameter provided by Concord
- * @note this will trigger the cleanup method of the parameter, so this should
+ * @brief Unclaim ownership of a resource provided by Concord
+ * @note this will make the resource eligible for cleanup, so this should
  *      only be called when you no longer plan to use it
  * @see discord_claim()
  *
  * @param client the client initialized with discord_init()
- * @param param a function parameter provided by Concord, that has been
+ * @param data a resource provided by Concord, that has been
  *      previously claimed with discord_claim()
  */
 void discord_unclaim(struct discord *client, const void *data);

--- a/src/discord-client.c
+++ b/src/discord-client.c
@@ -352,15 +352,18 @@ discord_config_get_field(struct discord *client,
 }
 
 void
-__discord_claim(struct discord *client, const void *param)
+__discord_claim(struct discord *client, const void *data)
 {
-    ASSERT_S(discord_refcounter_claim(&client->refcounter, (void *)param),
-             "Failed attempt to claim non-Concord function parameter");
+    CCORDcode code = discord_refcounter_claim(&client->refcounter, data);
+    VASSERT_S(code == CCORD_OK, "Failed attempt to claim resource (code %d)",
+              code);
 }
 
 void
-discord_unclaim(struct discord *client, const void *param)
+discord_unclaim(struct discord *client, const void *data)
 {
-    ASSERT_S(discord_refcounter_unclaim(&client->refcounter, (void *)param),
-             "Failed attempt to unclaim non-Concord function parameter");
+    CCORDcode code =
+        discord_refcounter_unclaim(&client->refcounter, (void *)data);
+    VASSERT_S(code == CCORD_OK, "Failed attempt to unclaim resource (code %d)",
+              code);
 }

--- a/src/discord-rest_request.c
+++ b/src/discord-rest_request.c
@@ -345,8 +345,6 @@ _discord_request_retry(struct discord_requestor *rqtor,
     return true;
 }
 
-/* parse request response and prepare callback that should be triggered
- * at _discord_rest_run_request_callback() */
 CCORDcode
 discord_requestor_info_read(struct discord_requestor *rqtor)
 {
@@ -591,8 +589,7 @@ discord_request_begin(struct discord_requestor *rqtor,
         code = discord_refcounter_incr(&client->refcounter,
                                        (void *)attr->dispatch.keep);
 
-        ASSERT_S(code == CCORD_OK,
-                 "'.keep' data must be a Concord callback parameter");
+        ASSERT_S(code == CCORD_OK, "'.keep' data must be a Concord resource");
     }
     if (attr->dispatch.data
         && CCORD_UNAVAILABLE


### PR DESCRIPTION
## What?
discord_claim() now allows multiple claims to the same resource (instead of a single one), so it only gets cleaned up after the same amount of discord_unclaim() has been called.

## Why?
Add this change to make caching easier to implement and not require cloning every resource it references.