### PR TITLE
Type inconsistency for bitmasks

### DIFF
--- a/gencodecs/api/channel.PRE.h
+++ b/gencodecs/api/channel.PRE.h
@@ -180,7 +180,7 @@ PUB_STRUCT(discord_channel)
   /** computed permissions for the invoking user in the channel, including
        overwrites, only included when part of the `resolved` data received
        on a application command interaction */
-    FIELD_PTR(permissions, char, *)
+    FIELD_BITMASK(permissions)
 STRUCT_END
 #endif
 
@@ -328,9 +328,9 @@ STRUCT(discord_overwrite)
   /** either 0 (role) or 1 (member) */
     FIELD(type, int, 0)
   /** @ref DiscordPermissions bit set */
-    FIELD_SNOWFLAKE(allow)
+    FIELD_BITMASK(allow)
   /** @ref DiscordPermissions bit set */
-    FIELD_SNOWFLAKE(deny)
+    FIELD_BITMASK(deny)
 STRUCT_END
 #endif
 
@@ -698,7 +698,7 @@ PUB_STRUCT(discord_modify_channel)
     FIELD(user_limit, int, 0)
   COND_END
   /** channel or category-specific permissions */
-  COND_WRITE(self->permission_overwrites != NULL)
+  COND_WRITE(self->permission_overwrites != 0)
     FIELD_STRUCT_PTR(permission_overwrites, discord_overwrites, *)
   COND_END
   /** ID of the new parent category for a channel */

--- a/gencodecs/api/custom.PRE.h
+++ b/gencodecs/api/custom.PRE.h
@@ -19,6 +19,13 @@ PUB_LIST(snowflakes)
 LIST_END
 #endif
 
+/** @CCORD_pub_list{bitmasks} */
+#if GENCODECS_RECIPE & (DATA | JSON)
+PUB_LIST(bitmasks)
+    LISTTYPE(u64bitmask)
+LIST_END
+#endif
+
 /** @CCORD_pub_list{integers} */
 #if GENCODECS_RECIPE & (DATA | JSON)
 PUB_LIST(integers)

--- a/gencodecs/api/guild.PRE.h
+++ b/gencodecs/api/guild.PRE.h
@@ -114,8 +114,8 @@ PUB_STRUCT(discord_guild)
   /** id of owner */
     FIELD_SNOWFLAKE(owner_id)
   /** total permissions for the user in the guild (excludes overwrites) */
-  COND_WRITE(self->permissions != NULL)
-    FIELD_PTR(permissions, char, *)
+  COND_WRITE(self->permissions != 0)
+    FIELD_BITMASK(permissions)
   COND_END
   /** id of afk channel */
     FIELD_SNOWFLAKE(afk_channel_id)
@@ -338,8 +338,8 @@ PUB_STRUCT(discord_guild_member)
     FIELD(pending, bool, false)
   /** total permission of the member in the channel, including overwrites,
        returned when in the interaction object */
-  COND_WRITE(self->permissions != NULL)
-    FIELD_PTR(permissions, char, *)
+  COND_WRITE(self->permissions != 0)
+    FIELD_BITMASK(permissions)
   COND_END
   /** when the user's timeout will expire and the user will be able to
        communicate in the guild again, null or a time in the past if the
@@ -757,7 +757,7 @@ PUB_STRUCT(discord_create_guild_role)
   /** name of the role */
     FIELD_PTR(name, char, *)
   /** `@everyone` permissions in guild */
-    FIELD_SNOWFLAKE(permissions)
+    FIELD_BITMASK(permissions)
   /** RGB color value */
     FIELD(color, int, 0)
   /** whether the role should be displayed separately in the sidebar */
@@ -796,7 +796,7 @@ PUB_STRUCT(discord_modify_guild_role)
   /** name of the role */
     FIELD_PTR(name, char, *)
   /** bitwise value of the enabled/disabled permissions */
-    FIELD_SNOWFLAKE(permissions)
+    FIELD_BITMASK(permissions)
   /** RGB color value */
     FIELD(color, int, 0)
   /** whether the role should be displayed separately in the sidebar */

--- a/gencodecs/api/teams.PRE.h
+++ b/gencodecs/api/teams.PRE.h
@@ -33,7 +33,7 @@ STRUCT(discord_team_member)
     FIELD_ENUM(membership_state, discord_membership_state)
   /** will always be \"[\"*\"]\" */
   COND_WRITE(self->permissions != NULL)
-    FIELD_STRUCT_PTR(permissions, strings, *)
+    FIELD_STRUCT_PTR(permissions, bitmasks, *)
   COND_END
   /** the ID of the parent team of which they are a member */
     FIELD_SNOWFLAKE(team_id)


### PR DESCRIPTION
## What?
Make every bitmask field a `u64bitmask`

## Why?
Some bitmask fields vary between being a string and a u64bitmask type, which makes it inconsistent to the user

## How?
Changes the `gencodecs` specs to replace each bitmask string with a u64bitmask

## Testing?
Simply compiling the codebase should be enough to tell if this change was successful

## Anything Else?
Although this is a small change, it's also a breaking change. Any existing bots using the string bitmasks will need to be updated.
