### PR TITLE
Timer Callback Refactor

### DIFF
--- a/examples/timers.c
+++ b/examples/timers.c
@@ -22,7 +22,7 @@ on_timer_tick(struct discord *client, struct discord_timer *timer)
 
     if (timer->repeat == 1) {
         puts("Canceling repeating timer.");
-        discord_timer_cancel(client, timer->id);
+        timer->flags |= DISCORD_TIMER_CANCELED;
     }
 }
 

--- a/examples/timers.c
+++ b/examples/timers.c
@@ -30,6 +30,12 @@ static void
 on_timer_status_changed(struct discord *client, struct discord_timer *timer)
 {
     print_timer_info(timer, "on_timer_status_changed");
+    if (timer->flags & DISCORD_TIMER_CANCELED) {
+        puts("TIMER CANCELED");
+    }
+    if (timer->flags & DISCORD_TIMER_DELETE) {
+        puts("TIMER DELETED - FREEING DATA");
+    }
 }
 
 static void
@@ -37,13 +43,17 @@ use_same_function(struct discord *client, struct discord_timer *timer)
 {
     print_timer_info(timer, "use_same_function");
     if (timer->flags & DISCORD_TIMER_TICK) {
-        puts("TICK");
+        puts("TIMER TICK");
     }
 
     if (timer->flags & DISCORD_TIMER_CANCELED) {
-        puts("CANCELED");
+        puts("TIMER CANCELED");
     }
-    free(timer->data);
+
+    if (timer->flags & DISCORD_TIMER_DELETE) {
+        puts("TIMER DELETED - FREEING DATA");
+        free(timer->data);
+    }
 }
 
 int
@@ -55,7 +65,8 @@ main(int argc, char *argv[])
 
     for (int i = 0; i < 10; i++)
         // one shot auto deleting timer
-        discord_timer(client, on_timer_tick, NULL, NULL, i * 1000);
+        discord_timer(client, on_timer_tick, on_timer_status_changed, NULL,
+                      i * 1000);
 
     // repeating auto deleting timer
     discord_timer_interval(client, on_timer_tick, on_timer_status_changed,

--- a/include/discord-internal.h
+++ b/include/discord-internal.h
@@ -162,13 +162,16 @@ unsigned discord_internal_timer_ctl(struct discord *client,
  *      completion
  *
  * @param client the client created with discord_init()
- * @param cb the callback that should be called when timer triggers
+ * @param on_tick_cb the callback that should be called when timer triggers
+ * @param on_status_changed_cb the callback for status updates, such as
+ * DISCORD_TIMER_CANCELED
  * @param data user data
  * @param delay delay before timer should start in milliseconds
  * @return the id of the timer
  */
 unsigned discord_internal_timer(struct discord *client,
-                                discord_ev_timer cb,
+                                discord_ev_timer on_tick_cb,
+                                discord_ev_timer on_status_changed_cb,
                                 void *data,
                                 int64_t delay);
 

--- a/include/discord-internal.h
+++ b/include/discord-internal.h
@@ -162,9 +162,10 @@ unsigned discord_internal_timer_ctl(struct discord *client,
  *      completion
  *
  * @param client the client created with discord_init()
- * @param on_tick_cb the callback that should be called when timer triggers
- * @param on_status_changed_cb the callback for status updates, such as
- * DISCORD_TIMER_CANCELED
+ * @param on_tick_cb (nullable) the callback that should be called when timer
+ * triggers
+ * @param on_status_changed_cb (nullable) the callback for status updates
+ * timer->flags will have: DISCORD_TIMER_CANCELED, and DISCORD_TIMER_DELETE
  * @param data user data
  * @param delay delay before timer should start in milliseconds
  * @return the id of the timer

--- a/include/discord.h
+++ b/include/discord.h
@@ -368,7 +368,8 @@ enum discord_timer_flags {
     DISCORD_TIMER_DELETE_AUTO = 1 << 2,
     /** timer has been canceled. user should cleanup only */
     DISCORD_TIMER_CANCELED = 1 << 3,
-
+    /** flag is set when on_tick callback has been called */
+    DISCORD_TIMER_TICK = 1 << 4,
     /** used in discord_timer_ctl to get the timer's data */
     DISCORD_TIMER_GET = 1 << 5,
     /** timer should run using a fixed interval based on start time */
@@ -382,7 +383,10 @@ struct discord_timer {
     /** the flags used to manipulate the timer */
     enum discord_timer_flags flags;
     /** the callback that should be called when timer triggers */
-    discord_ev_timer cb;
+    discord_ev_timer on_tick;
+    /** the callback that should be called when an event happens, such as
+     * DISCORD_TIMER_CANCELED*/
+    discord_ev_timer on_status_changed;
     /** user data */
     void *data;
     /** delay before timer should start */
@@ -408,13 +412,16 @@ unsigned discord_timer_ctl(struct discord *client,
  *        deletes itself upon completion
  *
  * @param client the client created with discord_init()
- * @param cb the callback that should be called when timer triggers
+ * @param on_tick_cb the callback that should be called when timer triggers
+ * @param on_status_changed_cb the callback for status updates, such as
+ * DISCORD_TIMER_CANCELED
  * @param data user data
  * @param delay delay before timer should start in milliseconds
  * @return the id of the timer
  */
 unsigned discord_timer(struct discord *client,
-                       discord_ev_timer cb,
+                       discord_ev_timer on_tick_cb,
+                       discord_ev_timer on_status_changed_cb,
                        void *data,
                        int64_t delay);
 
@@ -423,7 +430,9 @@ unsigned discord_timer(struct discord *client,
  *        deletes itself upon completion
  *
  * @param client the client created with discord_init()
- * @param cb the callback that should be called when timer triggers
+ * @param on_tick_cb the callback that should be called when timer triggers
+ * @param on_status_changed_cb the callback for status updates, such as
+ * DISCORD_TIMER_CANCELED
  * @param data user data
  * @param delay delay before timer should start in milliseconds
  * @param interval interval between runs. (-1 == disable repeat)
@@ -431,7 +440,8 @@ unsigned discord_timer(struct discord *client,
  * @return the id of the timer
  */
 unsigned discord_timer_interval(struct discord *client,
-                                discord_ev_timer cb,
+                                discord_ev_timer on_tick_cb,
+                                discord_ev_timer on_status_changed_cb,
                                 void *data,
                                 int64_t delay,
                                 int64_t interval,

--- a/include/discord.h
+++ b/include/discord.h
@@ -382,10 +382,10 @@ struct discord_timer {
     unsigned id;
     /** the flags used to manipulate the timer */
     enum discord_timer_flags flags;
-    /** the callback that should be called when timer triggers */
+    /** (nullable) the callback that should be called when timer triggers */
     discord_ev_timer on_tick;
-    /** the callback that should be called when an event happens, such as
-     * DISCORD_TIMER_CANCELED*/
+    /** (nullable) the callback for status updates timer->flags
+     * will have: DISCORD_TIMER_CANCELED, and DISCORD_TIMER_DELETE */
     discord_ev_timer on_status_changed;
     /** user data */
     void *data;
@@ -412,9 +412,10 @@ unsigned discord_timer_ctl(struct discord *client,
  *        deletes itself upon completion
  *
  * @param client the client created with discord_init()
- * @param on_tick_cb the callback that should be called when timer triggers
- * @param on_status_changed_cb the callback for status updates, such as
- * DISCORD_TIMER_CANCELED
+ * @param on_tick_cb (nullable) the callback that should be called when timer
+ * triggers
+ * @param on_status_changed_cb (nullable) the callback for status updates
+ * timer->flags will have: DISCORD_TIMER_CANCELED, and DISCORD_TIMER_DELETE
  * @param data user data
  * @param delay delay before timer should start in milliseconds
  * @return the id of the timer
@@ -430,9 +431,10 @@ unsigned discord_timer(struct discord *client,
  *        deletes itself upon completion
  *
  * @param client the client created with discord_init()
- * @param on_tick_cb the callback that should be called when timer triggers
- * @param on_status_changed_cb the callback for status updates, such as
- * DISCORD_TIMER_CANCELED
+ * @param on_tick_cb (nullable) the callback that should be called when timer
+ * triggers
+ * @param on_status_changed_cb (nullable) the callback for status updates
+ * timer->flags will have: DISCORD_TIMER_CANCELED, and DISCORD_TIMER_DELETE
  * @param data user data
  * @param delay delay before timer should start in milliseconds
  * @param interval interval between runs. (-1 == disable repeat)

--- a/src/discord-gateway_dispatch.c
+++ b/src/discord-gateway_dispatch.c
@@ -230,21 +230,18 @@ _discord_on_heartbeat_timeout(struct discord *client,
     (void)client;
     struct discord_gateway *gw = timer->data;
 
-    if (~timer->flags & DISCORD_TIMER_CANCELED) {
-        if (CCORD_OK == discord_gateway_perform(gw)
-            && ~gw->session->status & DISCORD_SESSION_SHUTDOWN
-            && gw->session->is_ready)
-        {
-            discord_gateway_send_heartbeat(gw, gw->payload.seq);
-        }
-        const u64unix_ms next_hb =
-            gw->timer->hbeat_last + (u64unix_ms)gw->timer->hbeat_interval;
-
-        timer->interval =
-            (int64_t)(next_hb) - (int64_t)discord_timestamp(client);
-        if (timer->interval < 1) timer->interval = 1;
-        timer->repeat = 1;
+    if (CCORD_OK == discord_gateway_perform(gw)
+        && ~gw->session->status & DISCORD_SESSION_SHUTDOWN
+        && gw->session->is_ready)
+    {
+        discord_gateway_send_heartbeat(gw, gw->payload.seq);
     }
+    const u64unix_ms next_hb =
+        gw->timer->hbeat_last + (u64unix_ms)gw->timer->hbeat_interval;
+
+    timer->interval = (int64_t)(next_hb) - (int64_t)discord_timestamp(client);
+    if (timer->interval < 1) timer->interval = 1;
+    timer->repeat = 1;
 }
 
 /* send heartbeat pulse to websockets server in order
@@ -279,7 +276,7 @@ discord_gateway_send_heartbeat(struct discord_gateway *gw, int seq)
         gw->timer->hbeat_last = gw->timer->now;
         if (!gw->timer->hbeat_timer)
             gw->timer->hbeat_timer = discord_internal_timer(
-                CLIENT(gw, gw), _discord_on_heartbeat_timeout, gw,
+                CLIENT(gw, gw), _discord_on_heartbeat_timeout, NULL, gw,
                 gw->timer->hbeat_interval);
     }
     else {

--- a/src/discord-loop.c
+++ b/src/discord-loop.c
@@ -8,7 +8,8 @@
 static void
 discord_wake_timer_cb(struct discord *client, struct discord_timer *timer)
 {
-    if (~timer->flags & DISCORD_TIMER_CANCELED && client->wakeup_timer.cb)
+    (void)timer;
+    if (client->wakeup_timer.cb)
         client->wakeup_timer.cb(client);
 }
 
@@ -18,7 +19,7 @@ discord_set_next_wakeup(struct discord *client, int64_t delay)
     unsigned id =
         discord_internal_timer_ctl(client, &(struct discord_timer){
                                                .id = client->wakeup_timer.id,
-                                               .cb = discord_wake_timer_cb,
+                                               .on_tick = discord_wake_timer_cb,
                                                .delay = delay,
                                            });
     client->wakeup_timer.id = id;
@@ -32,7 +33,7 @@ discord_set_on_wakeup(struct discord *client,
     if (client->wakeup_timer.id) {
         discord_internal_timer_ctl(client, &(struct discord_timer){
                                                .id = client->wakeup_timer.id,
-                                               .cb = discord_wake_timer_cb,
+                                               .on_tick = discord_wake_timer_cb,
                                                .delay = -1,
                                            });
     }

--- a/src/discord-rest_ratelimit.c
+++ b/src/discord-rest_ratelimit.c
@@ -218,7 +218,7 @@ _discord_bucket_try_timeout(struct discord_ratelimiter *rl,
 
     _discord_timer_ctl(client, &client->rest.timers,
                        &(struct discord_timer){
-                           .cb = &_discord_bucket_wake_cb,
+                           .on_tick = &_discord_bucket_wake_cb,
                            .data = b,
                            .delay = delay_ms,
                            .flags = DISCORD_TIMER_DELETE_AUTO,


### PR DESCRIPTION
## What?
- Added DISCORD_TIMER_TICK flag for on_tick callback
- Replaced single callback with 2 separate callbacks(on_tick, and on_status_changed)
when a timer is run, `on_tick` will be called with the flag `DISCORD_TIMER_TICK` set
when a timer is deleted, `on_status_changed` will be called with the flag `DISCORD_TIMER_DELETE` set
when a timer is canceled, `on_status_changed` will be called with the flag `DISCORD_TIMER_CANCELED` set
- Updated timer example

Before:
```c
static void
on_timer_tick(struct discord *client, struct discord_timer *timer) {
  if (!(timer->flags & DISCORD_TIMER_CANCELED)) {
    // do something
  }
  // clean up resources
}

discord_timer(client, on_timer_tick, NULL, 0);
```
Now:
```c
static void
on_timer_tick(struct discord *client, struct discord_timer *timer) {
  // do something
  // or, optionally if (timer->flags & DISCORD_TIMER_TICK) 
}

static void
on_timer_status_changed(struct discord *client, struct discord_timer *timer) {
  if (timer->flags & DISCORD_TIMER_CANCELED) {
    // ...
  }
  if (timer->flags & DISCORD_TIMER_DELETED) {
    // clean up resources
  }
}

discord_timer(client, on_timer_tick, on_timer_status_changed, NULL, 0);

// both callbacks are nullable, so this is valid - it will wake up and no callback will be called
discord_timer(client, NULL, NULL, NULL, 0);
```

## Why?
The current method is confusing to users. As of right now, you MUST check if a timer is canceled inside the callback, but this change would eliminate that by only using the on_tick callback for timer ticks, and using the on_status_changed callback for everything else.

## Testing?
Tested using the example file that has been updated
