### PR TITLE
 Fix RATELIMITER_TABLE_INIT reading too many bytes from the string given.

### DIFF
--- a/src/discord-rest_ratelimit.c
+++ b/src/discord-rest_ratelimit.c
@@ -20,8 +20,12 @@
 #define RATELIMITER_TABLE_FREE_VALUE(_value) free(_value)
 #define RATELIMITER_TABLE_COMPARE(_cmp_a, _cmp_b)                             \
     chash_string_compare(_cmp_a, _cmp_b)
-#define RATELIMITER_TABLE_INIT(route, _key, _value)                           \
-    memcpy(route.key, _key, sizeof(route.key));                               \
+#define RATELIMITER_TABLE_INIT(route, _key, _value)                     \
+    {                                                                   \
+        size_t _l = strlen(_key) + 1;                                   \
+        ASSERT_NOT_OOB(_l, sizeof(route.key));                          \
+        memcpy(route.key, _key, _l);                                    \
+    }                                                                   \
     route.bucket = _value
 
 struct _discord_route {


### PR DESCRIPTION
## What?
This PR will fix an overread in `src/discord-rest_ratelimit.c`

## Why?
Copying of too many bytes from a string.

## How?
This PR will change the `RATELIMITER_TABLE_INIT` macro to use `strlen` to determine the length of the string `_key` passed to it.

## Testing?
Compiles and runs the "guild" and "ping-pong" examples flawlessly with AddressSanitizer.