### PR TITLE
Caching Interface

### DIFF
--- a/core/anomap.c
+++ b/core/anomap.c
@@ -51,8 +51,13 @@ anomap_length(struct anomap *map) {
   return map->map.len;
 }
 
-static bool
-_anomap_find(struct anomap *map, void *key, size_t *position) {
+void anomap_clear(struct anomap *map) {
+  map->map.len = 0;
+  map->map.highest = 0;
+}
+
+bool
+anomap_index_of(struct anomap *map, void *key, size_t *position) {
   size_t lo = 0, mid, hi = map->map.len;
   while (lo < hi) {
     mid = (lo + hi) / 2;
@@ -62,14 +67,6 @@ _anomap_find(struct anomap *map, void *key, size_t *position) {
     else hi = mid;
   }
   return *position = lo, false;
-}
-
-bool
-anomap_index_of(struct anomap *map, size_t *index, void *key) {
-  size_t mpos = 0;
-  if (!_anomap_find(map, key, &mpos))
-    return false;
-  return *index = mpos, true;
 }
 
 bool
@@ -115,7 +112,7 @@ anomap_do(struct anomap *map, enum anomap_operation operation,
 {
   enum anomap_operation result = 0;
   size_t mpos = 0;
-  if (!_anomap_find(map, key, &mpos)) {
+  if (!anomap_index_of(map, key, &mpos)) {
     if (~operation & anomap_insert)
       return 0;
     if (!_anomap_ensure_capacity(map, map->map.len + 1))
@@ -177,4 +174,42 @@ anomap_do(struct anomap *map, enum anomap_operation operation,
     map->map.arr[map->map.len] = pos;
   }
   return result;
+}
+
+bool
+anomap_copy_range(struct anomap *map, size_t index, size_t count,
+                  void *keys, void *vals)
+{
+  if (index + count > map->map.len) return false;
+  if (keys || vals) {
+    for (size_t i = 0; i < count; i++, index++) {
+      if (keys) memcpy(((char *)keys) + map->keys.size * i,
+                        map->keys.arr + map->keys.size * map->map.arr[index],
+                        map->keys.size);
+      if (vals) memcpy(((char *)vals) + map->vals.size * i,
+                        map->vals.arr + map->vals.size * map->map.arr[index],
+                        map->vals.size);
+    }
+  }
+  return true;
+}
+
+bool
+anomap_delete_range(struct anomap *map, size_t index, size_t count,
+                    void *keys, void *vals)
+{
+  if (!anomap_copy_range(map, index, count, keys, vals))
+    return false;
+  while (count) {
+    unsigned tmp[4096];
+    size_t block = count > 4096 ? 4096 : count;
+    size_t copy_size = block * sizeof *map->map.arr;
+    memcpy(tmp, map->map.arr + index, copy_size);
+    memmove(map->map.arr + index, map->map.arr + index + block, (
+            map->map.len - index - block) * sizeof *map->map.arr);
+    map->map.len -= block;
+    memcpy(map->map.arr + map->map.len, tmp, copy_size);
+    count -= block;
+  }
+  return true;
 }

--- a/core/anomap.h
+++ b/core/anomap.h
@@ -22,17 +22,21 @@ struct anomap;
 
 struct anomap *anomap_create(size_t key_size, size_t val_size,
                              int (*cmp)(const void *, const void *));
-
 void anomap_destroy(struct anomap *map);
 
 size_t anomap_length(struct anomap *map);
+void anomap_clear(struct anomap *map);
 
-bool anomap_index_of(struct anomap *map, size_t *index, void *key);
-
+bool anomap_index_of(struct anomap *map, void *key, size_t *index);
 bool anomap_at_index(struct anomap *map, size_t index, void *key, void *val);
 
 enum anomap_operation anomap_do(struct anomap *map,
                                 enum anomap_operation operation,
                                 void *key, void *val);
+
+bool anomap_copy_range(struct anomap *map, size_t index, size_t count,
+                       void *keys, void *vals);
+bool anomap_delete_range(struct anomap *map, size_t index, size_t count,
+                         void *keys, void *vals);
 
 #endif // !ANOMAP_H

--- a/core/anomap.h
+++ b/core/anomap.h
@@ -34,9 +34,11 @@ enum anomap_operation anomap_do(struct anomap *map,
                                 enum anomap_operation operation,
                                 void *key, void *val);
 
-bool anomap_copy_range(struct anomap *map, size_t index, size_t count,
-                       void *keys, void *vals);
-bool anomap_delete_range(struct anomap *map, size_t index, size_t count,
+size_t anomap_copy_range(struct anomap *map,
+                         size_t from_index, size_t to_index,
                          void *keys, void *vals);
+size_t anomap_delete_range(struct anomap *map,
+                           size_t from_index, size_t to_index,
+                           void *keys, void *vals);
 
 #endif // !ANOMAP_H

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -9,6 +9,7 @@ GENCODECS_DIR = $(TOP)/gencodecs
 STD_BOTS   = 8ball \
              audit-log \
              ban \
+             cache \
              channel \
              components \
              copycat \

--- a/examples/cache.c
+++ b/examples/cache.c
@@ -1,0 +1,51 @@
+
+#include "discord.h"
+
+static void
+on_message(struct discord *client, const struct discord_message *message)
+{
+    if (message->author->bot) return;
+
+    const struct discord_guild *guild =
+        discord_cache_get_guild(client, message->guild_id);
+    if (guild) {
+        printf("message received in guild '%s'\n", guild->name);
+        discord_unclaim(client, guild);
+    }
+
+    // check if this message is in the cache, NULL if it isn't
+    const struct discord_message *cached_message =
+        discord_cache_get_channel_message(client, message->channel_id,
+                                          message->id);
+
+    if (cached_message) {
+        // discord_claim(cached_message); is implicit
+        discord_create_message(client, cached_message->channel_id,
+                               &(struct discord_create_message){
+                                   .content = cached_message->content,
+                               },
+                               NULL);
+
+        // don't forget to clean up cached message when done
+        discord_unclaim(client, cached_message);
+    }
+}
+
+int
+main(int argc, char *argv[])
+{
+    const char *const config_file = argc > 1 ? argv[1] : "../config.json";
+    ccord_global_init();
+    struct discord *client = discord_config_init(config_file);
+
+    // enable message caching
+    discord_cache_enable(client,
+                         DISCORD_CACHE_MESSAGES | DISCORD_CACHE_GUILDS);
+
+    discord_add_intents(client, DISCORD_GATEWAY_MESSAGE_CONTENT);
+    discord_set_on_message_create(client, on_message);
+
+    discord_run(client);
+    discord_cleanup(client);
+    ccord_global_cleanup();
+}

--- a/include/discord-cache.h
+++ b/include/discord-cache.h
@@ -1,0 +1,35 @@
+#ifndef DISCORD_CACHE_H
+#define DISCORD_CACHE_H
+
+enum discord_cache_options {
+    DISCORD_CACHE_MESSAGES = 1 << 0,
+    DISCORD_CACHE_GUILDS = 1 << 1,
+};
+
+void discord_cache_enable(struct discord *client,
+                          enum discord_cache_options options);
+
+/**
+ * @brief get a message from cache, only if locally available in RAM
+ * @note you must call discord_unclaim(client, message) when done
+ * 
+ * @param client the client initialized with discord_init()
+ * @param channel_id the channel id the message is in
+ * @param message_id the id of the message
+ * @return NULL if not found, or the message from the cache
+ */
+const struct discord_message *discord_cache_get_channel_message(
+    struct discord *client, u64snowflake channel_id, u64snowflake message_id);
+
+/**
+ * @brief get a guild from cache, only if locally available in RAM
+ * @note you must call discord_unclaim(client, guild) when done
+ * 
+ * @param client the client initialized with discord_init()
+ * @param guild_id the id of the guild
+ * @return NULL if not found, or the guild from the cache
+ */
+const struct discord_guild *discord_cache_get_guild(
+    struct discord *client, u64snowflake guild_id);
+
+#endif // !DISCORD_CACHE_H

--- a/include/discord-internal.h
+++ b/include/discord-internal.h
@@ -777,10 +777,11 @@ struct discord_gateway {
     struct discord_gateway_payload payload;
     /**
      * the user's callbacks for Discord events
+     * @note index 0 for cache callbacks, index 1 for user callbacks
      * @todo should be cast to the original callback signature before calling,
      *      otherwise its UB
      */
-    discord_ev_event cbs[DISCORD_EV_MAX];
+    discord_ev_event cbs[2][DISCORD_EV_MAX];
     /** the event scheduler callback */
     discord_ev_scheduler scheduler;
 };
@@ -1135,6 +1136,17 @@ bool discord_message_commands_try_perform(
 
 /** @} DiscordInternalMessageCommands */
 
+/** @defgroup DiscordInternalCache Cache API
+ * @brief The Cache API for storage and retrieval of Discord data
+ *  @{ */
+
+struct discord_cache {
+    struct _discord_cache_data *data;
+    void (*cleanup)(struct discord *client);
+};
+
+/** @} DiscordInternalCache */
+
 /**
  * @brief The Discord client handler
  *
@@ -1162,6 +1174,8 @@ struct discord {
     struct discord_gateway gw;
     /** the client's user structure */
     struct discord_user self;
+    /** the handle for registering and retrieving Discord data */
+    struct discord_cache cache;
 
     struct {
         struct discord_timers internal;

--- a/include/discord-internal.h
+++ b/include/discord-internal.h
@@ -1140,9 +1140,24 @@ bool discord_message_commands_try_perform(
  * @brief The Cache API for storage and retrieval of Discord data
  *  @{ */
 
+/**
+ * @brief The Discord Cache control handler
+ * 
+ */
 struct discord_cache {
     struct _discord_cache_data *data;
     void (*cleanup)(struct discord *client);
+
+    /** gateway should call this when a shard has lost connection */
+    void (*on_shard_disconnected)(struct discord *client,
+                                  const struct discord_identify *ident,
+                                  bool resumable);
+    /** gateway should call this when a shard has resumed */
+    void (*on_shard_resumed)(struct discord *client,
+                             const struct discord_identify *ident);
+    /** gateway should call this when a shard has reconnected */
+    void (*on_shard_reconnected)(struct discord *client,
+                                 const struct discord_identify *ident);
 };
 
 /** @} DiscordInternalCache */

--- a/include/discord.h
+++ b/include/discord.h
@@ -302,6 +302,14 @@ void *discord_set_data(struct discord *client, void *data);
  */
 void *discord_get_data(struct discord *client);
 
+
+enum discord_cache_options {
+    DISCORD_CACHE_GUILDS = 1,
+};
+
+void discord_enable_cache(struct discord *client,
+                          enum discord_cache_options options);
+
 /**
  * @brief Get the client WebSockets ping
  * @note Only works after a connection has been established via discord_run()

--- a/include/discord.h
+++ b/include/discord.h
@@ -155,6 +155,7 @@ const char *discord_strerror(CCORDcode code, struct discord *client);
 
 /** @struct discord */
 
+#include "discord-cache.h"
 #include "discord-events.h"
 
 /**
@@ -302,17 +303,10 @@ void *discord_set_data(struct discord *client, void *data);
  */
 void *discord_get_data(struct discord *client);
 
-
-enum discord_cache_options {
-    DISCORD_CACHE_GUILDS = 1,
-};
-
-void discord_enable_cache(struct discord *client,
-                          enum discord_cache_options options);
-
 /**
  * @brief Get the client WebSockets ping
- * @note Only works after a connection has been established via discord_run()
+ * @note Only works after a connection has been established via
+ * discord_run()
  *
  * @param client the client created with discord_init()
  * @return the ping in milliseconds

--- a/src/Makefile
+++ b/src/Makefile
@@ -30,6 +30,7 @@ OBJS += concord-once.o             \
         discord-rest_ratelimit.o   \
         discord-client.o           \
         discord-events.o           \
+        discord-cache.o            \
         discord-loop.o             \
         discord-gateway.o          \
         discord-gateway_dispatch.o \

--- a/src/discord-cache.c
+++ b/src/discord-cache.c
@@ -1,0 +1,72 @@
+#include "discord.h"
+#include "discord-internal.h"
+#include "chash.h"
+
+struct _discord_cache_data {
+    enum discord_cache_options options;
+};
+
+#define EV_CB(name, data)                                                     \
+    static void _on_##name(struct discord *client, const struct data *ev)
+
+EV_CB(guild_create, discord_guild)
+{
+    struct _discord_cache_data *data = client->cache.data;
+}
+
+EV_CB(guild_update, discord_guild) {}
+EV_CB(guild_delete, discord_guild) {}
+
+EV_CB(channel_create, discord_channel) {}
+EV_CB(channel_update, discord_channel) {}
+EV_CB(channel_delete, discord_channel) {}
+
+EV_CB(guild_role_create, discord_guild_role_create) {}
+EV_CB(guild_role_update, discord_guild_role_update) {}
+EV_CB(guild_role_delete, discord_guild_role_delete) {}
+
+EV_CB(message_create, discord_message) {}
+EV_CB(message_update, discord_message) {}
+EV_CB(message_delete, discord_message_delete) {}
+
+#define ASSIGN_CB(ev, cb) client->gw.cbs[0][ev] = (discord_ev_event)_on_##cb
+
+static void
+_discord_cache_cleanup(struct discord *client)
+{
+}
+
+void
+discord_enable_cache(struct discord *client,
+                     enum discord_cache_options options)
+{
+    struct _discord_cache_data *data;
+    if (client->cache.data)
+        data = client->cache.data;
+    else {
+        client->cache.cleanup = _discord_cache_cleanup;
+        data = client->cache.data = calloc(1, sizeof *data);
+    }
+    data->options |= options;
+
+    if (options & DISCORD_CACHE_GUILDS) {
+        discord_add_intents(client, DISCORD_GATEWAY_GUILDS);
+        ASSIGN_CB(DISCORD_EV_GUILD_CREATE, guild_create);
+        ASSIGN_CB(DISCORD_EV_GUILD_UPDATE, guild_update);
+        ASSIGN_CB(DISCORD_EV_GUILD_DELETE, guild_delete);
+
+        ASSIGN_CB(DISCORD_EV_CHANNEL_CREATE, channel_create);
+        ASSIGN_CB(DISCORD_EV_CHANNEL_UPDATE, channel_update);
+        ASSIGN_CB(DISCORD_EV_CHANNEL_DELETE, channel_delete);
+
+        ASSIGN_CB(DISCORD_EV_GUILD_ROLE_CREATE, guild_role_create);
+        ASSIGN_CB(DISCORD_EV_GUILD_ROLE_UPDATE, guild_role_update);
+        ASSIGN_CB(DISCORD_EV_GUILD_ROLE_DELETE, guild_role_delete);
+    }
+
+    if (0) {
+        ASSIGN_CB(DISCORD_EV_MESSAGE_CREATE, message_create);
+        ASSIGN_CB(DISCORD_EV_MESSAGE_UPDATE, message_update);
+        ASSIGN_CB(DISCORD_EV_MESSAGE_DELETE, message_delete);
+    }
+}

--- a/src/discord-cache.c
+++ b/src/discord-cache.c
@@ -215,7 +215,7 @@ _on_garbage_collection(struct discord *client, struct discord_timer *timer)
             while (index > 0) {
                 struct discord_message *vals[0x1000];
                 const size_t delete_count = index > 0x1000 ? 0x1000 : index;
-                anomap_delete_range(cache->msg_map, 0, delete_count, NULL,
+                anomap_delete_range(cache->msg_map, 0, delete_count - 1, NULL,
                                     vals);
                 index -= delete_count;
                 for (size_t j = 0; j < delete_count; j++)

--- a/src/discord-cache.c
+++ b/src/discord-cache.c
@@ -1,53 +1,286 @@
+#include <pthread.h>
+#include <string.h>
+
 #include "discord.h"
 #include "discord-internal.h"
-#include "chash.h"
+#include "anomap.h"
+
+#define DISCORD_EPOCH 1420070400000
+
+static int
+cmp_sf(const void *a, const void *b)
+{
+    if (*(u64snowflake *)a == *(u64snowflake *)b) return 0;
+    return *(u64snowflake *)a > *(u64snowflake *)b ? 1 : -1;
+}
+
+static int
+_calculate_shard(u64snowflake guild_id, int total_shards)
+{
+    return (int)((guild_id >> 22) % (unsigned)total_shards);
+}
+
+struct _discord_shard_cache {
+    pthread_mutex_t lock;
+    bool valid;
+    struct anomap *guild_map;
+    struct anomap *msg_map;
+};
 
 struct _discord_cache_data {
     enum discord_cache_options options;
+    struct _discord_shard_cache *caches;
+    int total_shards;
+    unsigned garbage_collection_timer;
 };
+
+static void
+_discord_shard_cache_cleanup(struct discord *client,
+                             struct _discord_shard_cache *cache)
+{
+    pthread_mutex_lock(&cache->lock);
+    for (size_t i = 0; i < anomap_length(cache->guild_map); i++) {
+        struct discord_guild *guild;
+        anomap_at_index(cache->guild_map, i, NULL, &guild);
+        discord_refcounter_decr(&client->refcounter, guild);
+    }
+    for (size_t i = 0; i < anomap_length(cache->msg_map); i++) {
+        struct discord_message *message;
+        anomap_at_index(cache->msg_map, i, NULL, &message);
+        discord_refcounter_decr(&client->refcounter, message);
+    }
+    anomap_clear(cache->guild_map);
+    anomap_clear(cache->msg_map);
+    pthread_mutex_unlock(&cache->lock);
+}
 
 #define EV_CB(name, data)                                                     \
     static void _on_##name(struct discord *client, const struct data *ev)
 
-EV_CB(guild_create, discord_guild)
+#define CACHE_BEGIN(DATA, CACHE, SHARD, GUILD_ID)                             \
+    struct _discord_cache_data *const DATA = client->cache.data;              \
+    const int SHARD = _calculate_shard(GUILD_ID, DATA->total_shards);         \
+    struct _discord_shard_cache *const cache = &data->caches[SHARD];          \
+    pthread_mutex_lock(&CACHE->lock)
+
+#define CACHE_END(CACHE) pthread_mutex_unlock(&CACHE->lock)
+
+EV_CB(ready, discord_ready)
 {
+    int shard = ev->shard ? ev->shard->array[0] : 0;
     struct _discord_cache_data *data = client->cache.data;
+    struct _discord_shard_cache *cache = &data->caches[shard];
+    pthread_mutex_lock(&cache->lock);
+    cache->valid = true;
+    pthread_mutex_unlock(&cache->lock);
 }
 
-EV_CB(guild_update, discord_guild) {}
-EV_CB(guild_delete, discord_guild) {}
+static void
+_on_shard_resumed(struct discord *client, const struct discord_identify *ev)
+{
+    int shard = ev->shard ? ev->shard->array[0] : 0;
+    struct _discord_cache_data *data = client->cache.data;
+    struct _discord_shard_cache *cache = &data->caches[shard];
+    pthread_mutex_lock(&cache->lock);
+    cache->valid = true;
+    pthread_mutex_unlock(&cache->lock);
+}
 
-EV_CB(channel_create, discord_channel) {}
-EV_CB(channel_update, discord_channel) {}
-EV_CB(channel_delete, discord_channel) {}
+static void
+_on_shard_reconnected(struct discord *client,
+                      const struct discord_identify *ev)
+{
+    int shard = ev->shard ? ev->shard->array[0] : 0;
+    struct _discord_cache_data *data = client->cache.data;
+    struct _discord_shard_cache *cache = &data->caches[shard];
+    _discord_shard_cache_cleanup(client, cache);
+    pthread_mutex_lock(&cache->lock);
+    cache->valid = true;
+    pthread_mutex_unlock(&cache->lock);
+}
 
-EV_CB(guild_role_create, discord_guild_role_create) {}
-EV_CB(guild_role_update, discord_guild_role_update) {}
-EV_CB(guild_role_delete, discord_guild_role_delete) {}
+static void
+_on_shard_disconnected(struct discord *client,
+                       const struct discord_identify *ev,
+                       bool resumable)
+{
+    int shard = ev->shard ? ev->shard->array[0] : 0;
+    struct _discord_cache_data *data = client->cache.data;
+    struct _discord_shard_cache *cache = &data->caches[shard];
+    if (!resumable) _discord_shard_cache_cleanup(client, cache);
+    pthread_mutex_lock(&cache->lock);
+    cache->valid = false;
+    pthread_mutex_unlock(&cache->lock);
+}
 
-EV_CB(message_create, discord_message) {}
-EV_CB(message_update, discord_message) {}
-EV_CB(message_delete, discord_message_delete) {}
+#define GUILD_BEGIN(guild)                                                    \
+    struct discord_guild *guild = calloc(1, sizeof *guild);                   \
+    memcpy(guild, ev, sizeof *guild);                                         \
+    guild->channels = NULL;                                                   \
+    guild->members = NULL;                                                    \
+    guild->roles = NULL;                                                      \
+    do {                                                                      \
+        char buf[0x40000];                                                    \
+        const size_t size = discord_guild_to_json(buf, sizeof buf, guild);    \
+        memset(guild, 0, sizeof *guild);                                      \
+        discord_guild_from_json(buf, size, guild);                            \
+        discord_refcounter_add_internal(                                      \
+            &client->refcounter, guild,                                       \
+            (void (*)(void *))discord_guild_cleanup, true);                   \
+    } while (0)
 
-#define ASSIGN_CB(ev, cb) client->gw.cbs[0][ev] = (discord_ev_event)_on_##cb
+EV_CB(guild_create, discord_guild)
+{
+    CACHE_BEGIN(data, cache, shard, ev->id);
+    GUILD_BEGIN(guild);
+    enum anomap_operation op = anomap_insert;
+    anomap_do(cache->guild_map, op, (u64snowflake *)&ev->id, &guild);
+    CACHE_END(cache);
+}
+
+EV_CB(guild_update, discord_guild)
+{
+    CACHE_BEGIN(data, cache, shard, ev->id);
+    GUILD_BEGIN(guild);
+    struct anomap *map = cache->guild_map;
+    enum anomap_operation op = anomap_upsert | anomap_getval;
+    if (anomap_do(map, op, (u64snowflake *)&ev->id, &guild) & anomap_getval)
+        discord_refcounter_decr(&client->refcounter, guild);
+    CACHE_END(cache);
+}
+
+EV_CB(guild_delete, discord_guild)
+{
+    CACHE_BEGIN(data, cache, shard, ev->id);
+    struct discord_guild *guild = NULL;
+    struct anomap *map = cache->guild_map;
+    enum anomap_operation op = anomap_delete | anomap_getval;
+    if (anomap_do(map, op, (u64snowflake *)&ev->id, &guild) & anomap_getval)
+        discord_refcounter_decr(&client->refcounter, guild);
+    CACHE_END(cache);
+}
+
+// EV_CB(channel_create, discord_channel) {}
+// EV_CB(channel_update, discord_channel) {}
+// EV_CB(channel_delete, discord_channel) {}
+
+// EV_CB(guild_role_create, discord_guild_role_create) {}
+// EV_CB(guild_role_update, discord_guild_role_update) {}
+// EV_CB(guild_role_delete, discord_guild_role_delete) {}
+
+EV_CB(message_create, discord_message)
+{
+    CACHE_BEGIN(data, cache, shard, ev->guild_id);
+    struct anomap *map = cache->msg_map;
+    enum anomap_operation op = anomap_insert;
+    if (anomap_do(map, op, (u64snowflake *)&ev->id, &ev))
+        discord_refcounter_incr(&client->refcounter, (void *)ev);
+    CACHE_END(cache);
+}
+
+EV_CB(message_update, discord_message)
+{
+    CACHE_BEGIN(data, cache, shard, ev->guild_id);
+    struct anomap *map = cache->msg_map;
+    enum anomap_operation op = anomap_upsert | anomap_getval;
+    discord_refcounter_incr(&client->refcounter, (void *)ev);
+    if (anomap_do(map, op, (u64snowflake *)&ev->id, &ev) & anomap_getval)
+        discord_refcounter_decr(&client->refcounter, (void *)ev);
+    CACHE_END(cache);
+}
+
+EV_CB(message_delete, discord_message_delete)
+{
+    CACHE_BEGIN(data, cache, shard, ev->guild_id);
+    struct anomap *map = cache->msg_map;
+    enum anomap_operation op = anomap_delete | anomap_getval;
+    struct discord_message *msg;
+    if (anomap_do(map, op, (u64snowflake *)&ev->id, &msg) & anomap_getval)
+        discord_refcounter_decr(&client->refcounter, (void *)msg);
+    CACHE_END(cache);
+}
+
+static void
+_on_garbage_collection(struct discord *client, struct discord_timer *timer)
+{
+    struct _discord_cache_data *data = timer->data;
+    for (int i = 0; i < data->total_shards; i++) {
+        struct _discord_shard_cache *const cache = &data->caches[i];
+        pthread_mutex_lock(&cache->lock);
+        { // DELETE MESSAGES
+            u64snowflake delete_before =
+                ((cog_timestamp_ms() - DISCORD_EPOCH) - 10 * 60 * 1000) << 22;
+            size_t index;
+            anomap_index_of(cache->msg_map, &delete_before, &index);
+            while (index > 0) {
+                struct discord_message *vals[0x1000];
+                const size_t delete_count = index > 0x1000 ? 0x1000 : index;
+                anomap_delete_range(cache->msg_map, 0, delete_count, NULL,
+                                    vals);
+                index -= delete_count;
+                for (size_t j = 0; j < delete_count; j++)
+                    discord_refcounter_decr(&client->refcounter,
+                                            (void *)vals[j]);
+            }
+        } // !DELETE MESSAGES
+        pthread_mutex_unlock(&cache->lock);
+    }
+    timer->repeat = 1;
+    timer->interval = 1000 * 60;
+}
 
 static void
 _discord_cache_cleanup(struct discord *client)
 {
+    struct _discord_cache_data *data = client->cache.data;
+    for (int i = 0; i < data->total_shards; i++) {
+        struct _discord_shard_cache *cache = &data->caches[i];
+        _discord_shard_cache_cleanup(client, cache);
+        anomap_destroy(cache->guild_map);
+        anomap_destroy(cache->msg_map);
+        pthread_mutex_destroy(&cache->lock);
+    }
+    free(data->caches);
+    discord_internal_timer_ctl(client,
+                               &(struct discord_timer){
+                                   .id = data->garbage_collection_timer,
+                                   .flags = DISCORD_TIMER_DELETE,
+                               });
+    free(data);
 }
 
+#define ASSIGN_CB(ev, cb) client->gw.cbs[0][ev] = (discord_ev_event)_on_##cb
+
 void
-discord_enable_cache(struct discord *client,
+discord_cache_enable(struct discord *client,
                      enum discord_cache_options options)
 {
     struct _discord_cache_data *data;
-    if (client->cache.data)
+    if (client->cache.data) {
         data = client->cache.data;
+    }
     else {
         client->cache.cleanup = _discord_cache_cleanup;
         data = client->cache.data = calloc(1, sizeof *data);
+
+        size_t nshards = (size_t)(data->total_shards = 1);
+        data->caches = calloc(nshards, sizeof *data->caches);
+        for (int i = 0; i < data->total_shards; i++) {
+            struct _discord_shard_cache *cache = &data->caches[i];
+            pthread_mutex_init(&cache->lock, NULL);
+            cache->guild_map =
+                anomap_create(sizeof(u64snowflake), sizeof(void *), cmp_sf);
+            cache->msg_map =
+                anomap_create(sizeof(u64snowflake), sizeof(void *), cmp_sf);
+        }
+        data->garbage_collection_timer = discord_internal_timer(
+            client, _on_garbage_collection, NULL, data, 0);
     }
     data->options |= options;
+    ASSIGN_CB(DISCORD_EV_READY, ready);
+    client->cache.on_shard_resumed = _on_shard_resumed;
+    client->cache.on_shard_reconnected = _on_shard_reconnected;
+    client->cache.on_shard_disconnected = _on_shard_disconnected;
 
     if (options & DISCORD_CACHE_GUILDS) {
         discord_add_intents(client, DISCORD_GATEWAY_GUILDS);
@@ -55,18 +288,58 @@ discord_enable_cache(struct discord *client,
         ASSIGN_CB(DISCORD_EV_GUILD_UPDATE, guild_update);
         ASSIGN_CB(DISCORD_EV_GUILD_DELETE, guild_delete);
 
-        ASSIGN_CB(DISCORD_EV_CHANNEL_CREATE, channel_create);
-        ASSIGN_CB(DISCORD_EV_CHANNEL_UPDATE, channel_update);
-        ASSIGN_CB(DISCORD_EV_CHANNEL_DELETE, channel_delete);
+        // ASSIGN_CB(DISCORD_EV_CHANNEL_CREATE, channel_create);
+        // ASSIGN_CB(DISCORD_EV_CHANNEL_UPDATE, channel_update);
+        // ASSIGN_CB(DISCORD_EV_CHANNEL_DELETE, channel_delete);
 
-        ASSIGN_CB(DISCORD_EV_GUILD_ROLE_CREATE, guild_role_create);
-        ASSIGN_CB(DISCORD_EV_GUILD_ROLE_UPDATE, guild_role_update);
-        ASSIGN_CB(DISCORD_EV_GUILD_ROLE_DELETE, guild_role_delete);
+        // ASSIGN_CB(DISCORD_EV_GUILD_ROLE_CREATE, guild_role_create);
+        // ASSIGN_CB(DISCORD_EV_GUILD_ROLE_UPDATE, guild_role_update);
+        // ASSIGN_CB(DISCORD_EV_GUILD_ROLE_DELETE, guild_role_delete);
     }
 
-    if (0) {
+    if (options & DISCORD_CACHE_MESSAGES) {
         ASSIGN_CB(DISCORD_EV_MESSAGE_CREATE, message_create);
         ASSIGN_CB(DISCORD_EV_MESSAGE_UPDATE, message_update);
         ASSIGN_CB(DISCORD_EV_MESSAGE_DELETE, message_delete);
     }
+}
+
+const struct discord_message *
+discord_cache_get_channel_message(struct discord *client,
+                                  u64snowflake channel_id,
+                                  u64snowflake message_id)
+{
+    if (!client->cache.data) return NULL;
+    struct _discord_cache_data *data = client->cache.data;
+    for (int i = 0; i < data->total_shards; i++) {
+        struct _discord_shard_cache *cache = &data->caches[i];
+        struct discord_message *message = NULL;
+        pthread_mutex_lock(&cache->lock);
+        anomap_do(cache->msg_map, anomap_getval, &message_id, &message);
+        const bool found = message;
+        const bool valid = cache->valid;
+        if (found && message->channel_id != channel_id) message = NULL;
+        if (message && valid) (void)discord_claim(client, message);
+        pthread_mutex_unlock(&cache->lock);
+        if (found) return valid ? message : NULL;
+    }
+    return NULL;
+}
+
+const struct discord_guild *
+discord_cache_get_guild(struct discord *client, u64snowflake guild_id)
+{
+    if (!client->cache.data) return NULL;
+    struct _discord_cache_data *data = client->cache.data;
+    for (int i = 0; i < data->total_shards; i++) {
+        struct _discord_shard_cache *cache = &data->caches[i];
+        struct discord_guild *guild = NULL;
+        pthread_mutex_lock(&cache->lock);
+        anomap_do(cache->guild_map, anomap_getval, &guild_id, &guild);
+        const bool valid = cache->valid;
+        if (guild && valid) (void)discord_claim(client, guild);
+        pthread_mutex_unlock(&cache->lock);
+        if (guild) return valid ? guild : NULL;
+    }
+    return NULL;
 }

--- a/src/discord-client.c
+++ b/src/discord-client.c
@@ -222,6 +222,8 @@ discord_cleanup(struct discord *client)
         discord_voice_connections_cleanup(client);
 #endif
         discord_user_cleanup(&client->self);
+        if (client->cache.cleanup)
+            client->cache.cleanup(client);
         discord_refcounter_cleanup(&client->refcounter);
         discord_timers_cleanup(client, &client->timers.user);
         discord_timers_cleanup(client, &client->timers.internal);

--- a/src/discord-events.c
+++ b/src/discord-events.c
@@ -22,7 +22,7 @@ void
 discord_request_guild_members(struct discord *client,
                               struct discord_request_guild_members *request)
 {
-    ASSERT_S(client->gw.cbs[DISCORD_EV_GUILD_MEMBERS_CHUNK] != NULL,
+    ASSERT_S(client->gw.cbs[1][DISCORD_EV_GUILD_MEMBERS_CHUNK] != NULL,
              "Missing callback for discord_set_on_guild_members_chunk()");
     discord_gateway_send_request_guild_members(&client->gw, request);
 }
@@ -117,7 +117,7 @@ discord_set_on_ready(struct discord *client,
                      void (*cb)(struct discord *client,
                                 const struct discord_ready *event))
 {
-    client->gw.cbs[DISCORD_EV_READY] = (discord_ev_event)cb;
+    client->gw.cbs[1][DISCORD_EV_READY] = (discord_ev_event)cb;
 }
 
 void
@@ -126,7 +126,7 @@ discord_set_on_application_command_permissions_update(
     void (*cb)(struct discord *client,
                const struct discord_application_command_permissions *event))
 {
-    client->gw.cbs[DISCORD_EV_APPLICATION_COMMAND_PERMISSIONS_UPDATE] =
+    client->gw.cbs[1][DISCORD_EV_APPLICATION_COMMAND_PERMISSIONS_UPDATE] =
         (discord_ev_event)cb;
 }
 
@@ -136,7 +136,7 @@ discord_set_on_auto_moderation_rule_create(
     void (*cb)(struct discord *client,
                const struct discord_auto_moderation_rule *event))
 {
-    client->gw.cbs[DISCORD_EV_AUTO_MODERATION_RULE_CREATE] =
+    client->gw.cbs[1][DISCORD_EV_AUTO_MODERATION_RULE_CREATE] =
         (discord_ev_event)cb;
     discord_add_intents(client, DISCORD_GATEWAY_AUTO_MODERATION_CONFIGURATION);
 }
@@ -147,7 +147,7 @@ discord_set_on_auto_moderation_rule_update(
     void (*cb)(struct discord *client,
                const struct discord_auto_moderation_rule *event))
 {
-    client->gw.cbs[DISCORD_EV_AUTO_MODERATION_RULE_UPDATE] =
+    client->gw.cbs[1][DISCORD_EV_AUTO_MODERATION_RULE_UPDATE] =
         (discord_ev_event)cb;
     discord_add_intents(client, DISCORD_GATEWAY_AUTO_MODERATION_CONFIGURATION);
 }
@@ -158,7 +158,7 @@ discord_set_on_auto_moderation_rule_delete(
     void (*cb)(struct discord *client,
                const struct discord_auto_moderation_rule *event))
 {
-    client->gw.cbs[DISCORD_EV_AUTO_MODERATION_RULE_DELETE] =
+    client->gw.cbs[1][DISCORD_EV_AUTO_MODERATION_RULE_DELETE] =
         (discord_ev_event)cb;
     discord_add_intents(client, DISCORD_GATEWAY_AUTO_MODERATION_CONFIGURATION);
 }
@@ -169,7 +169,7 @@ discord_set_on_auto_moderation_action_execution(
     void (*cb)(struct discord *client,
                const struct discord_auto_moderation_action_execution *event))
 {
-    client->gw.cbs[DISCORD_EV_AUTO_MODERATION_ACTION_EXECUTION] =
+    client->gw.cbs[1][DISCORD_EV_AUTO_MODERATION_ACTION_EXECUTION] =
         (discord_ev_event)cb;
     discord_add_intents(client, DISCORD_GATEWAY_AUTO_MODERATION_EXECUTION);
 }
@@ -179,7 +179,7 @@ discord_set_on_channel_create(struct discord *client,
                               void (*cb)(struct discord *client,
                                          const struct discord_channel *event))
 {
-    client->gw.cbs[DISCORD_EV_CHANNEL_CREATE] = (discord_ev_event)cb;
+    client->gw.cbs[1][DISCORD_EV_CHANNEL_CREATE] = (discord_ev_event)cb;
     discord_add_intents(client, DISCORD_GATEWAY_GUILDS);
 }
 
@@ -188,7 +188,7 @@ discord_set_on_channel_update(struct discord *client,
                               void (*cb)(struct discord *client,
                                          const struct discord_channel *event))
 {
-    client->gw.cbs[DISCORD_EV_CHANNEL_UPDATE] = (discord_ev_event)cb;
+    client->gw.cbs[1][DISCORD_EV_CHANNEL_UPDATE] = (discord_ev_event)cb;
     discord_add_intents(client, DISCORD_GATEWAY_GUILDS);
 }
 
@@ -197,7 +197,7 @@ discord_set_on_channel_delete(struct discord *client,
                               void (*cb)(struct discord *client,
                                          const struct discord_channel *event))
 {
-    client->gw.cbs[DISCORD_EV_CHANNEL_DELETE] = (discord_ev_event)cb;
+    client->gw.cbs[1][DISCORD_EV_CHANNEL_DELETE] = (discord_ev_event)cb;
     discord_add_intents(client, DISCORD_GATEWAY_GUILDS);
 }
 
@@ -207,7 +207,7 @@ discord_set_on_channel_pins_update(
     void (*cb)(struct discord *client,
                const struct discord_channel_pins_update *event))
 {
-    client->gw.cbs[DISCORD_EV_CHANNEL_PINS_UPDATE] = (discord_ev_event)cb;
+    client->gw.cbs[1][DISCORD_EV_CHANNEL_PINS_UPDATE] = (discord_ev_event)cb;
     discord_add_intents(client, DISCORD_GATEWAY_GUILDS
                                     | DISCORD_GATEWAY_DIRECT_MESSAGES);
 }
@@ -217,7 +217,7 @@ discord_set_on_thread_create(struct discord *client,
                              void (*cb)(struct discord *client,
                                         const struct discord_channel *event))
 {
-    client->gw.cbs[DISCORD_EV_THREAD_CREATE] = (discord_ev_event)cb;
+    client->gw.cbs[1][DISCORD_EV_THREAD_CREATE] = (discord_ev_event)cb;
     discord_add_intents(client, DISCORD_GATEWAY_GUILDS);
 }
 
@@ -226,7 +226,7 @@ discord_set_on_thread_update(struct discord *client,
                              void (*cb)(struct discord *client,
                                         const struct discord_channel *event))
 {
-    client->gw.cbs[DISCORD_EV_THREAD_UPDATE] = (discord_ev_event)cb;
+    client->gw.cbs[1][DISCORD_EV_THREAD_UPDATE] = (discord_ev_event)cb;
     discord_add_intents(client, DISCORD_GATEWAY_GUILDS);
 }
 
@@ -235,7 +235,7 @@ discord_set_on_thread_delete(struct discord *client,
                              void (*cb)(struct discord *client,
                                         const struct discord_channel *event))
 {
-    client->gw.cbs[DISCORD_EV_THREAD_DELETE] = (discord_ev_event)cb;
+    client->gw.cbs[1][DISCORD_EV_THREAD_DELETE] = (discord_ev_event)cb;
     discord_add_intents(client, DISCORD_GATEWAY_GUILDS);
 }
 
@@ -245,7 +245,7 @@ discord_set_on_thread_list_sync(
     void (*cb)(struct discord *client,
                const struct discord_thread_list_sync *event))
 {
-    client->gw.cbs[DISCORD_EV_THREAD_LIST_SYNC] = (discord_ev_event)cb;
+    client->gw.cbs[1][DISCORD_EV_THREAD_LIST_SYNC] = (discord_ev_event)cb;
     discord_add_intents(client, DISCORD_GATEWAY_GUILDS);
 }
 
@@ -255,7 +255,7 @@ discord_set_on_thread_member_update(
     void (*cb)(struct discord *client,
                const struct discord_thread_member *event))
 {
-    client->gw.cbs[DISCORD_EV_THREAD_MEMBER_UPDATE] = (discord_ev_event)cb;
+    client->gw.cbs[1][DISCORD_EV_THREAD_MEMBER_UPDATE] = (discord_ev_event)cb;
     discord_add_intents(client, DISCORD_GATEWAY_GUILDS);
 }
 
@@ -265,7 +265,7 @@ discord_set_on_thread_members_update(
     void (*cb)(struct discord *client,
                const struct discord_thread_members_update *event))
 {
-    client->gw.cbs[DISCORD_EV_THREAD_MEMBERS_UPDATE] = (discord_ev_event)cb;
+    client->gw.cbs[1][DISCORD_EV_THREAD_MEMBERS_UPDATE] = (discord_ev_event)cb;
     discord_add_intents(client, DISCORD_GATEWAY_GUILDS
                                     | DISCORD_GATEWAY_GUILD_MEMBERS);
 }
@@ -275,7 +275,7 @@ discord_set_on_guild_create(struct discord *client,
                             void (*cb)(struct discord *client,
                                        const struct discord_guild *event))
 {
-    client->gw.cbs[DISCORD_EV_GUILD_CREATE] = (discord_ev_event)cb;
+    client->gw.cbs[1][DISCORD_EV_GUILD_CREATE] = (discord_ev_event)cb;
     discord_add_intents(client, DISCORD_GATEWAY_GUILDS);
 }
 
@@ -284,7 +284,7 @@ discord_set_on_guild_update(struct discord *client,
                             void (*cb)(struct discord *client,
                                        const struct discord_guild *event))
 {
-    client->gw.cbs[DISCORD_EV_GUILD_UPDATE] = (discord_ev_event)cb;
+    client->gw.cbs[1][DISCORD_EV_GUILD_UPDATE] = (discord_ev_event)cb;
     discord_add_intents(client, DISCORD_GATEWAY_GUILDS);
 }
 
@@ -293,7 +293,7 @@ discord_set_on_guild_delete(struct discord *client,
                             void (*cb)(struct discord *client,
                                        const struct discord_guild *event))
 {
-    client->gw.cbs[DISCORD_EV_GUILD_DELETE] = (discord_ev_event)cb;
+    client->gw.cbs[1][DISCORD_EV_GUILD_DELETE] = (discord_ev_event)cb;
     discord_add_intents(client, DISCORD_GATEWAY_GUILDS);
 }
 
@@ -303,7 +303,7 @@ discord_set_on_guild_ban_add(
     void (*cb)(struct discord *client,
                const struct discord_guild_ban_add *event))
 {
-    client->gw.cbs[DISCORD_EV_GUILD_BAN_ADD] = (discord_ev_event)cb;
+    client->gw.cbs[1][DISCORD_EV_GUILD_BAN_ADD] = (discord_ev_event)cb;
     discord_add_intents(client, DISCORD_GATEWAY_GUILD_BANS);
 }
 
@@ -313,7 +313,7 @@ discord_set_on_guild_ban_remove(
     void (*cb)(struct discord *client,
                const struct discord_guild_ban_remove *event))
 {
-    client->gw.cbs[DISCORD_EV_GUILD_BAN_REMOVE] = (discord_ev_event)cb;
+    client->gw.cbs[1][DISCORD_EV_GUILD_BAN_REMOVE] = (discord_ev_event)cb;
     discord_add_intents(client, DISCORD_GATEWAY_GUILD_BANS);
 }
 
@@ -323,7 +323,7 @@ discord_set_on_guild_emojis_update(
     void (*cb)(struct discord *client,
                const struct discord_guild_emojis_update *event))
 {
-    client->gw.cbs[DISCORD_EV_GUILD_EMOJIS_UPDATE] = (discord_ev_event)cb;
+    client->gw.cbs[1][DISCORD_EV_GUILD_EMOJIS_UPDATE] = (discord_ev_event)cb;
     discord_add_intents(client, DISCORD_GATEWAY_GUILD_EMOJIS_AND_STICKERS);
 }
 
@@ -333,7 +333,7 @@ discord_set_on_guild_stickers_update(
     void (*cb)(struct discord *client,
                const struct discord_guild_stickers_update *event))
 {
-    client->gw.cbs[DISCORD_EV_GUILD_STICKERS_UPDATE] = (discord_ev_event)cb;
+    client->gw.cbs[1][DISCORD_EV_GUILD_STICKERS_UPDATE] = (discord_ev_event)cb;
     discord_add_intents(client, DISCORD_GATEWAY_GUILD_EMOJIS_AND_STICKERS);
 }
 
@@ -343,7 +343,7 @@ discord_set_on_guild_integrations_update(
     void (*cb)(struct discord *client,
                const struct discord_guild_integrations_update *event))
 {
-    client->gw.cbs[DISCORD_EV_GUILD_INTEGRATIONS_UPDATE] =
+    client->gw.cbs[1][DISCORD_EV_GUILD_INTEGRATIONS_UPDATE] =
         (discord_ev_event)cb;
     discord_add_intents(client, DISCORD_GATEWAY_GUILD_INTEGRATIONS);
 }
@@ -354,7 +354,7 @@ discord_set_on_guild_member_add(
     void (*cb)(struct discord *client,
                const struct discord_guild_member *event))
 {
-    client->gw.cbs[DISCORD_EV_GUILD_MEMBER_ADD] = (discord_ev_event)cb;
+    client->gw.cbs[1][DISCORD_EV_GUILD_MEMBER_ADD] = (discord_ev_event)cb;
     discord_add_intents(client, DISCORD_GATEWAY_GUILD_MEMBERS);
 }
 
@@ -364,7 +364,7 @@ discord_set_on_guild_member_update(
     void (*cb)(struct discord *client,
                const struct discord_guild_member_update *event))
 {
-    client->gw.cbs[DISCORD_EV_GUILD_MEMBER_UPDATE] = (discord_ev_event)cb;
+    client->gw.cbs[1][DISCORD_EV_GUILD_MEMBER_UPDATE] = (discord_ev_event)cb;
     discord_add_intents(client, DISCORD_GATEWAY_GUILD_MEMBERS);
 }
 
@@ -374,7 +374,7 @@ discord_set_on_guild_member_remove(
     void (*cb)(struct discord *client,
                const struct discord_guild_member_remove *event))
 {
-    client->gw.cbs[DISCORD_EV_GUILD_MEMBER_REMOVE] = (discord_ev_event)cb;
+    client->gw.cbs[1][DISCORD_EV_GUILD_MEMBER_REMOVE] = (discord_ev_event)cb;
     discord_add_intents(client, DISCORD_GATEWAY_GUILD_MEMBERS);
 }
 
@@ -384,7 +384,7 @@ discord_set_on_guild_members_chunk(
     void (*cb)(struct discord *client,
                const struct discord_guild_members_chunk *event))
 {
-    client->gw.cbs[DISCORD_EV_GUILD_MEMBERS_CHUNK] = (discord_ev_event)cb;
+    client->gw.cbs[1][DISCORD_EV_GUILD_MEMBERS_CHUNK] = (discord_ev_event)cb;
 }
 
 void
@@ -393,7 +393,7 @@ discord_set_on_guild_role_create(
     void (*cb)(struct discord *client,
                const struct discord_guild_role_create *event))
 {
-    client->gw.cbs[DISCORD_EV_GUILD_ROLE_CREATE] = (discord_ev_event)cb;
+    client->gw.cbs[1][DISCORD_EV_GUILD_ROLE_CREATE] = (discord_ev_event)cb;
     discord_add_intents(client, DISCORD_GATEWAY_GUILDS);
 }
 
@@ -403,7 +403,7 @@ discord_set_on_guild_role_update(
     void (*cb)(struct discord *client,
                const struct discord_guild_role_update *event))
 {
-    client->gw.cbs[DISCORD_EV_GUILD_ROLE_UPDATE] = (discord_ev_event)cb;
+    client->gw.cbs[1][DISCORD_EV_GUILD_ROLE_UPDATE] = (discord_ev_event)cb;
     discord_add_intents(client, DISCORD_GATEWAY_GUILDS);
 }
 
@@ -413,7 +413,7 @@ discord_set_on_guild_role_delete(
     void (*cb)(struct discord *client,
                const struct discord_guild_role_delete *event))
 {
-    client->gw.cbs[DISCORD_EV_GUILD_ROLE_DELETE] = (discord_ev_event)cb;
+    client->gw.cbs[1][DISCORD_EV_GUILD_ROLE_DELETE] = (discord_ev_event)cb;
     discord_add_intents(client, DISCORD_GATEWAY_GUILDS);
 }
 
@@ -423,7 +423,7 @@ discord_set_on_guild_scheduled_event_create(
     void (*cb)(struct discord *client,
                const struct discord_guild_scheduled_event *event))
 {
-    client->gw.cbs[DISCORD_EV_GUILD_SCHEDULED_EVENT_CREATE] =
+    client->gw.cbs[1][DISCORD_EV_GUILD_SCHEDULED_EVENT_CREATE] =
         (discord_ev_event)cb;
     discord_add_intents(client, DISCORD_GATEWAY_GUILD_SCHEDULED_EVENTS);
 }
@@ -434,7 +434,7 @@ discord_set_on_guild_scheduled_event_update(
     void (*cb)(struct discord *client,
                const struct discord_guild_scheduled_event *event))
 {
-    client->gw.cbs[DISCORD_EV_GUILD_SCHEDULED_EVENT_UPDATE] =
+    client->gw.cbs[1][DISCORD_EV_GUILD_SCHEDULED_EVENT_UPDATE] =
         (discord_ev_event)cb;
     discord_add_intents(client, DISCORD_GATEWAY_GUILD_SCHEDULED_EVENTS);
 }
@@ -445,7 +445,7 @@ discord_set_on_guild_scheduled_event_delete(
     void (*cb)(struct discord *client,
                const struct discord_guild_scheduled_event *event))
 {
-    client->gw.cbs[DISCORD_EV_GUILD_SCHEDULED_EVENT_DELETE] =
+    client->gw.cbs[1][DISCORD_EV_GUILD_SCHEDULED_EVENT_DELETE] =
         (discord_ev_event)cb;
     discord_add_intents(client, DISCORD_GATEWAY_GUILD_SCHEDULED_EVENTS);
 }
@@ -456,7 +456,7 @@ discord_set_on_guild_scheduled_event_user_add(
     void (*cb)(struct discord *client,
                const struct discord_guild_scheduled_event_user_add *event))
 {
-    client->gw.cbs[DISCORD_EV_GUILD_SCHEDULED_EVENT_USER_ADD] =
+    client->gw.cbs[1][DISCORD_EV_GUILD_SCHEDULED_EVENT_USER_ADD] =
         (discord_ev_event)cb;
     discord_add_intents(client, DISCORD_GATEWAY_GUILD_SCHEDULED_EVENTS);
 }
@@ -467,7 +467,7 @@ discord_set_on_guild_scheduled_event_user_remove(
     void (*cb)(struct discord *client,
                const struct discord_guild_scheduled_event_user_remove *event))
 {
-    client->gw.cbs[DISCORD_EV_GUILD_SCHEDULED_EVENT_USER_REMOVE] =
+    client->gw.cbs[1][DISCORD_EV_GUILD_SCHEDULED_EVENT_USER_REMOVE] =
         (discord_ev_event)cb;
     discord_add_intents(client, DISCORD_GATEWAY_GUILD_SCHEDULED_EVENTS);
 }
@@ -478,7 +478,7 @@ discord_set_on_integration_create(
     void (*cb)(struct discord *client,
                const struct discord_integration *event))
 {
-    client->gw.cbs[DISCORD_EV_INTEGRATION_CREATE] = (discord_ev_event)cb;
+    client->gw.cbs[1][DISCORD_EV_INTEGRATION_CREATE] = (discord_ev_event)cb;
     discord_add_intents(client, DISCORD_GATEWAY_GUILD_INTEGRATIONS);
 }
 
@@ -488,7 +488,7 @@ discord_set_on_integration_update(
     void (*cb)(struct discord *client,
                const struct discord_integration *event))
 {
-    client->gw.cbs[DISCORD_EV_INTEGRATION_UPDATE] = (discord_ev_event)cb;
+    client->gw.cbs[1][DISCORD_EV_INTEGRATION_UPDATE] = (discord_ev_event)cb;
     discord_add_intents(client, DISCORD_GATEWAY_GUILD_INTEGRATIONS);
 }
 
@@ -498,7 +498,7 @@ discord_set_on_integration_delete(
     void (*cb)(struct discord *client,
                const struct discord_integration_delete *event))
 {
-    client->gw.cbs[DISCORD_EV_INTEGRATION_DELETE] = (discord_ev_event)cb;
+    client->gw.cbs[1][DISCORD_EV_INTEGRATION_DELETE] = (discord_ev_event)cb;
     discord_add_intents(client, DISCORD_GATEWAY_GUILD_INTEGRATIONS);
 }
 
@@ -508,7 +508,7 @@ discord_set_on_interaction_create(
     void (*cb)(struct discord *client,
                const struct discord_interaction *event))
 {
-    client->gw.cbs[DISCORD_EV_INTERACTION_CREATE] = (discord_ev_event)cb;
+    client->gw.cbs[1][DISCORD_EV_INTERACTION_CREATE] = (discord_ev_event)cb;
 }
 
 void
@@ -517,7 +517,7 @@ discord_set_on_invite_create(
     void (*cb)(struct discord *client,
                const struct discord_invite_create *event))
 {
-    client->gw.cbs[DISCORD_EV_INVITE_CREATE] = (discord_ev_event)cb;
+    client->gw.cbs[1][DISCORD_EV_INVITE_CREATE] = (discord_ev_event)cb;
     discord_add_intents(client, DISCORD_GATEWAY_GUILD_INVITES);
 }
 
@@ -527,7 +527,7 @@ discord_set_on_invite_delete(
     void (*cb)(struct discord *client,
                const struct discord_invite_delete *event))
 {
-    client->gw.cbs[DISCORD_EV_INVITE_DELETE] = (discord_ev_event)cb;
+    client->gw.cbs[1][DISCORD_EV_INVITE_DELETE] = (discord_ev_event)cb;
     discord_add_intents(client, DISCORD_GATEWAY_GUILD_INVITES);
 }
 
@@ -536,7 +536,7 @@ discord_set_on_message_create(struct discord *client,
                               void (*cb)(struct discord *client,
                                          const struct discord_message *event))
 {
-    client->gw.cbs[DISCORD_EV_MESSAGE_CREATE] = (discord_ev_event)cb;
+    client->gw.cbs[1][DISCORD_EV_MESSAGE_CREATE] = (discord_ev_event)cb;
     discord_add_intents(client, DISCORD_GATEWAY_GUILD_MESSAGES
                                     | DISCORD_GATEWAY_DIRECT_MESSAGES);
 }
@@ -546,7 +546,7 @@ discord_set_on_message_update(struct discord *client,
                               void (*cb)(struct discord *client,
                                          const struct discord_message *event))
 {
-    client->gw.cbs[DISCORD_EV_MESSAGE_UPDATE] = (discord_ev_event)cb;
+    client->gw.cbs[1][DISCORD_EV_MESSAGE_UPDATE] = (discord_ev_event)cb;
     discord_add_intents(client, DISCORD_GATEWAY_GUILD_MESSAGES
                                     | DISCORD_GATEWAY_DIRECT_MESSAGES);
 }
@@ -557,7 +557,7 @@ discord_set_on_message_delete(
     void (*cb)(struct discord *client,
                const struct discord_message_delete *event))
 {
-    client->gw.cbs[DISCORD_EV_MESSAGE_DELETE] = (discord_ev_event)cb;
+    client->gw.cbs[1][DISCORD_EV_MESSAGE_DELETE] = (discord_ev_event)cb;
     discord_add_intents(client, DISCORD_GATEWAY_GUILD_MESSAGES
                                     | DISCORD_GATEWAY_DIRECT_MESSAGES);
 }
@@ -568,7 +568,7 @@ discord_set_on_message_delete_bulk(
     void (*cb)(struct discord *client,
                const struct discord_message_delete_bulk *event))
 {
-    client->gw.cbs[DISCORD_EV_MESSAGE_DELETE_BULK] = (discord_ev_event)cb;
+    client->gw.cbs[1][DISCORD_EV_MESSAGE_DELETE_BULK] = (discord_ev_event)cb;
     discord_add_intents(client, DISCORD_GATEWAY_GUILD_MESSAGES);
 }
 
@@ -578,7 +578,7 @@ discord_set_on_message_reaction_add(
     void (*cb)(struct discord *client,
                const struct discord_message_reaction_add *event))
 {
-    client->gw.cbs[DISCORD_EV_MESSAGE_REACTION_ADD] = (discord_ev_event)cb;
+    client->gw.cbs[1][DISCORD_EV_MESSAGE_REACTION_ADD] = (discord_ev_event)cb;
     discord_add_intents(client,
                         DISCORD_GATEWAY_GUILD_MESSAGE_REACTIONS
                             | DISCORD_GATEWAY_DIRECT_MESSAGE_REACTIONS);
@@ -590,7 +590,7 @@ discord_set_on_message_reaction_remove(
     void (*cb)(struct discord *client,
                const struct discord_message_reaction_remove *event))
 {
-    client->gw.cbs[DISCORD_EV_MESSAGE_REACTION_REMOVE] = (discord_ev_event)cb;
+    client->gw.cbs[1][DISCORD_EV_MESSAGE_REACTION_REMOVE] = (discord_ev_event)cb;
     discord_add_intents(client,
                         DISCORD_GATEWAY_GUILD_MESSAGE_REACTIONS
                             | DISCORD_GATEWAY_DIRECT_MESSAGE_REACTIONS);
@@ -602,7 +602,7 @@ discord_set_on_message_reaction_remove_all(
     void (*cb)(struct discord *client,
                const struct discord_message_reaction_remove_all *event))
 {
-    client->gw.cbs[DISCORD_EV_MESSAGE_REACTION_REMOVE_ALL] =
+    client->gw.cbs[1][DISCORD_EV_MESSAGE_REACTION_REMOVE_ALL] =
         (discord_ev_event)cb;
     discord_add_intents(client,
                         DISCORD_GATEWAY_GUILD_MESSAGE_REACTIONS
@@ -615,7 +615,7 @@ discord_set_on_message_reaction_remove_emoji(
     void (*cb)(struct discord *client,
                const struct discord_message_reaction_remove_emoji *event))
 {
-    client->gw.cbs[DISCORD_EV_MESSAGE_REACTION_REMOVE_EMOJI] =
+    client->gw.cbs[1][DISCORD_EV_MESSAGE_REACTION_REMOVE_EMOJI] =
         (discord_ev_event)cb;
     discord_add_intents(client,
                         DISCORD_GATEWAY_GUILD_MESSAGE_REACTIONS
@@ -628,7 +628,7 @@ discord_set_on_presence_update(
     void (*cb)(struct discord *client,
                const struct discord_presence_update *event))
 {
-    client->gw.cbs[DISCORD_EV_PRESENCE_UPDATE] = (discord_ev_event)cb;
+    client->gw.cbs[1][DISCORD_EV_PRESENCE_UPDATE] = (discord_ev_event)cb;
     discord_add_intents(client, DISCORD_GATEWAY_GUILD_PRESENCES);
 }
 
@@ -638,7 +638,7 @@ discord_set_on_stage_instance_create(
     void (*cb)(struct discord *client,
                const struct discord_stage_instance *event))
 {
-    client->gw.cbs[DISCORD_EV_STAGE_INSTANCE_CREATE] = (discord_ev_event)cb;
+    client->gw.cbs[1][DISCORD_EV_STAGE_INSTANCE_CREATE] = (discord_ev_event)cb;
     discord_add_intents(client, DISCORD_GATEWAY_GUILDS);
 }
 
@@ -648,7 +648,7 @@ discord_set_on_stage_instance_update(
     void (*cb)(struct discord *client,
                const struct discord_stage_instance *event))
 {
-    client->gw.cbs[DISCORD_EV_STAGE_INSTANCE_UPDATE] = (discord_ev_event)cb;
+    client->gw.cbs[1][DISCORD_EV_STAGE_INSTANCE_UPDATE] = (discord_ev_event)cb;
     discord_add_intents(client, DISCORD_GATEWAY_GUILDS);
 }
 
@@ -658,7 +658,7 @@ discord_set_on_stage_instance_delete(
     void (*cb)(struct discord *client,
                const struct discord_stage_instance *event))
 {
-    client->gw.cbs[DISCORD_EV_STAGE_INSTANCE_DELETE] = (discord_ev_event)cb;
+    client->gw.cbs[1][DISCORD_EV_STAGE_INSTANCE_DELETE] = (discord_ev_event)cb;
     discord_add_intents(client, DISCORD_GATEWAY_GUILDS);
 }
 
@@ -668,7 +668,7 @@ discord_set_on_typing_start(
     void (*cb)(struct discord *client,
                const struct discord_typing_start *event))
 {
-    client->gw.cbs[DISCORD_EV_TYPING_START] = (discord_ev_event)cb;
+    client->gw.cbs[1][DISCORD_EV_TYPING_START] = (discord_ev_event)cb;
     discord_add_intents(client, DISCORD_GATEWAY_GUILD_MESSAGE_TYPING
                                     | DISCORD_GATEWAY_DIRECT_MESSAGE_TYPING);
 }
@@ -678,7 +678,7 @@ discord_set_on_user_update(struct discord *client,
                            void (*cb)(struct discord *client,
                                       const struct discord_user *event))
 {
-    client->gw.cbs[DISCORD_EV_USER_UPDATE] = (discord_ev_event)cb;
+    client->gw.cbs[1][DISCORD_EV_USER_UPDATE] = (discord_ev_event)cb;
 }
 
 void
@@ -687,7 +687,7 @@ discord_set_on_voice_state_update(
     void (*cb)(struct discord *client,
                const struct discord_voice_state *event))
 {
-    client->gw.cbs[DISCORD_EV_VOICE_STATE_UPDATE] = (discord_ev_event)cb;
+    client->gw.cbs[1][DISCORD_EV_VOICE_STATE_UPDATE] = (discord_ev_event)cb;
     discord_add_intents(client, DISCORD_GATEWAY_GUILD_VOICE_STATES);
 }
 
@@ -697,7 +697,7 @@ discord_set_on_voice_server_update(
     void (*cb)(struct discord *client,
                const struct discord_voice_server_update *event))
 {
-    client->gw.cbs[DISCORD_EV_VOICE_SERVER_UPDATE] = (discord_ev_event)cb;
+    client->gw.cbs[1][DISCORD_EV_VOICE_SERVER_UPDATE] = (discord_ev_event)cb;
     discord_add_intents(client, DISCORD_GATEWAY_GUILD_VOICE_STATES);
 }
 
@@ -707,6 +707,6 @@ discord_set_on_webhooks_update(
     void (*cb)(struct discord *client,
                const struct discord_webhooks_update *event))
 {
-    client->gw.cbs[DISCORD_EV_WEBHOOKS_UPDATE] = (discord_ev_event)cb;
+    client->gw.cbs[1][DISCORD_EV_WEBHOOKS_UPDATE] = (discord_ev_event)cb;
     discord_add_intents(client, DISCORD_GATEWAY_GUILD_WEBHOOKS);
 }

--- a/src/discord-gateway_dispatch.c
+++ b/src/discord-gateway_dispatch.c
@@ -110,7 +110,7 @@ discord_gateway_dispatch(struct discord_gateway *gw)
         }
     /* fall-through */
     default:
-        if (gw->cbs[event]) {
+        if (gw->cbs[0][event] || gw->cbs[1][event]) {
             void *event_data = calloc(1, dispatch[event].size);
 
             dispatch[event].from_jsmnf(gw->payload.data,
@@ -123,7 +123,8 @@ discord_gateway_dispatch(struct discord_gateway *gw)
                                                 event_data,
                                                 dispatch[event].cleanup, true);
             }
-            gw->cbs[event](client, event_data);
+            if (gw->cbs[0][event]) gw->cbs[0][event](client, event_data);
+            if (gw->cbs[1][event]) gw->cbs[1][event](client, event_data);
             discord_refcounter_decr(&client->refcounter, event_data);
         }
         break;


### PR DESCRIPTION
### What?
- Create an extendable caching interface
- Implement caching for Guilds and Messages(more to come later)

```c
// to enable caching
discord_cache_enable(client, DISCORD_CACHE_MESSAGES | DISCORD_CACHE_GUILDS);

// get item from cache
const struct discord_guild *guild = discord_cache_get_guild(client, guild_id);
if (guild) {
  printf("guild name '%s'\n", guild->name);
  discord_unclaim(client, guild); // MUST ALWAYS UNCLAIM CACHED RESOURCES
}
```
_more detailed example can be seen in examples/cache.c_

### Why?
- Avoid having to make REST request for commonly used data
- Skip having to use a callback to request local data

### How?
- Have gateway dispatch all callbacks to caching handler before calling user callback

### Testing?
Testing using examples/cache.c and confirmed it's all working fine, garbage collector is being run, cleanup of all resources is being handled.
reconnects/resumes appear to be working