### PR TITLE
Reserve positive integer values of CCORDcode for change of states

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -263,7 +263,7 @@ TAB_SIZE               = 4
 
 ALIASES += "CCORD_ret{1}=@param \1 return context of the request. if successful the assigned `done` will be triggered @see @ref discord_ret for more options^^" \
            "CCORD_ret_obj{2}=@param \1 return context of the request. if successful a @ref discord_\2 will be sent over to its assigned `done` callback @see @ref discord_ret_\2 for more options^^" \
-           "CCORD_return=@return @ref CCORDcode for how the operation went, @ref CCORD_OK means nothing out of the ordinary^^" \
+           "CCORD_return=@return @ref CCORDcode value for how the operation went:^^  - `0` means nothing out of the ordinary^^  - `greater than zero` means a change of state^^  - `lesser than zero` means an error has occurred^^" \
            "CCORD_pub_struct{1}=**Public methods**^^^^  - Initializer:^^^^    - `\1_init(struct \1 *this)`^^  - Cleanup:^^^^    - `\1_cleanup(struct \1 *this)`^^  - JSON Decoder:^^^^    - `\1_from_json(const char json[], size_t len, struct \1 *this)`^^    - `\1_from_jsmnf(jsmnf *root, const char json[], struct \1 *this)`^^  - JSON Encoder:^^^^    - `\1_to_json(char buf[], size_t size, const struct \1 *this)`^^    - `\1_to_jsonb(jsonb *b, char buf[], size_t size, const struct \1 *this)`" \
            "CCORD_pub_list{1}=**Public methods**^^^^  - Cleanup:^^^^    - `\1_cleanup(struct \1 *this)`^^  - JSON Decoder:^^^^    - `\1_from_json(const char json[], size_t len, struct \1 *this)`^^    - `\1_from_jsmnf(jsmnf *root, const char json[], struct \1 *this)`^^  - JSON Encoder:^^^^    - `\1_to_json(char buf[], size_t size, const struct \1 *this)`^^    - `\1_to_jsonb(jsonb *b, char buf[], size_t size, const struct \1 *this)`"
 

--- a/core/error.h
+++ b/core/error.h
@@ -7,33 +7,45 @@
  *  @brief Concord error codes and meaning
  *  @{ */
 
-/** the error code datatype */
-typedef int CCORDcode;
-
-/** action was a success */
-#define CCORD_OK 0
-/** request wasn't succesful */
-#define CCORD_HTTP_CODE -1
-/** no response came through from curl */
-#define CCORD_CURL_NO_RESPONSE -2
-/** received a non-standard http code */
-#define CCORD_UNUSUAL_HTTP_CODE -3
-/** bad value for parameter */
-#define CCORD_BAD_PARAMETER -4
-/** internal failure when encoding or decoding JSON */
-#define CCORD_BAD_JSON -5
-/** curl's easy handle internal error */
-#define CCORD_CURLE_INTERNAL -6
-/** curl's multi handle internal error */
-#define CCORD_CURLM_INTERNAL -7
-/** attempt to initialize globals more than once */
-#define CCORD_GLOBAL_INIT -8
-/** couldn't perform action because of resource's ownership issues */
-#define CCORD_OWNERSHIP -9
-/** couldn't perform action because resource is unavailable */
-#define CCORD_UNAVAILABLE -10
-/** couldn't enqueue worker thread (queue is full) */
-#define CCORD_FULL_WORKER -11
+typedef enum CCORDcode {
+    /** couldn't enqueue worker thread (queue is full) */
+    CCORD_FULL_WORKER = -11,
+    /** couldn't perform action because resource is unavailable */
+    CCORD_UNAVAILABLE = -10,
+    /** couldn't perform action because of resource's ownership issues */
+    CCORD_OWNERSHIP = -9,
+    /** attempt to initialize globals more than once */
+    CCORD_GLOBAL_INIT = -8,
+    /** curl's multi handle internal error */
+    CCORD_CURLM_INTERNAL = -7,
+    /** curl's easy handle internal error */
+    CCORD_CURLE_INTERNAL = -6,
+    /** internal failure when encoding or decoding JSON */
+    CCORD_BAD_JSON = -5,
+    /** bad value for parameter */
+    CCORD_BAD_PARAMETER = -4,
+    /** received a non-standard http code */
+    CCORD_UNUSUAL_HTTP_CODE = -3,
+    /** no response came through from curl */
+    CCORD_CURL_NO_RESPONSE = -2,
+    /** request wasn't succesful */
+    CCORD_HTTP_CODE = -1,
+    /** action was a success */
+    CCORD_OK = 0,
+    /**
+     * action is pending (ex: request has been enqueued and will be performed
+     *      later)
+     */
+    CCORD_PENDING,
+    /** received a JSON error message */
+    CCORD_DISCORD_JSON_CODE = 100,
+    /** bad authentication token */
+    CCORD_DISCORD_BAD_AUTH,
+    /** being ratelimited */
+    CCORD_DISCORD_RATELIMIT,
+    /** couldn't establish connection to Discord */
+    CCORD_DISCORD_CONNECTION,
+} CCORDcode;
 
 /** @} ConcordError */
 

--- a/include/discord.h
+++ b/include/discord.h
@@ -88,15 +88,6 @@ struct discord;
 /** @addtogroup ConcordError
  *  @{ */
 
-/** Received a JSON error message */
-#define CCORD_DISCORD_JSON_CODE 1
-/** Bad authentication token */
-#define CCORD_DISCORD_BAD_AUTH 2
-/** Being ratelimited */
-#define CCORD_DISCORD_RATELIMIT 3
-/** Couldn't establish connection to Discord */
-#define CCORD_DISCORD_CONNECTION 4
-
 /**
  * @brief Return a Concord's error
  * @note used to log and return an error


### PR DESCRIPTION
## What?
- Add positive integer CCORDcode reserved for change of states
- Update `@CCORD_return` Doxygen alias with new description

## Why?
Sometimes, when dealing with asynchronous operations it is too early to tell whether it was successful or not. The positive integers may so be used for signaling a change of state, and that an operation is underway.

## How?
For now, added `CCORD_PENDING`, which is returned for asynchronous requests that have just been enqueued.

## Testing?
Example bots work just fine, as this was a simple swap of returned values.
