### PR TITLE
Fix ratelimiting 429 and bucket creation

### DIFF
--- a/include/discord-internal.h
+++ b/include/discord-internal.h
@@ -220,7 +220,7 @@ struct discord_ratelimiter {
     struct discord_bucket *miss;
 
     /* client-wide global ratelimiting */
-    u64unix_ms *global_wait_ms;
+    u64unix_ms *global_wait_tstamp;
 
     /** bucket queues */
     struct {
@@ -275,6 +275,18 @@ void discord_ratelimiter_build(struct discord_ratelimiter *rl,
                                const char key[],
                                struct ua_info *info);
 
+/**
+ * @brief Update global ratelimiting value
+ * @todo check if all pending buckets must be unset
+ *
+ * @param rl the handle initialized with discord_ratelimiter_init()
+ * @param bucket bucket that received the global ratelimiting notice
+ * @param wait_ms the amount of time that all buckets should wait for
+ */
+void discord_ratelimiter_set_global_timeout(struct discord_ratelimiter *rl,
+                                            struct discord_bucket *bucket,
+                                            u64unix_ms wait_ms);
+
 /** @brief The Discord bucket for handling per-group ratelimits */
 struct discord_bucket {
     /** the hash associated with the bucket's ratelimiting group */
@@ -302,14 +314,13 @@ struct discord_bucket {
 };
 
 /**
- * @brief Return bucket timeout timestamp
+ * @brief Set bucket timeout
  *
- * @param rl the handle initialized with discord_ratelimiter_init()
  * @param bucket the bucket to be checked for time out
- * @return the timeout timestamp
+ * @param wait_ms how long the bucket should wait for
  */
-u64unix_ms discord_bucket_get_timeout(struct discord_ratelimiter *rl,
-                                      struct discord_bucket *bucket);
+void discord_bucket_set_timeout(struct discord_bucket *bucket,
+                                u64unix_ms wait_ms);
 
 /**
  * @brief Get a `struct discord_bucket` assigned to `key`
@@ -1142,7 +1153,6 @@ bool discord_message_commands_try_perform(
 
 /**
  * @brief The Discord Cache control handler
- * 
  */
 struct discord_cache {
     struct _discord_cache_data *data;

--- a/include/discord-internal.h
+++ b/include/discord-internal.h
@@ -450,12 +450,8 @@ struct discord_request {
     char key[DISCORD_ROUTE_LEN];
     /** the connection handler assigned */
     struct ua_conn *conn;
-
     /** request's status code */
     CCORDcode code;
-    /** how long to wait for in case of request being ratelimited */
-    int64_t wait_ms;
-
     /** current retry attempt (stop at rest->retry_limit) */
     int retry_attempt;
     /** synchronize synchronous requests */

--- a/src/discord-rest_ratelimit.c
+++ b/src/discord-rest_ratelimit.c
@@ -58,6 +58,8 @@ discord_ratelimiter_build_key(enum http_method method,
     const char *curr = endpoint_fmt, *prev = "";
     size_t currlen = 0;
 
+    if (method == HTTP_MIMEPOST) method = HTTP_POST;
+
     KEY_PUSH(key, &keylen, "%d", method);
     do {
         u64snowflake id_arg = 0ULL;


### PR DESCRIPTION
Closes #83, closes #84

## What?
- Use the 429 `retry_after` value for freezing up the request's bucket
- `HTTP_POST` and `HTTP_MIMEPOST` being used in the same endpoint should generate the same bucket key

## Why?
- _discord_request_retry() would return true even if the request wasn't added back to the bucket's queue, resulting in a bucket freeze, making so consecutive requests of that bucket group never reach Discord
- They should be considered identical values when generating a bucket's key

## How?
- `bucket->busy_req` must be set to NULL once a 429 has been detected, and the failed request should be added back to the head of its queue. This will make it so that the next time the bucket is checked, it will trigger a timeout based on the `retry_after` value.

## Testing?
See #83 example code

