### PR TITLE
Fix sending multiple attachments in a message

### DIFF
--- a/core/carray.h
+++ b/core/carray.h
@@ -37,22 +37,25 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
-/* Modified by Lucas Müller (muller.lucas@hotmail.com), 15 Feb 2022 
+/* Modified by Lucas Müller <lucas@muller.codes>, 19 Sept 2022 
+ * - __carray_init() should initialize its `size` value
+ *
+ * Modified by Lucas Müller <lucas@muller.codes>, 15 Feb 2022 
  * - CARRAY_RESIZE() has a fallback value (+1)
  *
- * Modified by Lucas Müller (muller.lucas@hotmail.com), 06 Feb 2022 
+ * Modified by Lucas Müller <lucas@muller.codes>, 06 Feb 2022 
  * - __carray_init() accept initial length
  *
- * Modified by Lucas Müller (muller.lucas@hotmail.com), 02 Feb 2022 
+ * Modified by Lucas Müller <lucas@muller.codes>, 02 Feb 2022 
  * - remove free(carray) at __carrray_free()
  *
- * Modified by Lucas Müller (muller.lucas@hotmail.com), 01 Feb 2022 
+ * Modified by Lucas Müller <lucas@muller.codes>, 01 Feb 2022 
  * - change CARRAY_INITIAL_SIZE from 5 to 4
  * - change CARRAY_RESIZE to doubling arrays to reduce realloc calls
  * - remove calloc() from __carray_init(), expect user to allocate it
  * - remove pseudo-return from __carray_init()
  *
- * Modified by Lucas Müller (muller.lucas@hotmail.com), 27 Jan 2022 
+ * Modified by Lucas Müller <lucas@muller.codes>, 27 Jan 2022 
  * - rename contents -> array 
  * - rename logical_size -> size
  * - rename physical_size -> realsize
@@ -75,6 +78,7 @@
 #define __carray_init(carray, length, _type, _compare, _free) \
 do {                                                          \
     (carray)->realsize = length;                              \
+    (carray)->size = 0;                                       \
     (carray)->array = calloc(length, sizeof(_type));          \
 } while (0)
 

--- a/gencodecs/api/channel.PRE.h
+++ b/gencodecs/api/channel.PRE.h
@@ -406,11 +406,17 @@ STRUCT(discord_attachment)
     FIELD_PTR(content_type, char, *)
   COND_END
   /** size of file in bytes */
+  COND_WRITE(self->size != 0)
     FIELD(size, size_t, 0)
+  COND_END
   /** source url of file */
+  COND_WRITE(self->url != NULL)
     FIELD_PTR(url, char, *)
+  COND_END
   /** proxied url of file */
+  COND_WRITE(self->proxy_url != NULL)
     FIELD_PTR(proxy_url, char, *)
+  COND_END
   /** height of file (if image) */
   COND_WRITE(self->height != 0)
     FIELD(height, int, 0)

--- a/include/discord-request.h
+++ b/include/discord-request.h
@@ -78,4 +78,16 @@ typedef struct {
 #define DISCORD_ATTR_BLANK_INIT(attr, ret)                                    \
     if (ret) _RET_COPY_TYPELESS(attr.dispatch, *ret)
 
+/**
+ * @brief Helper for initializing attachments ids
+ *
+ * @param attchs a @ref discord_attachments to have its IDs initialized
+ */
+#define DISCORD_ATTACHMENTS_IDS_INIT(attchs)                                  \
+    do {                                                                      \
+        for (int i = 0; i < attchs->size; ++i) {                              \
+            attchs->array[i].id = (u64snowflake)i;                            \
+        }                                                                     \
+    } while (0)
+
 #endif /* DISCORD_REQUEST_H */

--- a/src/channel.c
+++ b/src/channel.c
@@ -226,16 +226,17 @@ discord_create_message(struct discord *client,
     CCORD_EXPECT(client, channel_id != 0, CCORD_BAD_PARAMETER, "");
     CCORD_EXPECT(client, params != NULL, CCORD_BAD_PARAMETER, "");
 
-    body.size = discord_create_message_to_json(buf, sizeof(buf), params);
-    body.start = buf;
-
     if (params->attachments) {
         method = HTTP_MIMEPOST;
+        DISCORD_ATTACHMENTS_IDS_INIT(params->attachments);
         attr.attachments = *params->attachments;
     }
     else {
         method = HTTP_POST;
     }
+
+    body.size = discord_create_message_to_json(buf, sizeof(buf), params);
+    body.start = buf;
 
     DISCORD_ATTR_INIT(attr, discord_message, ret);
 

--- a/src/interaction.c
+++ b/src/interaction.c
@@ -24,16 +24,17 @@ discord_create_interaction_response(
                  "");
     CCORD_EXPECT(client, params != NULL, CCORD_BAD_PARAMETER, "");
 
-    body.size = discord_interaction_response_to_json(buf, sizeof(buf), params);
-    body.start = buf;
-
     if (params->data && params->data->attachments) {
         method = HTTP_MIMEPOST;
+        DISCORD_ATTACHMENTS_IDS_INIT(params->data->attachments);
         attr.attachments = *params->data->attachments;
     }
     else {
         method = HTTP_POST;
     }
+
+    body.size = discord_interaction_response_to_json(buf, sizeof(buf), params);
+    body.start = buf;
 
     DISCORD_ATTR_INIT(attr, discord_interaction_response, ret);
 
@@ -80,17 +81,18 @@ discord_edit_original_interaction_response(
                  "");
     CCORD_EXPECT(client, params != NULL, CCORD_BAD_PARAMETER, "");
 
-    body.size = discord_edit_original_interaction_response_to_json(
-        buf, sizeof(buf), params);
-    body.start = buf;
-
     if (params->attachments) {
         method = HTTP_MIMEPOST;
+        DISCORD_ATTACHMENTS_IDS_INIT(params->attachments);
         attr.attachments = *params->attachments;
     }
     else {
         method = HTTP_PATCH;
     }
+
+    body.size = discord_edit_original_interaction_response_to_json(
+        buf, sizeof(buf), params);
+    body.start = buf;
 
     DISCORD_ATTR_INIT(attr, discord_interaction_response, ret);
 
@@ -142,17 +144,18 @@ discord_create_followup_message(struct discord *client,
         ASSERT_NOT_OOB(offset, sizeof(query));
     }
 
-    body.size =
-        discord_create_followup_message_to_json(buf, sizeof(buf), params);
-    body.start = buf;
-
     if (params->attachments) {
         method = HTTP_MIMEPOST;
+        DISCORD_ATTACHMENTS_IDS_INIT(params->attachments);
         attr.attachments = *params->attachments;
     }
     else {
         method = HTTP_POST;
     }
+
+    body.size =
+        discord_create_followup_message_to_json(buf, sizeof(buf), params);
+    body.start = buf;
 
     DISCORD_ATTR_INIT(attr, discord_webhook, ret);
 
@@ -201,17 +204,18 @@ discord_edit_followup_message(struct discord *client,
     CCORD_EXPECT(client, message_id != 0, CCORD_BAD_PARAMETER, "");
     CCORD_EXPECT(client, params != NULL, CCORD_BAD_PARAMETER, "");
 
-    body.size =
-        discord_edit_followup_message_to_json(buf, sizeof(buf), params);
-    body.start = buf;
-
     if (params->attachments) {
         method = HTTP_MIMEPOST;
+        DISCORD_ATTACHMENTS_IDS_INIT(params->attachments);
         attr.attachments = *params->attachments;
     }
     else {
         method = HTTP_PATCH;
     }
+
+    body.size =
+        discord_edit_followup_message_to_json(buf, sizeof(buf), params);
+    body.start = buf;
 
     DISCORD_ATTR_INIT(attr, discord_message, ret);
 

--- a/src/webhook.c
+++ b/src/webhook.c
@@ -205,16 +205,17 @@ discord_execute_webhook(struct discord *client,
         ASSERT_NOT_OOB(offset, sizeof(query));
     }
 
-    body.size = discord_execute_webhook_to_json(buf, sizeof(buf), params);
-    body.start = buf;
-
     if (params->attachments) {
         method = HTTP_MIMEPOST;
+        DISCORD_ATTACHMENTS_IDS_INIT(params->attachments);
         attr.attachments = *params->attachments;
     }
     else {
         method = HTTP_POST;
     }
+
+    body.size = discord_execute_webhook_to_json(buf, sizeof(buf), params);
+    body.start = buf;
 
     DISCORD_ATTR_BLANK_INIT(attr, ret);
 
@@ -263,16 +264,17 @@ discord_edit_webhook_message(struct discord *client,
     CCORD_EXPECT(client, message_id != 0, CCORD_BAD_PARAMETER, "");
     CCORD_EXPECT(client, params != NULL, CCORD_BAD_PARAMETER, "");
 
-    body.size = discord_edit_webhook_message_to_json(buf, sizeof(buf), params);
-    body.start = buf;
-
     if (params->attachments) {
         method = HTTP_MIMEPOST;
+        DISCORD_ATTACHMENTS_IDS_INIT(params->attachments);
         attr.attachments = *params->attachments;
     }
     else {
         method = HTTP_PATCH;
     }
+
+    body.size = discord_edit_webhook_message_to_json(buf, sizeof(buf), params);
+    body.start = buf;
 
     DISCORD_ATTR_INIT(attr, discord_message, ret);
 


### PR DESCRIPTION
Closes #78 

## What?
Allow for multiple attachments in a single request

## Why?
Prior to this in order to send multiple attachments in a single message, the user would have to manually assign each individual attachment an ID, which was very unintuitive.

## How?
Automatically initializes each individual attachment ID, when an attachments field is included by the user.

## Testing?
Ran it against the example code from #78 