### PR TITLE
Support `X-Audit-Log-Reason` header

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -263,7 +263,8 @@ TAB_SIZE               = 4
 
 ALIASES += "CCORD_ret{1}=@param \1 return context of the request. if successful the assigned `done` will be triggered @see @ref discord_ret for more options^^" \
            "CCORD_ret_obj{2}=@param \1 return context of the request. if successful a @ref discord_\2 will be sent over to its assigned `done` callback @see @ref discord_ret_\2 for more options^^" \
-           "CCORD_return=@return @ref CCORDcode value for how the operation went:^^  - `0` means nothing out of the ordinary^^  - `greater than zero` means a change of state^^  - `lesser than zero` means an error has occurred^^" \
+           "CCORD_reason{1}=@param \1 a `reason` to indicate why the action was taken^^" \
+           "CCORD_return=@return @ref CCORDcode value for how the operation went, @ref CCORD_OK means nothing out of the ordinary^^" \
            "CCORD_pub_struct{1}=**Public methods**^^^^  - Initializer:^^^^    - `\1_init(struct \1 *this)`^^  - Cleanup:^^^^    - `\1_cleanup(struct \1 *this)`^^  - JSON Decoder:^^^^    - `\1_from_json(const char json[], size_t len, struct \1 *this)`^^    - `\1_from_jsmnf(jsmnf *root, const char json[], struct \1 *this)`^^  - JSON Encoder:^^^^    - `\1_to_json(char buf[], size_t size, const struct \1 *this)`^^    - `\1_to_jsonb(jsonb *b, char buf[], size_t size, const struct \1 *this)`" \
            "CCORD_pub_list{1}=**Public methods**^^^^  - Cleanup:^^^^    - `\1_cleanup(struct \1 *this)`^^  - JSON Decoder:^^^^    - `\1_from_json(const char json[], size_t len, struct \1 *this)`^^    - `\1_from_jsmnf(jsmnf *root, const char json[], struct \1 *this)`^^  - JSON Encoder:^^^^    - `\1_to_json(char buf[], size_t size, const struct \1 *this)`^^    - `\1_to_jsonb(jsonb *b, char buf[], size_t size, const struct \1 *this)`"
 

--- a/examples/ban.c
+++ b/examples/ban.c
@@ -61,7 +61,11 @@ on_unban(struct discord *client, const struct discord_message *event)
     u64snowflake target_id = 0ULL;
     sscanf(event->content, "%" SCNu64, &target_id);
 
-    discord_remove_guild_ban(client, event->guild_id, target_id, NULL);
+    struct discord_remove_guild_ban params = {
+        .reason = "Someone really likes you!"
+    };
+    discord_remove_guild_ban(client, event->guild_id, target_id, &params,
+                             NULL);
 }
 
 void

--- a/examples/channel.c
+++ b/examples/channel.c
@@ -78,7 +78,10 @@ on_channel_create(struct discord *client, const struct discord_message *event)
 {
     if (event->author->bot) return;
 
-    struct discord_create_guild_channel params = { .name = event->content };
+    struct discord_create_guild_channel params = {
+        .name = event->content,
+        .reason = "Shiny new channel",
+    };
     discord_create_guild_channel(client, event->guild_id, &params, NULL);
 }
 
@@ -88,7 +91,10 @@ on_channel_rename_this(struct discord *client,
 {
     if (event->author->bot) return;
 
-    struct discord_modify_channel params = { .name = event->content };
+    struct discord_modify_channel params = {
+        .name = event->content,
+        .reason = "Clicks better",
+    };
     discord_modify_channel(client, event->channel_id, &params, NULL);
 }
 
@@ -98,7 +104,8 @@ on_channel_delete_this(struct discord *client,
 {
     if (event->author->bot) return;
 
-    discord_delete_channel(client, event->channel_id, NULL);
+    struct discord_delete_channel params = { .reason = "Stinky channel" };
+    discord_delete_channel(client, event->channel_id, &params, NULL);
 }
 
 void

--- a/examples/guild.c
+++ b/examples/guild.c
@@ -83,7 +83,8 @@ on_role_delete(struct discord *client, const struct discord_message *event)
         return;
     }
 
-    discord_delete_guild_role(client, event->guild_id, role_id, NULL);
+    struct discord_delete_guild_role params = { .reason = "Stinky role" };
+    discord_delete_guild_role(client, event->guild_id, role_id, &params, NULL);
 }
 
 void
@@ -100,8 +101,11 @@ on_role_member_add(struct discord *client, const struct discord_message *event)
         return;
     }
 
+    struct discord_add_guild_member_role params = {
+        .reason = "Special role for a special member",
+    };
     discord_add_guild_member_role(client, event->guild_id, user_id, role_id,
-                                  NULL);
+                                  &params, NULL);
 }
 
 void
@@ -119,8 +123,11 @@ on_role_member_remove(struct discord *client,
         return;
     }
 
+    struct discord_remove_guild_member_role params = {
+        .reason = "Didn't deserve it",
+    };
     discord_remove_guild_member_role(client, event->guild_id, user_id, role_id,
-                                     NULL);
+                                     &params, NULL);
 }
 
 void

--- a/examples/invite.c
+++ b/examples/invite.c
@@ -79,7 +79,8 @@ on_invite_delete(struct discord *client, const struct discord_message *event)
         .fail = &fail,
         .keep = event,
     };
-    discord_delete_invite(client, event->content, &ret);
+    struct discord_delete_invite params = { .reason = "Stale invite" };
+    discord_delete_invite(client, event->content, &params, &ret);
 }
 
 int

--- a/examples/pin.c
+++ b/examples/pin.c
@@ -42,7 +42,8 @@ on_pin(struct discord *client, const struct discord_message *event)
         msg_id = event->referenced_message->id;
     }
 
-    discord_pin_message(client, event->channel_id, msg_id, NULL);
+    struct discord_pin_message params = { .reason = "Important message" };
+    discord_pin_message(client, event->channel_id, msg_id, &params, NULL);
 }
 
 void
@@ -60,7 +61,8 @@ on_unpin(struct discord *client, const struct discord_message *event)
         msg_id = event->referenced_message->id;
     }
 
-    discord_unpin_message(client, event->channel_id, msg_id, NULL);
+    struct discord_unpin_message params = { .reason = "No longer relevant" };
+    discord_unpin_message(client, event->channel_id, msg_id, &params, NULL);
 }
 
 void

--- a/gencodecs/api/auto_moderation.PRE.h
+++ b/gencodecs/api/auto_moderation.PRE.h
@@ -160,6 +160,10 @@ LIST_END
 /** @CCORD_pub_struct{discord_create_auto_moderation_rule} */
 #if GENCODECS_RECIPE & (DATA | JSON)
 PUB_STRUCT(discord_create_auto_moderation_rule)
+  /** @CCORD_reason{reason} */
+#if GENCODECS_RECIPE == DATA
+    FIELD_PTR(reason, char, *)
+#endif
   /** the rule name */
     FIELD_PTR(name, char, *)
   /** the rule event type */
@@ -194,8 +198,14 @@ STRUCT_END
 /** @CCORD_pub_struct{discord_modify_auto_moderation_rule} */
 #if GENCODECS_RECIPE & (DATA | JSON)
 PUB_STRUCT(discord_modify_auto_moderation_rule)
+  /** @CCORD_reason{reason} */
+#if GENCODECS_RECIPE == DATA
+    FIELD_PTR(reason, char, *)
+#endif
   /** the rule name */
+  COND_WRITE(self->name != NULL)
     FIELD_PTR(name, char, *)
+  COND_END
   /** the rule event type */
   COND_WRITE(self->event_type != 0)
     FIELD_ENUM(event_type, discord_auto_moderation_event_types)
@@ -218,5 +228,12 @@ PUB_STRUCT(discord_modify_auto_moderation_rule)
   COND_WRITE(self->exempt_channels != NULL)
     FIELD_STRUCT_PTR(exempt_channels, snowflakes, *)
   COND_END
+STRUCT_END
+#endif
+
+#if GENCODECS_RECIPE == DATA
+STRUCT(discord_delete_auto_moderation_rule)
+  /** @CCORD_reason{reason} */
+    FIELD_PTR(reason, char, *)
 STRUCT_END
 #endif

--- a/gencodecs/api/channel.PRE.h
+++ b/gencodecs/api/channel.PRE.h
@@ -672,6 +672,10 @@ STRUCT_END
 /** @CCORD_pub_struct{discord_modify_channel} */
 #if GENCODECS_RECIPE & (DATA | JSON)
 PUB_STRUCT(discord_modify_channel)
+  /** @CCORD_reason{reason} */
+#if GENCODECS_RECIPE == DATA
+    FIELD_PTR(reason, char, *)
+#endif
   /** 1-100 character channel name */
     FIELD_PTR(name, char, *)
   /* GROUP DM */
@@ -741,7 +745,14 @@ STRUCT_END
 #endif
 
 #if GENCODECS_RECIPE == DATA
-PUB_STRUCT(discord_get_channel_messages)
+STRUCT(discord_delete_channel)
+  /** @CCORD_reason{reason} */
+    FIELD_PTR(reason, char, *)
+STRUCT_END
+#endif
+
+#if GENCODECS_RECIPE == DATA
+STRUCT(discord_get_channel_messages)
   /** get messages around this message ID */
   COND_WRITE(self->around != 0)
     FIELD_SNOWFLAKE(around)
@@ -799,7 +810,7 @@ STRUCT_END
 #endif
 
 #if GENCODECS_RECIPE == DATA
-PUB_STRUCT(discord_get_reactions)
+STRUCT(discord_get_reactions)
   /** get users after this user ID */
   COND_WRITE(self->after != 0)
     FIELD_SNOWFLAKE(after)
@@ -838,9 +849,20 @@ PUB_STRUCT(discord_edit_message)
 STRUCT_END
 #endif
 
+#if GENCODECS_RECIPE == DATA
+STRUCT(discord_delete_message)
+  /** @CCORD_reason{reason} */
+    FIELD_PTR(reason, char, *)
+STRUCT_END
+#endif
+
 /** @CCORD_pub_struct{discord_bulk_delete_messages} */
 #if GENCODECS_RECIPE & (DATA | JSON)
 PUB_STRUCT(discord_bulk_delete_messages)
+  /** @CCORD_reason{reason} */
+#if GENCODECS_RECIPE == DATA
+    FIELD_PTR(reason, char, *)
+#endif
   /** an array of message ids to delete (2-100) */
     FIELD_STRUCT_PTR(messages, snowflakes, *)
 STRUCT_END
@@ -849,6 +871,10 @@ STRUCT_END
 /** @CCORD_pub_struct{discord_edit_channel_permissions} */
 #if GENCODECS_RECIPE & (DATA | JSON)
 PUB_STRUCT(discord_edit_channel_permissions)
+  /** @CCORD_reason{reason} */
+#if GENCODECS_RECIPE == DATA
+    FIELD_PTR(reason, char, *)
+#endif
   /** the bitwise value of all allowed permissions (default \"0\")
         @see @ref DiscordPermissions */
   COND_WRITE(self->allow != 0)
@@ -867,6 +893,10 @@ STRUCT_END
 /** @CCORD_pub_struct{discord_create_channel_invite} */
 #if GENCODECS_RECIPE & (DATA | JSON)
 PUB_STRUCT(discord_create_channel_invite)
+  /** @CCORD_reason{reason} */
+#if GENCODECS_RECIPE == DATA
+    FIELD_PTR(reason, char, *)
+#endif
   /** duration of invite in seconds before expiry, or 0 for never. between
        0 and 604800 (7 days) */
   COND_WRITE(self->max_age != 0)
@@ -902,6 +932,13 @@ PUB_STRUCT(discord_create_channel_invite)
 STRUCT_END
 #endif
 
+#if GENCODECS_RECIPE == DATA
+STRUCT(discord_delete_channel_permission)
+  /** @CCORD_reason{reason} */
+    FIELD_PTR(reason, char, *)
+STRUCT_END
+#endif
+
 /** @CCORD_pub_struct{discord_follow_news_channel} */
 #if GENCODECS_RECIPE & (DATA | JSON)
 PUB_STRUCT(discord_follow_news_channel)
@@ -909,6 +946,20 @@ PUB_STRUCT(discord_follow_news_channel)
   COND_WRITE(self->webhook_channel_id != 0)
     FIELD_SNOWFLAKE(webhook_channel_id)
   COND_END
+STRUCT_END
+#endif
+
+#if GENCODECS_RECIPE == DATA
+STRUCT(discord_pin_message)
+  /** @CCORD_reason{reason} */
+    FIELD_PTR(reason, char, *)
+STRUCT_END
+#endif
+
+#if GENCODECS_RECIPE == DATA
+STRUCT(discord_unpin_message)
+  /** @CCORD_reason{reason} */
+    FIELD_PTR(reason, char, *)
 STRUCT_END
 #endif
 
@@ -925,6 +976,10 @@ STRUCT_END
 /** @CCORD_pub_struct{discord_start_thread_with_message} */
 #if GENCODECS_RECIPE & (DATA | JSON)
 PUB_STRUCT(discord_start_thread_with_message)
+  /** @CCORD_reason{reason} */
+#if GENCODECS_RECIPE == DATA
+    FIELD_PTR(reason, char, *)
+#endif
   /** 1-100 character channel name */
     FIELD_PTR(name, char, *)
   /** duration in minutes to automatically archive the thread after recent
@@ -944,6 +999,10 @@ STRUCT_END
 /** @CCORD_pub_struct{discord_start_thread_without_message} */
 #if GENCODECS_RECIPE & (DATA | JSON)
 PUB_STRUCT(discord_start_thread_without_message)
+  /** @CCORD_reason{reason} */
+#if GENCODECS_RECIPE == DATA
+    FIELD_PTR(reason, char, *)
+#endif
   /** 1-100 character channel name */
     FIELD_PTR(name, char, *)
   /** duration in minutes to automatically archive the thread after recent

--- a/gencodecs/api/emoji.PRE.h
+++ b/gencodecs/api/emoji.PRE.h
@@ -43,6 +43,10 @@ LIST_END
 /** @CCORD_pub_struct{discord_create_guild_emoji} */
 #if GENCODECS_RECIPE & (DATA | JSON)
 PUB_STRUCT(discord_create_guild_emoji)
+  /** @CCORD_reason{reason} */
+#if GENCODECS_RECIPE == DATA
+    FIELD_PTR(reason, char, *)
+#endif
   /** name of the emoji */
     FIELD_PTR(name, char, *)
   /* TODO: implement base64 encoding */
@@ -58,6 +62,10 @@ STRUCT_END
 /** @CCORD_pub_struct{discord_modify_guild_emoji} */
 #if GENCODECS_RECIPE & (DATA | JSON)
 PUB_STRUCT(discord_modify_guild_emoji)
+  /** @CCORD_reason{reason} */
+#if GENCODECS_RECIPE == DATA
+    FIELD_PTR(reason, char, *)
+#endif
   /** name of the emoji */
     FIELD_PTR(name, char, *)
   /* TODO: implement base64 encoding */
@@ -67,5 +75,12 @@ PUB_STRUCT(discord_modify_guild_emoji)
   COND_WRITE(self->roles != NULL)
     FIELD_STRUCT_PTR(roles, snowflakes, *)
   COND_END
+STRUCT_END
+#endif
+
+#if GENCODECS_RECIPE == DATA
+STRUCT(discord_delete_guild_emoji)
+  /** @CCORD_reason{reason} */
+    FIELD_PTR(reason, char, *)
 STRUCT_END
 #endif

--- a/gencodecs/api/guild.PRE.h
+++ b/gencodecs/api/guild.PRE.h
@@ -281,6 +281,10 @@ STRUCT_END
 /** @CCORD_pub_struct{discord_guild_widget_settings} */
 #if GENCODECS_RECIPE & (DATA | JSON)
 PUB_STRUCT(discord_guild_widget_settings)
+  /** @CCORD_reason{reason} */
+#if GENCODECS_RECIPE == DATA
+    FIELD_PTR(reason, char, *)
+#endif
   /** whether the widget is enabled */
     FIELD(enabled, bool, false)
   /** the widget channel ID */
@@ -494,6 +498,10 @@ STRUCT_END
 /** @CCORD_pub_struct{discord_create_guild} */
 #if GENCODECS_RECIPE & (DATA | JSON)
 PUB_STRUCT(discord_create_guild)
+  /** @CCORD_reason{reason} */
+#if GENCODECS_RECIPE == DATA
+    FIELD_PTR(reason, char, *)
+#endif
   /** name of the guild (2-100 charaters) */
     FIELD_PTR(name, char, *)
   /** voice region ID @deprecated deprecated field */
@@ -536,6 +544,10 @@ STRUCT_END
 /** @CCORD_pub_struct{discord_modify_guild} */
 #if GENCODECS_RECIPE & (DATA | JSON)
 PUB_STRUCT(discord_modify_guild)
+  /** @CCORD_reason{reason} */
+#if GENCODECS_RECIPE == DATA
+    FIELD_PTR(reason, char, *)
+#endif
   /** guild name */
     FIELD_PTR(name, char, *)
   /** verification level */
@@ -588,6 +600,10 @@ STRUCT_END
 /** @CCORD_pub_struct{discord_create_guild_channel} */
 #if GENCODECS_RECIPE & (DATA | JSON)
 PUB_STRUCT(discord_create_guild_channel)
+  /** @CCORD_reason{reason} */
+#if GENCODECS_RECIPE == DATA
+    FIELD_PTR(reason, char, *)
+#endif
   /** channel name (1-100 characters) */
     FIELD_PTR(name, char, *)
   /** the type of channel */
@@ -693,6 +709,10 @@ STRUCT_END
 /** @CCORD_pub_struct{discord_modify_guild_member} */
 #if GENCODECS_RECIPE & (DATA | JSON)
 PUB_STRUCT(discord_modify_guild_member)
+  /** @CCORD_reason{reason} */
+#if GENCODECS_RECIPE == DATA
+    FIELD_PTR(reason, char, *)
+#endif
   /** value to set user's nickname to */
   COND_WRITE(self->nick != NULL)
     FIELD_PTR(nick, char, *)
@@ -733,6 +753,10 @@ STRUCT_END
 /** @CCORD_pub_struct{discord_modify_current_member} */
 #if GENCODECS_RECIPE & (DATA | JSON)
 PUB_STRUCT(discord_modify_current_member)
+  /** @CCORD_reason{reason} */
+#if GENCODECS_RECIPE == DATA
+    FIELD_PTR(reason, char, *)
+#endif
   /** value to set user's nickname to */
   COND_WRITE(self->nick != NULL)
     FIELD_PTR(nick, char, *)
@@ -743,6 +767,10 @@ STRUCT_END
 /** @CCORD_pub_struct{discord_modify_current_user_nick} */
 #if GENCODECS_RECIPE & (DATA | JSON)
 PUB_STRUCT(discord_modify_current_user_nick)
+  /** @CCORD_reason{reason} */
+#if GENCODECS_RECIPE == DATA
+    FIELD_PTR(reason, char, *)
+#endif
   /** value to set user's nickname to */
   COND_WRITE(self->nick != NULL)
     FIELD_PTR(nick, char, *)
@@ -750,23 +778,55 @@ PUB_STRUCT(discord_modify_current_user_nick)
 STRUCT_END
 #endif
 
+#if GENCODECS_RECIPE == DATA
+STRUCT(discord_add_guild_member_role)
+  /** @CCORD_reason{reason} */
+    FIELD_PTR(reason, char, *)
+STRUCT_END
+#endif
+
+#if GENCODECS_RECIPE == DATA
+STRUCT(discord_remove_guild_member_role)
+  /** @CCORD_reason{reason} */
+    FIELD_PTR(reason, char, *)
+STRUCT_END
+#endif
+
+#if GENCODECS_RECIPE == DATA
+STRUCT(discord_remove_guild_member)
+  /** @CCORD_reason{reason} */
+    FIELD_PTR(reason, char, *)
+STRUCT_END
+#endif
+
 /** @CCORD_pub_struct{discord_create_guild_ban} */
 #if GENCODECS_RECIPE & (DATA | JSON)
 PUB_STRUCT(discord_create_guild_ban)
+  /** @CCORD_reason{reason} */
+#if GENCODECS_RECIPE == DATA
+    FIELD_PTR(reason, char, *)
+#endif
   /** number of days to delete messages for (0-7) */
   COND_WRITE(self->delete_message_days >= 0 && self->delete_message_days <= 7)
     FIELD(delete_message_days, int, 0)
   COND_END
-  /** reason for the ban @deprecated deprecated field */
-  COND_WRITE(self->reason != NULL)
+STRUCT_END
+#endif
+
+#if GENCODECS_RECIPE == DATA
+STRUCT(discord_remove_guild_ban)
+  /** @CCORD_reason{reason} */
     FIELD_PTR(reason, char, *)
-  COND_END
 STRUCT_END
 #endif
 
 /** @CCORD_pub_struct{discord_create_guild_role} */
 #if GENCODECS_RECIPE & (DATA | JSON)
 PUB_STRUCT(discord_create_guild_role)
+  /** @CCORD_reason{reason} */
+#if GENCODECS_RECIPE == DATA
+    FIELD_PTR(reason, char, *)
+#endif
   /** name of the role */
     FIELD_PTR(name, char, *)
   /** `@everyone` permissions in guild */
@@ -796,6 +856,7 @@ STRUCT(discord_modify_guild_role_position)
 STRUCT_END
 #endif
 
+/** TODO: support X-Audit-Log-Reason */
 /** @CCORD_pub_list{discord_modify_guild_role_positions} */
 #if GENCODECS_RECIPE & (DATA | JSON)
 PUB_LIST(discord_modify_guild_role_positions)
@@ -806,6 +867,10 @@ LIST_END
 /** @CCORD_pub_struct{discord_modify_guild_role} */
 #if GENCODECS_RECIPE & (DATA | JSON)
 PUB_STRUCT(discord_modify_guild_role)
+  /** @CCORD_reason{reason} */
+#if GENCODECS_RECIPE == DATA
+    FIELD_PTR(reason, char, *)
+#endif
   /** name of the role */
     FIELD_PTR(name, char, *)
   /** bitwise value of the enabled/disabled permissions */
@@ -825,6 +890,13 @@ STRUCT_END
 #endif
 
 #if GENCODECS_RECIPE == DATA
+STRUCT(discord_delete_guild_role)
+  /** @CCORD_reason{reason} */
+    FIELD_PTR(reason, char, *)
+STRUCT_END
+#endif
+
+#if GENCODECS_RECIPE == DATA
 STRUCT(discord_get_guild_prune_count)
   /** number of days to count prune for (1-30) */
   COND_WRITE(self->days >= 1 && self->days <= 30)
@@ -838,6 +910,10 @@ STRUCT_END
 /** @CCORD_pub_struct{discord_begin_guild_prune} */
 #if GENCODECS_RECIPE & (DATA | JSON)
 PUB_STRUCT(discord_begin_guild_prune)
+  /** @CCORD_reason{reason} */
+#if GENCODECS_RECIPE == DATA
+    FIELD_PTR(reason, char, *)
+#endif
   /** number of days to prune */
   COND_WRITE(self->days != 0)
     FIELD(days, int, 7)
@@ -846,10 +922,19 @@ PUB_STRUCT(discord_begin_guild_prune)
     FIELD(compute_prune_count, bool, true)
   /** role(s) to include */
     FIELD_STRUCT_PTR(include_roles, snowflakes, *)
-  /** reason for the prune @deprecated deprecated field */
-  COND_WRITE(self->reason != NULL)
+STRUCT_END
+#endif
+
+#if GENCODECS_RECIPE == DATA
+STRUCT(discord_delete_guild_integrations)
+  /** @CCORD_reason{reason} */
     FIELD_PTR(reason, char, *)
+  /** number of days to count prune for (1-30) */
+  COND_WRITE(self->days >= 1 && self->days <= 30)
+    FIELD(days, int, 7)
   COND_END
+  /** role(s) to include */
+    FIELD_STRUCT_PTR(include_roles, snowflakes, *)
 STRUCT_END
 #endif
 
@@ -866,6 +951,10 @@ STRUCT_END
 /** @CCORD_pub_struct{discord_modify_guild_welcome_screen} */
 #if GENCODECS_RECIPE & (DATA | JSON)
 PUB_STRUCT(discord_modify_guild_welcome_screen)
+  /** @CCORD_reason{reason} */
+#if GENCODECS_RECIPE == DATA
+    FIELD_PTR(reason, char, *)
+#endif
   /** whether the welcome screen is enabled */
     FIELD(enabled, bool, false)
   /** channels linked in the welcome screen and their display options */

--- a/gencodecs/api/guild_scheduled_event.PRE.h
+++ b/gencodecs/api/guild_scheduled_event.PRE.h
@@ -129,6 +129,10 @@ STRUCT_END
 /** @CCORD_pub_struct{discord_create_guild_scheduled_event} */
 #if GENCODECS_RECIPE & (DATA | JSON)
 PUB_STRUCT(discord_create_guild_scheduled_event)
+  /** @CCORD_reason{reason} */
+#if GENCODECS_RECIPE == DATA
+    FIELD_PTR(reason, char, *)
+#endif
   /** the channel ID of the scheduled event */
   COND_WRITE(self->channel_id != 0)
     FIELD_SNOWFLAKE(channel_id)
@@ -176,6 +180,10 @@ STRUCT_END
 /** @CCORD_pub_struct{discord_modify_guild_scheduled_event} */
 #if GENCODECS_RECIPE & (DATA | JSON)
 PUB_STRUCT(discord_modify_guild_scheduled_event)
+  /** @CCORD_reason{reason} */
+#if GENCODECS_RECIPE == DATA
+    FIELD_PTR(reason, char, *)
+#endif
   /** the channel ID of the scheduled event */
   COND_WRITE(self->channel_id != 0)
     FIELD_SNOWFLAKE(channel_id)

--- a/gencodecs/api/invite.PRE.h
+++ b/gencodecs/api/invite.PRE.h
@@ -115,3 +115,10 @@ PUB_STRUCT(discord_get_invite)
   COND_END
 STRUCT_END
 #endif
+
+#if GENCODECS_RECIPE == DATA
+STRUCT(discord_delete_invite)
+  /** @CCORD_reason{reason} */
+    FIELD_PTR(reason, char, *)
+STRUCT_END
+#endif

--- a/gencodecs/api/stage_instance.PRE.h
+++ b/gencodecs/api/stage_instance.PRE.h
@@ -44,6 +44,10 @@ LIST_END
 /** @CCORD_pub_struct{discord_create_stage_instance} */
 #if GENCODECS_RECIPE & (DATA | JSON_DECODER)
 PUB_STRUCT(discord_create_stage_instance)
+  /** @CCORD_reason{reason} */
+#if GENCODECS_RECIPE == DATA
+    FIELD_PTR(reason, char, *)
+#endif
   /** the ID of the stage channel */
     FIELD_SNOWFLAKE(channel_id)
   /** the topic of the Stage instance (1-120 characters) */
@@ -58,11 +62,22 @@ STRUCT_END
 /** @CCORD_pub_struct{discord_modify_stage_instance} */
 #if GENCODECS_RECIPE & (DATA | JSON_DECODER)
 PUB_STRUCT(discord_modify_stage_instance)
+  /** @CCORD_reason{reason} */
+#if GENCODECS_RECIPE == DATA
+    FIELD_PTR(reason, char, *)
+#endif
   /** the topic of the Stage instance (1-120 characters) */
     FIELD_PTR(topic, char, *)
   /** the privacy level of the stage instance */
   COND_WRITE(self->privacy_level != 0)
     FIELD_ENUM(privacy_level, discord_privacy_level)
   COND_END
+STRUCT_END
+#endif
+
+#if GENCODECS_RECIPE == DATA
+STRUCT(discord_delete_stage_instance)
+  /** @CCORD_reason{reason} */
+    FIELD_PTR(reason, char, *)
 STRUCT_END
 #endif

--- a/gencodecs/api/sticker.PRE.h
+++ b/gencodecs/api/sticker.PRE.h
@@ -131,6 +131,8 @@ STRUCT_END
 
 #if GENCODECS_RECIPE == DATA
 STRUCT(discord_create_guild_sticker)
+  /** @CCORD_reason{reason} */
+    FIELD_PTR(reason, char, *)
   /** name of the sticker (2-30 characters) */
     FIELD_PTR(name, char, *)
   /** description of the sticker (empty or 2-100 characters) */
@@ -152,5 +154,12 @@ PUB_STRUCT(discord_modify_guild_sticker)
     FIELD_PTR(description, char, *)
   /** autocomplete/suggestion tags for the sticker (max 200 characters) */
     FIELD_PTR(tags, char, *)
+STRUCT_END
+#endif
+
+#if GENCODECS_RECIPE == DATA
+STRUCT(discord_delete_guild_sticker)
+  /** @CCORD_reason{reason} */
+    FIELD_PTR(reason, char, *)
 STRUCT_END
 #endif

--- a/gencodecs/api/webhook.PRE.h
+++ b/gencodecs/api/webhook.PRE.h
@@ -63,6 +63,10 @@ LIST_END
 /** @CCORD_pub_struct{discord_create_webhook} */
 #if GENCODECS_RECIPE & (DATA | JSON)
 PUB_STRUCT(discord_create_webhook)
+  /** @CCORD_reason{reason} */
+#if GENCODECS_RECIPE == DATA
+    FIELD_PTR(reason, char, *)
+#endif
   /** name of the webhook (1-80 characters) */
     FIELD_PTR(name, char, *)
   /* TODO: base64 conv */
@@ -76,6 +80,10 @@ STRUCT_END
 /** @CCORD_pub_struct{discord_modify_webhook} */
 #if GENCODECS_RECIPE & (DATA | JSON)
 PUB_STRUCT(discord_modify_webhook)
+  /** @CCORD_reason{reason} */
+#if GENCODECS_RECIPE == DATA
+    FIELD_PTR(reason, char, *)
+#endif
   /** the default name of the webhook */
     FIELD_PTR(name, char, *)
   /* TODO: base64 conv */
@@ -85,6 +93,13 @@ PUB_STRUCT(discord_modify_webhook)
   COND_END
   /** the new channel ID for this webhook should be moved to */
     FIELD_SNOWFLAKE(channel_id)
+STRUCT_END
+#endif
+
+#if GENCODECS_RECIPE == DATA
+STRUCT(discord_delete_webhook)
+  /** @CCORD_reason{reason} */
+    FIELD_PTR(reason, char, *)
 STRUCT_END
 #endif
 

--- a/include/auto_moderation.h
+++ b/include/auto_moderation.h
@@ -48,6 +48,7 @@ CCORDcode discord_get_auto_moderation_rule(
  *
  * @param client the client created with discord_init()
  * @param guild_id the guild to create the rule in
+ * @param params request parameters
  * @CCORD_ret_obj{ret,auto_moderation_rule}
  * @CCORD_return
  */
@@ -64,6 +65,7 @@ CCORDcode discord_create_auto_moderation_rule(
  * @param client the client created with discord_init()
  * @param guild_id the guild where the rule to be modified is at
  * @param auto_moderation_rule_id the rule to be modified
+ * @param params request parameters
  * @CCORD_ret_obj{ret,auto_moderation_rule}
  * @CCORD_return
  */
@@ -81,6 +83,7 @@ CCORDcode discord_modify_auto_moderation_rule(
  * @param client the client created with discord_init()
  * @param guild_id the guild where the rule to be deleted is at
  * @param auto_moderation_rule_id the rule to be deleted
+ * @param params request parameters
  * @CCORD_ret{ret}
  * @CCORD_return
  */
@@ -88,6 +91,7 @@ CCORDcode discord_delete_auto_moderation_rule(
     struct discord *client,
     u64snowflake guild_id,
     u64snowflake auto_moderation_rule_id,
+    struct discord_delete_auto_moderation_rule *params,
     struct discord_ret *ret);
 
 /** @} DiscordAPIAutoModeration */

--- a/include/channel.h
+++ b/include/channel.h
@@ -56,11 +56,13 @@ CCORDcode discord_modify_channel(struct discord *client,
  *
  * @param client the client created with discord_init()
  * @param channel_id the channel to be deleted
+ * @param params request parameters
  * @CCORD_ret_obj{ret,channel}
  * @CCORD_return
  */
 CCORDcode discord_delete_channel(struct discord *client,
                                  u64snowflake channel_id,
+                                 struct discord_delete_channel *params,
                                  struct discord_ret_channel *ret);
 
 /**
@@ -266,11 +268,13 @@ CCORDcode discord_edit_message(struct discord *client,
  * @param channel_id the channel that the message belongs to
  * @param message_id the message that will be purged of reactions from
  *       particular emoji
+ * @param params request parameters
  * @CCORD_return
  */
 CCORDcode discord_delete_message(struct discord *client,
                                  u64snowflake channel_id,
                                  u64snowflake message_id,
+                                 struct discord_delete_message *params,
                                  struct discord_ret *ret);
 
 /**
@@ -340,13 +344,16 @@ CCORDcode discord_create_channel_invite(
  * @param client the client created with discord_init()
  * @param channel_id the channel to the permission deleted
  * @param overwrite_id the id of the overwritten permission
+ * @param params request parameters
  * @CCORD_ret{ret}
  * @CCORD_return
  */
-CCORDcode discord_delete_channel_permission(struct discord *client,
-                                            u64snowflake channel_id,
-                                            u64snowflake overwrite_id,
-                                            struct discord_ret *ret);
+CCORDcode discord_delete_channel_permission(
+    struct discord *client,
+    u64snowflake channel_id,
+    u64snowflake overwrite_id,
+    struct discord_delete_channel_permission *params,
+    struct discord_ret *ret);
 
 /**
  * @brief Post a typing indicator for the specified channel
@@ -394,12 +401,14 @@ CCORDcode discord_get_pinned_messages(struct discord *client,
  * @param client the client created with discord_init()
  * @param channel_id channel to pin the message on
  * @param message_id message to be pinned
+ * @param params request parameters
  * @CCORD_ret{ret}
  * @CCORD_return
  */
 CCORDcode discord_pin_message(struct discord *client,
                               u64snowflake channel_id,
                               u64snowflake message_id,
+                              struct discord_pin_message *params,
                               struct discord_ret *ret);
 
 /**
@@ -408,12 +417,14 @@ CCORDcode discord_pin_message(struct discord *client,
  * @param client the client created with discord_init()
  * @param channel_id channel for the message to be unpinned
  * @param message_id message to be unpinned
+ * @param params request parameters
  * @CCORD_ret{ret}
  * @CCORD_return
  */
 CCORDcode discord_unpin_message(struct discord *client,
                                 u64snowflake channel_id,
                                 u64snowflake message_id,
+                                struct discord_unpin_message *params,
                                 struct discord_ret *ret);
 
 /**

--- a/include/discord-internal.h
+++ b/include/discord-internal.h
@@ -422,8 +422,11 @@ struct discord_ret_response {
     struct discord_ret_dispatch dispatch;                                     \
     /** information for parsing response into a datatype (if possible) */     \
     struct discord_ret_response response;                                     \
-    /** in case of `HTTP_MIMEPOST` provide attachments for file transfer */   \
-    struct discord_attachments attachments
+    /** if @ref HTTP_MIMEPOST provide attachments for file transfer */        \
+    struct discord_attachments attachments;                                   \
+    /** indicated reason to why the action was taken @note when used at       \
+     *      @ref discord_request buffer is kept and reused */                 \
+    char *reason
 
 /** @brief Request to be performed */
 struct discord_attributes {
@@ -434,6 +437,7 @@ struct discord_attributes {
  * @brief Individual requests that are scheduled to run asynchronously
  * @note this struct **SHOULD NOT** be handled from the `REST` manager thread
  * @note its fields are aligned with @ref discord_attributes
+ *      (see @ref DISCORD_ATTRIBUTES_FIELDS)
  */
 struct discord_request {
     DISCORD_ATTRIBUTES_FIELDS;

--- a/include/discord-request.h
+++ b/include/discord-request.h
@@ -40,31 +40,35 @@ typedef struct {
 /**
  * @brief Helper for setting attributes for a specs-generated return struct
  *
- * @param attr attributes handler to be initialized
- * @param type datatype of the struct
- * @param ret dispatch attributes
+ * @param[out] attr @ref discord_attributes handler to be initialized
+ * @param[in] type datatype of the struct
+ * @param[in] ret dispatch attributes
+ * @param[in] _reason reason for request (if available)
  */
-#define DISCORD_ATTR_INIT(attr, type, ret)                                    \
+#define DISCORD_ATTR_INIT(attr, type, ret, _reason)                           \
     do {                                                                      \
         (attr).response.size = sizeof(struct type);                           \
         (attr).response.init = (cast_init)type##_init;                        \
         (attr).response.from_json = (cast_from_json)type##_from_json;         \
         (attr).response.cleanup = (cast_cleanup)type##_cleanup;               \
+        (attr).reason = _reason;                                              \
         if (ret) _RET_COPY_TYPED(attr.dispatch, *ret);                        \
     } while (0)
 
 /**
  * @brief Helper for setting attributes for a specs-generated list
  *
- * @param attr attributes handler to be initialized
- * @param type datatype of the list
- * @param ret dispatch attributes
+ * @param[out] attr @ref discord_attributes handler to be initialized
+ * @param[in] type datatype of the list
+ * @param[in] ret dispatch attributes
+ * @param[in] _reason reason for request (if available)
  */
-#define DISCORD_ATTR_LIST_INIT(attr, type, ret)                               \
+#define DISCORD_ATTR_LIST_INIT(attr, type, ret, _reason)                      \
     do {                                                                      \
         (attr).response.size = sizeof(struct type);                           \
         (attr).response.from_json = (cast_from_json)type##_from_json;         \
         (attr).response.cleanup = (cast_cleanup)type##_cleanup;               \
+        (attr).reason = _reason;                                              \
         if (ret) _RET_COPY_TYPED(attr.dispatch, *ret);                        \
     } while (0)
 
@@ -72,16 +76,20 @@ typedef struct {
  * @brief Helper for setting attributes for attruests that doensn't expect a
  *      response object
  *
- * @param attr attributes handler to be initialized
- * @param ret dispatch attributes
+ * @param[out] attr @ref discord_attributes handler to be initialized
+ * @param[in] ret dispatch attributes
+ * @param[in] _reason reason for request (if available)
  */
-#define DISCORD_ATTR_BLANK_INIT(attr, ret)                                    \
-    if (ret) _RET_COPY_TYPELESS(attr.dispatch, *ret)
+#define DISCORD_ATTR_BLANK_INIT(attr, ret, _reason)                           \
+    do {                                                                      \
+        (attr).reason = _reason;                                              \
+        if (ret) _RET_COPY_TYPELESS(attr.dispatch, *ret);                     \
+    } while (0)
 
 /**
  * @brief Helper for initializing attachments ids
  *
- * @param attchs a @ref discord_attachments to have its IDs initialized
+ * @param[in,out] attchs a @ref discord_attachments to have its IDs initialized
  */
 #define DISCORD_ATTACHMENTS_IDS_INIT(attchs)                                  \
     do {                                                                      \

--- a/include/emoji.h
+++ b/include/emoji.h
@@ -77,12 +77,14 @@ CCORDcode discord_modify_guild_emoji(struct discord *client,
  * @param client the client created with discord_init()
  * @param guild_id guild the emoji belongs to
  * @param emoji_id the emoji to be deleted
+ * @param params request parameters
  * @CCORD_ret{ret}
  * @CCORD_return
  */
 CCORDcode discord_delete_guild_emoji(struct discord *client,
                                      u64snowflake guild_id,
                                      u64snowflake emoji_id,
+                                     struct discord_delete_guild_emoji *params,
                                      struct discord_ret *ret);
 
 /** @example emoji.c

--- a/include/gateway.h
+++ b/include/gateway.h
@@ -23,8 +23,7 @@
  * @param ret a sized buffer containing the response JSON
  * @CCORD_return
  */
-CCORDcode discord_get_gateway(struct discord *client,
-                              struct ccord_szbuf *ret);
+CCORDcode discord_get_gateway(struct discord *client, struct ccord_szbuf *ret);
 
 /**
  * @brief Get a single valid WSS URL, and additional metadata that can help
@@ -52,6 +51,7 @@ CCORDcode discord_get_gateway_bot(struct discord *client,
  * @param client the client created with discord_init()
  * @param guild_id the guild the member belongs to
  * @param user_id the user to be disconnected
+ * @param params request parameters
  * @CCORD_ret_obj{ret,guild_member}
  * @CCORD_return
  */
@@ -59,6 +59,7 @@ CCORDcode discord_disconnect_guild_member(
     struct discord *client,
     u64snowflake guild_id,
     u64snowflake user_id,
+    struct discord_modify_guild_member *params,
     struct discord_ret_guild_member *ret);
 
 /**

--- a/include/guild.h
+++ b/include/guild.h
@@ -257,14 +257,17 @@ CCORDcode discord_modify_current_user_nick(
  * @param guild_id the unique id of the guild where the member exists
  * @param user_id the unique id of the user
  * @param role_id the unique id of the role to be added
+ * @param params request parameters
  * @CCORD_ret{ret}
  * @CCORD_return
  */
-CCORDcode discord_add_guild_member_role(struct discord *client,
-                                        u64snowflake guild_id,
-                                        u64snowflake user_id,
-                                        u64snowflake role_id,
-                                        struct discord_ret *ret);
+CCORDcode discord_add_guild_member_role(
+    struct discord *client,
+    u64snowflake guild_id,
+    u64snowflake user_id,
+    u64snowflake role_id,
+    struct discord_add_guild_member_role *params,
+    struct discord_ret *ret);
 
 /**
  * @brief Removes a role from a guild member
@@ -275,14 +278,17 @@ CCORDcode discord_add_guild_member_role(struct discord *client,
  * @param guild_id the unique id of the guild where the member exists
  * @param user_id the unique id of the user
  * @param role_id the unique id of the role to be removed
+ * @param params request parameters
  * @CCORD_ret{ret}
  * @CCORD_return
  */
-CCORDcode discord_remove_guild_member_role(struct discord *client,
-                                           u64snowflake guild_id,
-                                           u64snowflake user_id,
-                                           u64snowflake role_id,
-                                           struct discord_ret *ret);
+CCORDcode discord_remove_guild_member_role(
+    struct discord *client,
+    u64snowflake guild_id,
+    u64snowflake user_id,
+    u64snowflake role_id,
+    struct discord_remove_guild_member_role *params,
+    struct discord_ret *ret);
 
 /**
  * @brief Remove a member from a guild
@@ -292,13 +298,16 @@ CCORDcode discord_remove_guild_member_role(struct discord *client,
  * @param client the client created with discord_init()
  * @param guild_id the guild to remove the member from
  * @param user_id the user to be removed
+ * @param params request parameters
  * @CCORD_ret{ret}
  * @CCORD_return
  */
-CCORDcode discord_remove_guild_member(struct discord *client,
-                                      u64snowflake guild_id,
-                                      u64snowflake user_id,
-                                      struct discord_ret *ret);
+CCORDcode discord_remove_guild_member(
+    struct discord *client,
+    u64snowflake guild_id,
+    u64snowflake user_id,
+    struct discord_remove_guild_member *params,
+    struct discord_ret *ret);
 
 /**
  * @brief Fetch banned users for given guild
@@ -354,12 +363,14 @@ CCORDcode discord_create_guild_ban(struct discord *client,
  * @param client the client created with discord_init()
  * @param guild_id guild the user belonged to
  * @param user_id the user to have its ban revoked
+ * @param params request parameters
  * @CCORD_ret{ret}
  * @CCORD_return
  */
 CCORDcode discord_remove_guild_ban(struct discord *client,
                                    u64snowflake guild_id,
                                    u64snowflake user_id,
+                                   struct discord_remove_guild_ban *params,
                                    struct discord_ret *ret);
 
 /**
@@ -418,6 +429,7 @@ CCORDcode discord_get_guild_prune_count(
  *
  * @param client the client created with discord_init()
  * @param guild_id the unique id of the guild to start the prune
+ * @param params request parameters
  * @CCORD_ret{ret}
  * @CCORD_return
  */
@@ -475,13 +487,16 @@ CCORDcode discord_get_guild_integrations(struct discord *client,
  * @param client the client created with discord_init()
  * @param guild_id the unique id of the guild to delete the integrations from
  * @param integration_id the id of the integration to delete
+ * @param params request parameters
  * @CCORD_ret{ret}
  * @CCORD_return
  */
-CCORDcode discord_delete_guild_integrations(struct discord *client,
-                                            u64snowflake guild_id,
-                                            u64snowflake integration_id,
-                                            struct discord_ret *ret);
+CCORDcode discord_delete_guild_integrations(
+    struct discord *client,
+    u64snowflake guild_id,
+    u64snowflake integration_id,
+    struct discord_delete_guild_integrations *params,
+    struct discord_ret *ret);
 
 /**
  * @brief Get a guild widget settings
@@ -665,12 +680,14 @@ CCORDcode discord_modify_guild_role(struct discord *client,
  * @param client the client created with discord_init()
  * @param guild_id the unique id of the guild that the role belongs to
  * @param role_id the unique id of the role to delete
+ * @param params request parameters
  * @CCORD_ret{ret}
  * @CCORD_return
  */
 CCORDcode discord_delete_guild_role(struct discord *client,
                                     u64snowflake guild_id,
                                     u64snowflake role_id,
+                                    struct discord_delete_guild_role *params,
                                     struct discord_ret *ret);
 
 /** @example guild.c

--- a/include/invite.h
+++ b/include/invite.h
@@ -34,11 +34,13 @@ CCORDcode discord_get_invite(struct discord *client,
  *
  * @param client the client created with discord_init()
  * @param invite_code the invite code
+ * @param params request parameters
  * @CCORD_ret_obj{ret,invite}
  * @CCORD_return
  */
 CCORDcode discord_delete_invite(struct discord *client,
                                 char *invite_code,
+                                struct discord_delete_invite *params,
                                 struct discord_ret_invite *ret);
 
 /** @example invite.c

--- a/include/webhook.h
+++ b/include/webhook.h
@@ -115,11 +115,13 @@ CCORDcode discord_modify_webhook_with_token(
  * Delete a webhook permanently. Requires the MANAGE_WEBHOOKS permission
  * @param client the client created with discord_init()
  * @param webhook_id the webhook itself
+ * @param params request parameters
  * @CCORD_ret{ret}
  * @CCORD_return
  */
 CCORDcode discord_delete_webhook(struct discord *client,
                                  u64snowflake webhook_id,
+                                 struct discord_delete_webhook *params,
                                  struct discord_ret *ret);
 
 /**

--- a/src/application_command.c
+++ b/src/application_command.c
@@ -16,7 +16,7 @@ discord_get_global_application_commands(
 
     CCORD_EXPECT(client, application_id != 0, CCORD_BAD_PARAMETER, "");
 
-    DISCORD_ATTR_LIST_INIT(attr, discord_application_commands, ret);
+    DISCORD_ATTR_LIST_INIT(attr, discord_application_commands, ret, NULL);
 
     return discord_rest_run(&client->rest, &attr, NULL, HTTP_GET,
                             "/applications/%" PRIu64 "/commands",
@@ -40,7 +40,7 @@ discord_create_global_application_command(
     CCORD_EXPECT(client, NOT_EMPTY_STR(params->description),
                  CCORD_BAD_PARAMETER, "");
 
-    DISCORD_ATTR_INIT(attr, discord_application_command, ret);
+    DISCORD_ATTR_INIT(attr, discord_application_command, ret, NULL);
 
     body.size = discord_create_global_application_command_to_json(
         buf, sizeof(buf), params);
@@ -63,7 +63,7 @@ discord_get_global_application_command(
     CCORD_EXPECT(client, application_id != 0, CCORD_BAD_PARAMETER, "");
     CCORD_EXPECT(client, command_id != 0, CCORD_BAD_PARAMETER, "");
 
-    DISCORD_ATTR_INIT(attr, discord_application_command, ret);
+    DISCORD_ATTR_INIT(attr, discord_application_command, ret, NULL);
 
     return discord_rest_run(&client->rest, &attr, NULL, HTTP_GET,
                             "/applications/%" PRIu64 "/commands/%" PRIu64,
@@ -89,7 +89,7 @@ discord_edit_global_application_command(
         buf, sizeof(buf), params);
     body.start = buf;
 
-    DISCORD_ATTR_INIT(attr, discord_application_command, ret);
+    DISCORD_ATTR_INIT(attr, discord_application_command, ret, NULL);
 
     return discord_rest_run(&client->rest, &attr, &body, HTTP_PATCH,
                             "/applications/%" PRIu64 "/commands/%" PRIu64,
@@ -107,7 +107,7 @@ discord_delete_global_application_command(struct discord *client,
     CCORD_EXPECT(client, application_id != 0, CCORD_BAD_PARAMETER, "");
     CCORD_EXPECT(client, command_id != 0, CCORD_BAD_PARAMETER, "");
 
-    DISCORD_ATTR_BLANK_INIT(attr, ret);
+    DISCORD_ATTR_BLANK_INIT(attr, ret, NULL);
 
     return discord_rest_run(&client->rest, &attr, NULL, HTTP_DELETE,
                             "/applications/%" PRIu64 "/commands/%" PRIu64,
@@ -131,7 +131,7 @@ discord_bulk_overwrite_global_application_commands(
     body.size = discord_application_commands_to_json(buf, sizeof(buf), params);
     body.start = buf;
 
-    DISCORD_ATTR_LIST_INIT(attr, discord_application_commands, ret);
+    DISCORD_ATTR_LIST_INIT(attr, discord_application_commands, ret, NULL);
 
     return discord_rest_run(&client->rest, &attr, &body, HTTP_PUT,
                             "/applications/%" PRIu64 "/commands",
@@ -150,7 +150,7 @@ discord_get_guild_application_commands(
     CCORD_EXPECT(client, application_id != 0, CCORD_BAD_PARAMETER, "");
     CCORD_EXPECT(client, guild_id != 0, CCORD_BAD_PARAMETER, "");
 
-    DISCORD_ATTR_LIST_INIT(attr, discord_application_commands, ret);
+    DISCORD_ATTR_LIST_INIT(attr, discord_application_commands, ret, NULL);
 
     return discord_rest_run(&client->rest, &attr, NULL, HTTP_GET,
                             "/applications/%" PRIu64 "/guilds/%" PRIu64
@@ -181,7 +181,7 @@ discord_create_guild_application_command(
         buf, sizeof(buf), params);
     body.start = buf;
 
-    DISCORD_ATTR_INIT(attr, discord_application_command, ret);
+    DISCORD_ATTR_INIT(attr, discord_application_command, ret, NULL);
 
     return discord_rest_run(&client->rest, &attr, &body, HTTP_POST,
                             "/applications/%" PRIu64 "/guilds/%" PRIu64
@@ -203,7 +203,7 @@ discord_get_guild_application_command(
     CCORD_EXPECT(client, guild_id != 0, CCORD_BAD_PARAMETER, "");
     CCORD_EXPECT(client, command_id != 0, CCORD_BAD_PARAMETER, "");
 
-    DISCORD_ATTR_INIT(attr, discord_application_command, ret);
+    DISCORD_ATTR_INIT(attr, discord_application_command, ret, NULL);
 
     return discord_rest_run(&client->rest, &attr, NULL, HTTP_GET,
                             "/applications/%" PRIu64 "/guilds/%" PRIu64
@@ -232,7 +232,7 @@ discord_edit_guild_application_command(
         buf, sizeof(buf), params);
     body.start = buf;
 
-    DISCORD_ATTR_INIT(attr, discord_application_command, ret);
+    DISCORD_ATTR_INIT(attr, discord_application_command, ret, NULL);
 
     return discord_rest_run(&client->rest, &attr, &body, HTTP_PATCH,
                             "/applications/%" PRIu64 "/guilds/%" PRIu64
@@ -253,7 +253,7 @@ discord_delete_guild_application_command(struct discord *client,
     CCORD_EXPECT(client, guild_id != 0, CCORD_BAD_PARAMETER, "");
     CCORD_EXPECT(client, command_id != 0, CCORD_BAD_PARAMETER, "");
 
-    DISCORD_ATTR_BLANK_INIT(attr, ret);
+    DISCORD_ATTR_BLANK_INIT(attr, ret, NULL);
 
     return discord_rest_run(&client->rest, &attr, NULL, HTTP_DELETE,
                             "/applications/%" PRIu64 "/guilds/%" PRIu64
@@ -281,7 +281,7 @@ discord_bulk_overwrite_guild_application_commands(
         buf, sizeof(buf), params);
     body.start = buf;
 
-    DISCORD_ATTR_LIST_INIT(attr, discord_application_commands, ret);
+    DISCORD_ATTR_LIST_INIT(attr, discord_application_commands, ret, NULL);
 
     return discord_rest_run(&client->rest, &attr, &body, HTTP_PUT,
                             "/applications/%" PRIu64 "/guilds/%" PRIu64
@@ -301,7 +301,8 @@ discord_get_guild_application_command_permissions(
     CCORD_EXPECT(client, application_id != 0, CCORD_BAD_PARAMETER, "");
     CCORD_EXPECT(client, guild_id != 0, CCORD_BAD_PARAMETER, "");
 
-    DISCORD_ATTR_LIST_INIT(attr, discord_application_command_permissions, ret);
+    DISCORD_ATTR_LIST_INIT(attr, discord_application_command_permissions, ret,
+                           NULL);
 
     return discord_rest_run(&client->rest, &attr, NULL, HTTP_GET,
                             "/applications/%" PRIu64 "/guilds/%" PRIu64
@@ -323,7 +324,7 @@ discord_get_application_command_permissions(
     CCORD_EXPECT(client, guild_id != 0, CCORD_BAD_PARAMETER, "");
     CCORD_EXPECT(client, command_id != 0, CCORD_BAD_PARAMETER, "");
 
-    DISCORD_ATTR_INIT(attr, discord_application_command_permission, ret);
+    DISCORD_ATTR_INIT(attr, discord_application_command_permission, ret, NULL);
 
     return discord_rest_run(&client->rest, &attr, NULL, HTTP_GET,
                             "/applications/%" PRIu64 "/guilds/%" PRIu64
@@ -352,7 +353,7 @@ discord_edit_application_command_permissions(
         buf, sizeof(buf), params);
     body.start = buf;
 
-    DISCORD_ATTR_INIT(attr, discord_application_command_permission, ret);
+    DISCORD_ATTR_INIT(attr, discord_application_command_permission, ret, NULL);
 
     return discord_rest_run(&client->rest, &attr, &body, HTTP_PUT,
                             "/applications/%" PRIu64 "/guilds/%" PRIu64

--- a/src/audit_log.c
+++ b/src/audit_log.c
@@ -45,7 +45,7 @@ discord_get_guild_audit_log(struct discord *client,
         }
     }
 
-    DISCORD_ATTR_INIT(attr, discord_audit_log, ret);
+    DISCORD_ATTR_INIT(attr, discord_audit_log, ret, NULL);
 
     return discord_rest_run(&client->rest, &attr, NULL, HTTP_GET,
                             "/guilds/%" PRIu64 "/audit-logs%s", guild_id,

--- a/src/auto_moderation.c
+++ b/src/auto_moderation.c
@@ -16,7 +16,7 @@ discord_list_auto_moderation_rules_for_guild(
 
     CCORD_EXPECT(client, guild_id != 0, CCORD_BAD_PARAMETER, "");
 
-    DISCORD_ATTR_LIST_INIT(attr, discord_auto_moderation_rules, ret);
+    DISCORD_ATTR_LIST_INIT(attr, discord_auto_moderation_rules, ret, NULL);
 
     return discord_rest_run(&client->rest, &attr, NULL, HTTP_GET,
                             "/guilds/%" PRIu64 "/auto-moderation/rules",
@@ -35,7 +35,7 @@ discord_get_auto_moderation_rule(struct discord *client,
     CCORD_EXPECT(client, auto_moderation_rule_id != 0, CCORD_BAD_PARAMETER,
                  "");
 
-    DISCORD_ATTR_INIT(attr, discord_auto_moderation_rule, ret);
+    DISCORD_ATTR_INIT(attr, discord_auto_moderation_rule, ret, NULL);
 
     return discord_rest_run(&client->rest, &attr, NULL, HTTP_GET,
                             "/guilds/%" PRIu64
@@ -61,7 +61,7 @@ discord_create_auto_moderation_rule(
     CCORD_EXPECT(client, params->trigger_type != 0, CCORD_BAD_PARAMETER, "");
     CCORD_EXPECT(client, params->actions != NULL, CCORD_BAD_PARAMETER, "");
 
-    DISCORD_ATTR_INIT(attr, discord_auto_moderation_rule, ret);
+    DISCORD_ATTR_INIT(attr, discord_auto_moderation_rule, ret, params->reason);
 
     body.size =
         discord_create_auto_moderation_rule_to_json(buf, sizeof(buf), params);
@@ -92,7 +92,7 @@ discord_modify_auto_moderation_rule(
     CCORD_EXPECT(client, params->event_type != 0, CCORD_BAD_PARAMETER, "");
     CCORD_EXPECT(client, params->actions != NULL, CCORD_BAD_PARAMETER, "");
 
-    DISCORD_ATTR_INIT(attr, discord_auto_moderation_rule, ret);
+    DISCORD_ATTR_INIT(attr, discord_auto_moderation_rule, ret, params->reason);
 
     body.size =
         discord_modify_auto_moderation_rule_to_json(buf, sizeof(buf), params);
@@ -105,10 +105,12 @@ discord_modify_auto_moderation_rule(
 }
 
 CCORDcode
-discord_delete_auto_moderation_rule(struct discord *client,
-                                    u64snowflake guild_id,
-                                    u64snowflake auto_moderation_rule_id,
-                                    struct discord_ret *ret)
+discord_delete_auto_moderation_rule(
+    struct discord *client,
+    u64snowflake guild_id,
+    u64snowflake auto_moderation_rule_id,
+    struct discord_delete_auto_moderation_rule *params,
+    struct discord_ret *ret)
 {
     struct discord_attributes attr = { 0 };
 
@@ -116,7 +118,7 @@ discord_delete_auto_moderation_rule(struct discord *client,
     CCORD_EXPECT(client, auto_moderation_rule_id != 0, CCORD_BAD_PARAMETER,
                  "");
 
-    DISCORD_ATTR_BLANK_INIT(attr, ret);
+    DISCORD_ATTR_BLANK_INIT(attr, ret, params ? params->reason : NULL);
 
     return discord_rest_run(&client->rest, &attr, NULL, HTTP_DELETE,
                             "/guilds/%" PRIu64

--- a/src/channel.c
+++ b/src/channel.c
@@ -105,7 +105,7 @@ discord_get_channel(struct discord *client,
 
     CCORD_EXPECT(client, channel_id != 0, CCORD_BAD_PARAMETER, "");
 
-    DISCORD_ATTR_INIT(attr, discord_channel, ret);
+    DISCORD_ATTR_INIT(attr, discord_channel, ret, NULL);
 
     return discord_rest_run(&client->rest, &attr, NULL, HTTP_GET,
                             "/channels/%" PRIu64, channel_id);
@@ -127,7 +127,7 @@ discord_modify_channel(struct discord *client,
     body.size = discord_modify_channel_to_json(buf, sizeof(buf), params);
     body.start = buf;
 
-    DISCORD_ATTR_INIT(attr, discord_channel, ret);
+    DISCORD_ATTR_INIT(attr, discord_channel, ret, params->reason);
 
     return discord_rest_run(&client->rest, &attr, &body, HTTP_PATCH,
                             "/channels/%" PRIu64, channel_id);
@@ -136,13 +136,15 @@ discord_modify_channel(struct discord *client,
 CCORDcode
 discord_delete_channel(struct discord *client,
                        u64snowflake channel_id,
+                       struct discord_delete_channel *params,
                        struct discord_ret_channel *ret)
 {
     struct discord_attributes attr = { 0 };
 
     CCORD_EXPECT(client, channel_id != 0, CCORD_BAD_PARAMETER, "");
 
-    DISCORD_ATTR_INIT(attr, discord_channel, ret);
+    DISCORD_ATTR_INIT(attr, discord_channel, ret,
+                      params ? params->reason : NULL);
 
     return discord_rest_run(&client->rest, &attr, NULL, HTTP_DELETE,
                             "/channels/%" PRIu64, channel_id);
@@ -187,7 +189,7 @@ discord_get_channel_messages(struct discord *client,
         }
     }
 
-    DISCORD_ATTR_LIST_INIT(attr, discord_messages, ret);
+    DISCORD_ATTR_LIST_INIT(attr, discord_messages, ret, NULL);
 
     return discord_rest_run(&client->rest, &attr, NULL, HTTP_GET,
                             "/channels/%" PRIu64 "/messages%s%s", channel_id,
@@ -205,7 +207,7 @@ discord_get_channel_message(struct discord *client,
     CCORD_EXPECT(client, channel_id != 0, CCORD_BAD_PARAMETER, "");
     CCORD_EXPECT(client, message_id != 0, CCORD_BAD_PARAMETER, "");
 
-    DISCORD_ATTR_INIT(attr, discord_message, ret);
+    DISCORD_ATTR_INIT(attr, discord_message, ret, NULL);
 
     return discord_rest_run(&client->rest, &attr, NULL, HTTP_GET,
                             "/channels/%" PRIu64 "/messages/%" PRIu64,
@@ -238,7 +240,7 @@ discord_create_message(struct discord *client,
     body.size = discord_create_message_to_json(buf, sizeof(buf), params);
     body.start = buf;
 
-    DISCORD_ATTR_INIT(attr, discord_message, ret);
+    DISCORD_ATTR_INIT(attr, discord_message, ret, NULL);
 
     return discord_rest_run(&client->rest, &attr, &body, method,
                             "/channels/%" PRIu64 "/messages", channel_id);
@@ -255,7 +257,7 @@ discord_crosspost_message(struct discord *client,
     CCORD_EXPECT(client, channel_id != 0, CCORD_BAD_PARAMETER, "");
     CCORD_EXPECT(client, message_id != 0, CCORD_BAD_PARAMETER, "");
 
-    DISCORD_ATTR_INIT(attr, discord_message, ret);
+    DISCORD_ATTR_INIT(attr, discord_message, ret, NULL);
 
     return discord_rest_run(&client->rest, &attr, NULL, HTTP_POST,
                             "/channels/%" PRIu64 "/messages/%" PRIu64
@@ -288,7 +290,7 @@ discord_create_reaction(struct discord *client,
     else
         snprintf(emoji_endpoint, sizeof(emoji_endpoint), "%s", pct_emoji_name);
 
-    DISCORD_ATTR_BLANK_INIT(attr, ret);
+    DISCORD_ATTR_BLANK_INIT(attr, ret, NULL);
 
     code = discord_rest_run(&client->rest, &attr, NULL, HTTP_PUT,
                             "/channels/%" PRIu64 "/messages/%" PRIu64
@@ -325,7 +327,7 @@ discord_delete_own_reaction(struct discord *client,
     else
         snprintf(emoji_endpoint, sizeof(emoji_endpoint), "%s", pct_emoji_name);
 
-    DISCORD_ATTR_BLANK_INIT(attr, ret);
+    DISCORD_ATTR_BLANK_INIT(attr, ret, NULL);
 
     code = discord_rest_run(&client->rest, &attr, NULL, HTTP_DELETE,
                             "/channels/%" PRIu64 "/messages/%" PRIu64
@@ -364,7 +366,7 @@ discord_delete_user_reaction(struct discord *client,
     else
         snprintf(emoji_endpoint, sizeof(emoji_endpoint), "%s", pct_emoji_name);
 
-    DISCORD_ATTR_BLANK_INIT(attr, ret);
+    DISCORD_ATTR_BLANK_INIT(attr, ret, NULL);
 
     code = discord_rest_run(&client->rest, &attr, NULL, HTTP_DELETE,
                             "/channels/%" PRIu64 "/messages/%" PRIu64
@@ -424,7 +426,7 @@ discord_get_reactions(struct discord *client,
     else
         snprintf(emoji_endpoint, sizeof(emoji_endpoint), "%s", pct_emoji_name);
 
-    DISCORD_ATTR_LIST_INIT(attr, discord_users, ret);
+    DISCORD_ATTR_LIST_INIT(attr, discord_users, ret, NULL);
 
     code = discord_rest_run(&client->rest, &attr, NULL, HTTP_GET,
                             "/channels/%" PRIu64 "/messages/%" PRIu64
@@ -447,7 +449,7 @@ discord_delete_all_reactions(struct discord *client,
     CCORD_EXPECT(client, channel_id != 0, CCORD_BAD_PARAMETER, "");
     CCORD_EXPECT(client, message_id != 0, CCORD_BAD_PARAMETER, "");
 
-    DISCORD_ATTR_BLANK_INIT(attr, ret);
+    DISCORD_ATTR_BLANK_INIT(attr, ret, NULL);
 
     return discord_rest_run(&client->rest, &attr, NULL, HTTP_DELETE,
                             "/channels/%" PRIu64 "/messages/%" PRIu64
@@ -480,7 +482,7 @@ discord_delete_all_reactions_for_emoji(struct discord *client,
     else
         snprintf(emoji_endpoint, sizeof(emoji_endpoint), "%s", pct_emoji_name);
 
-    DISCORD_ATTR_BLANK_INIT(attr, ret);
+    DISCORD_ATTR_BLANK_INIT(attr, ret, NULL);
 
     code = discord_rest_run(&client->rest, &attr, NULL, HTTP_DELETE,
                             "/channels/%" PRIu64 "/messages/%" PRIu64
@@ -510,7 +512,7 @@ discord_edit_message(struct discord *client,
     body.size = discord_edit_message_to_json(buf, sizeof(buf), params);
     body.start = buf;
 
-    DISCORD_ATTR_INIT(attr, discord_message, ret);
+    DISCORD_ATTR_INIT(attr, discord_message, ret, NULL);
 
     return discord_rest_run(&client->rest, &attr, &body, HTTP_PATCH,
                             "/channels/%" PRIu64 "/messages/%" PRIu64,
@@ -521,6 +523,7 @@ CCORDcode
 discord_delete_message(struct discord *client,
                        u64snowflake channel_id,
                        u64snowflake message_id,
+                       struct discord_delete_message *params,
                        struct discord_ret *ret)
 {
     struct discord_attributes attr = { 0 };
@@ -528,7 +531,7 @@ discord_delete_message(struct discord *client,
     CCORD_EXPECT(client, channel_id != 0, CCORD_BAD_PARAMETER, "");
     CCORD_EXPECT(client, message_id != 0, CCORD_BAD_PARAMETER, "");
 
-    DISCORD_ATTR_BLANK_INIT(attr, ret);
+    DISCORD_ATTR_BLANK_INIT(attr, ret, params ? params->reason : NULL);
 
     return discord_rest_run(&client->rest, &attr, NULL, HTTP_DELETE,
                             "/channels/%" PRIu64 "/messages/%" PRIu64,
@@ -564,7 +567,7 @@ discord_bulk_delete_messages(struct discord *client,
     body.size = discord_bulk_delete_messages_to_json(buf, sizeof(buf), params);
     body.start = buf;
 
-    DISCORD_ATTR_BLANK_INIT(attr, ret);
+    DISCORD_ATTR_BLANK_INIT(attr, ret, params->reason);
 
     return discord_rest_run(&client->rest, &attr, &body, HTTP_POST,
                             "/channels/%" PRIu64 "/messages/bulk-delete",
@@ -591,7 +594,7 @@ discord_edit_channel_permissions(
         discord_edit_channel_permissions_to_json(buf, sizeof(buf), params);
     body.start = buf;
 
-    DISCORD_ATTR_BLANK_INIT(attr, ret);
+    DISCORD_ATTR_BLANK_INIT(attr, ret, params->reason);
 
     return discord_rest_run(&client->rest, &attr, &body, HTTP_PUT,
                             "/channels/%" PRIu64 "/permissions/%" PRIu64,
@@ -607,7 +610,7 @@ discord_get_channel_invites(struct discord *client,
 
     CCORD_EXPECT(client, channel_id != 0, CCORD_BAD_PARAMETER, "");
 
-    DISCORD_ATTR_LIST_INIT(attr, discord_invites, ret);
+    DISCORD_ATTR_LIST_INIT(attr, discord_invites, ret, NULL);
 
     return discord_rest_run(&client->rest, &attr, NULL, HTTP_GET,
                             "/channels/%" PRIu64 "/invites", channel_id);
@@ -621,35 +624,35 @@ discord_create_channel_invite(struct discord *client,
 {
     struct discord_attributes attr = { 0 };
     struct ccord_szbuf body;
-    char buf[1024] = "{}";
-    size_t len = 2;
+    char buf[1024];
 
     CCORD_EXPECT(client, channel_id != 0, CCORD_BAD_PARAMETER, "");
 
-    if (params)
-        len = discord_create_channel_invite_to_json(buf, sizeof(buf), params);
-
+    body.size =
+        discord_create_channel_invite_to_json(buf, sizeof(buf), params);
     body.start = buf;
-    body.size = len;
 
-    DISCORD_ATTR_INIT(attr, discord_invite, ret);
+    DISCORD_ATTR_INIT(attr, discord_invite, ret,
+                      params ? params->reason : NULL);
 
     return discord_rest_run(&client->rest, &attr, &body, HTTP_POST,
                             "/channels/%" PRIu64 "/invites", channel_id);
 }
 
 CCORDcode
-discord_delete_channel_permission(struct discord *client,
-                                  u64snowflake channel_id,
-                                  u64snowflake overwrite_id,
-                                  struct discord_ret *ret)
+discord_delete_channel_permission(
+    struct discord *client,
+    u64snowflake channel_id,
+    u64snowflake overwrite_id,
+    struct discord_delete_channel_permission *params,
+    struct discord_ret *ret)
 {
     struct discord_attributes attr = { 0 };
 
     CCORD_EXPECT(client, channel_id != 0, CCORD_BAD_PARAMETER, "");
     CCORD_EXPECT(client, overwrite_id != 0, CCORD_BAD_PARAMETER, "");
 
-    DISCORD_ATTR_BLANK_INIT(attr, ret);
+    DISCORD_ATTR_BLANK_INIT(attr, ret, params ? params->reason : NULL);
 
     return discord_rest_run(&client->rest, &attr, NULL, HTTP_DELETE,
                             "/channels/%" PRIu64 "/permissions/%" PRIu64,
@@ -674,7 +677,7 @@ discord_follow_news_channel(struct discord *client,
     body.size = discord_follow_news_channel_to_json(buf, sizeof(buf), params);
     body.start = buf;
 
-    DISCORD_ATTR_INIT(attr, discord_channel, ret);
+    DISCORD_ATTR_INIT(attr, discord_channel, ret, NULL);
 
     return discord_rest_run(&client->rest, &attr, &body, HTTP_POST,
                             "/channels/%" PRIu64 "/followers", channel_id);
@@ -689,7 +692,7 @@ discord_trigger_typing_indicator(struct discord *client,
 
     CCORD_EXPECT(client, channel_id != 0, CCORD_BAD_PARAMETER, "");
 
-    DISCORD_ATTR_BLANK_INIT(attr, ret);
+    DISCORD_ATTR_BLANK_INIT(attr, ret, NULL);
 
     return discord_rest_run(&client->rest, &attr, NULL, HTTP_POST,
                             "/channels/%" PRIu64 "/typing", channel_id);
@@ -704,7 +707,7 @@ discord_get_pinned_messages(struct discord *client,
 
     CCORD_EXPECT(client, channel_id != 0, CCORD_BAD_PARAMETER, "");
 
-    DISCORD_ATTR_LIST_INIT(attr, discord_messages, ret);
+    DISCORD_ATTR_LIST_INIT(attr, discord_messages, ret, NULL);
 
     return discord_rest_run(&client->rest, &attr, NULL, HTTP_GET,
                             "/channels/%" PRIu64 "/pins", channel_id);
@@ -714,6 +717,7 @@ CCORDcode
 discord_pin_message(struct discord *client,
                     u64snowflake channel_id,
                     u64snowflake message_id,
+                    struct discord_pin_message *params,
                     struct discord_ret *ret)
 {
     struct discord_attributes attr = { 0 };
@@ -721,7 +725,7 @@ discord_pin_message(struct discord *client,
     CCORD_EXPECT(client, channel_id != 0, CCORD_BAD_PARAMETER, "");
     CCORD_EXPECT(client, message_id != 0, CCORD_BAD_PARAMETER, "");
 
-    DISCORD_ATTR_BLANK_INIT(attr, ret);
+    DISCORD_ATTR_BLANK_INIT(attr, ret, params ? params->reason : NULL);
 
     return discord_rest_run(&client->rest, &attr, NULL, HTTP_PUT,
                             "/channels/%" PRIu64 "/pins/%" PRIu64, channel_id,
@@ -732,6 +736,7 @@ CCORDcode
 discord_unpin_message(struct discord *client,
                       u64snowflake channel_id,
                       u64snowflake message_id,
+                      struct discord_unpin_message *params,
                       struct discord_ret *ret)
 {
     struct discord_attributes attr = { 0 };
@@ -739,7 +744,7 @@ discord_unpin_message(struct discord *client,
     CCORD_EXPECT(client, channel_id != 0, CCORD_BAD_PARAMETER, "");
     CCORD_EXPECT(client, message_id != 0, CCORD_BAD_PARAMETER, "");
 
-    DISCORD_ATTR_BLANK_INIT(attr, ret);
+    DISCORD_ATTR_BLANK_INIT(attr, ret, params ? params->reason : NULL);
 
     return discord_rest_run(&client->rest, &attr, NULL, HTTP_DELETE,
                             "/channels/%" PRIu64 "/pins/%" PRIu64, channel_id,
@@ -765,7 +770,7 @@ discord_group_dm_add_recipient(struct discord *client,
         discord_group_dm_add_recipient_to_json(buf, sizeof(buf), params);
     body.start = buf;
 
-    DISCORD_ATTR_BLANK_INIT(attr, ret);
+    DISCORD_ATTR_BLANK_INIT(attr, ret, NULL);
 
     return discord_rest_run(&client->rest, &attr, &body, HTTP_PUT,
                             "/channels/%" PRIu64 "/recipients/%" PRIu64,
@@ -783,7 +788,7 @@ discord_group_dm_remove_recipient(struct discord *client,
     CCORD_EXPECT(client, channel_id != 0, CCORD_BAD_PARAMETER, "");
     CCORD_EXPECT(client, user_id != 0, CCORD_BAD_PARAMETER, "");
 
-    DISCORD_ATTR_BLANK_INIT(attr, ret);
+    DISCORD_ATTR_BLANK_INIT(attr, ret, NULL);
 
     return discord_rest_run(&client->rest, &attr, NULL, HTTP_DELETE,
                             "/channels/%" PRIu64 "/recipients/%" PRIu64,
@@ -810,7 +815,7 @@ discord_start_thread_with_message(
         discord_start_thread_with_message_to_json(buf, sizeof(buf), params);
     body.start = buf;
 
-    DISCORD_ATTR_INIT(attr, discord_channel, ret);
+    DISCORD_ATTR_INIT(attr, discord_channel, ret, params->reason);
 
     return discord_rest_run(&client->rest, &attr, &body, HTTP_POST,
                             "/channels/%" PRIu64 "/messages/%" PRIu64
@@ -836,7 +841,7 @@ discord_start_thread_without_message(
         discord_start_thread_without_message_to_json(buf, sizeof(buf), params);
     body.start = buf;
 
-    DISCORD_ATTR_INIT(attr, discord_channel, ret);
+    DISCORD_ATTR_INIT(attr, discord_channel, ret, params->reason);
 
     return discord_rest_run(&client->rest, &attr, &body, HTTP_POST,
                             "/channels/%" PRIu64 "/threads", channel_id);
@@ -851,7 +856,7 @@ discord_join_thread(struct discord *client,
 
     CCORD_EXPECT(client, channel_id != 0, CCORD_BAD_PARAMETER, "");
 
-    DISCORD_ATTR_BLANK_INIT(attr, ret);
+    DISCORD_ATTR_BLANK_INIT(attr, ret, NULL);
 
     return discord_rest_run(&client->rest, &attr, NULL, HTTP_PUT,
                             "/channels/%" PRIu64 "/thread-members/@me",
@@ -869,7 +874,7 @@ discord_add_thread_member(struct discord *client,
     CCORD_EXPECT(client, channel_id != 0, CCORD_BAD_PARAMETER, "");
     CCORD_EXPECT(client, user_id != 0, CCORD_BAD_PARAMETER, "");
 
-    DISCORD_ATTR_BLANK_INIT(attr, ret);
+    DISCORD_ATTR_BLANK_INIT(attr, ret, NULL);
 
     return discord_rest_run(&client->rest, &attr, NULL, HTTP_PUT,
                             "/channels/%" PRIu64 "/thread-members/" PRIu64,
@@ -885,7 +890,7 @@ discord_leave_thread(struct discord *client,
 
     CCORD_EXPECT(client, channel_id != 0, CCORD_BAD_PARAMETER, "");
 
-    DISCORD_ATTR_BLANK_INIT(attr, ret);
+    DISCORD_ATTR_BLANK_INIT(attr, ret, NULL);
 
     return discord_rest_run(&client->rest, &attr, NULL, HTTP_DELETE,
                             "/channels/%" PRIu64 "/thread-members/@me",
@@ -903,7 +908,7 @@ discord_remove_thread_member(struct discord *client,
     CCORD_EXPECT(client, channel_id != 0, CCORD_BAD_PARAMETER, "");
     CCORD_EXPECT(client, user_id != 0, CCORD_BAD_PARAMETER, "");
 
-    DISCORD_ATTR_BLANK_INIT(attr, ret);
+    DISCORD_ATTR_BLANK_INIT(attr, ret, NULL);
 
     return discord_rest_run(&client->rest, &attr, NULL, HTTP_DELETE,
                             "/channels/%" PRIu64 "/thread-members/" PRIu64,
@@ -919,7 +924,7 @@ discord_list_thread_members(struct discord *client,
 
     CCORD_EXPECT(client, channel_id != 0, CCORD_BAD_PARAMETER, "");
 
-    DISCORD_ATTR_LIST_INIT(attr, discord_thread_members, ret);
+    DISCORD_ATTR_LIST_INIT(attr, discord_thread_members, ret, NULL);
 
     return discord_rest_run(&client->rest, &attr, NULL, HTTP_GET,
                             "/channels/%" PRIu64 "/thread-members",
@@ -935,7 +940,7 @@ discord_list_active_threads(struct discord *client,
 
     CCORD_EXPECT(client, channel_id != 0, CCORD_BAD_PARAMETER, "");
 
-    DISCORD_ATTR_INIT(attr, discord_thread_response_body, ret);
+    DISCORD_ATTR_INIT(attr, discord_thread_response_body, ret, NULL);
 
     return discord_rest_run(&client->rest, &attr, NULL, HTTP_GET,
                             "/channels/%" PRIu64 "/threads/active",
@@ -967,7 +972,7 @@ discord_list_public_archived_threads(
         ASSERT_NOT_OOB(offset, sizeof(query));
     }
 
-    DISCORD_ATTR_INIT(attr, discord_thread_response_body, ret);
+    DISCORD_ATTR_INIT(attr, discord_thread_response_body, ret, NULL);
 
     return discord_rest_run(&client->rest, &attr, NULL, HTTP_GET,
                             "/channels/%" PRIu64
@@ -1000,7 +1005,7 @@ discord_list_private_archived_threads(
         ASSERT_NOT_OOB(offset, sizeof(query));
     }
 
-    DISCORD_ATTR_INIT(attr, discord_thread_response_body, ret);
+    DISCORD_ATTR_INIT(attr, discord_thread_response_body, ret, NULL);
 
     return discord_rest_run(&client->rest, &attr, NULL, HTTP_GET,
                             "/channels/%" PRIu64
@@ -1033,7 +1038,7 @@ discord_list_joined_private_archived_threads(
         ASSERT_NOT_OOB(offset, sizeof(query));
     }
 
-    DISCORD_ATTR_INIT(attr, discord_thread_response_body, ret);
+    DISCORD_ATTR_INIT(attr, discord_thread_response_body, ret, NULL);
 
     return discord_rest_run(&client->rest, &attr, NULL, HTTP_GET,
                             "/channels/%" PRIu64

--- a/src/discord-client.c
+++ b/src/discord-client.c
@@ -222,8 +222,7 @@ discord_cleanup(struct discord *client)
         discord_voice_connections_cleanup(client);
 #endif
         discord_user_cleanup(&client->self);
-        if (client->cache.cleanup)
-            client->cache.cleanup(client);
+        if (client->cache.cleanup) client->cache.cleanup(client);
         discord_refcounter_cleanup(&client->refcounter);
         discord_timers_cleanup(client, &client->timers.user);
         discord_timers_cleanup(client, &client->timers.internal);

--- a/src/emoji.c
+++ b/src/emoji.c
@@ -15,7 +15,7 @@ discord_list_guild_emojis(struct discord *client,
 
     CCORD_EXPECT(client, guild_id != 0, CCORD_BAD_PARAMETER, "");
 
-    DISCORD_ATTR_LIST_INIT(attr, discord_emojis, ret);
+    DISCORD_ATTR_LIST_INIT(attr, discord_emojis, ret, NULL);
 
     return discord_rest_run(&client->rest, &attr, NULL, HTTP_GET,
                             "/guilds/%" PRIu64 "/emojis", guild_id);
@@ -32,7 +32,7 @@ discord_get_guild_emoji(struct discord *client,
     CCORD_EXPECT(client, guild_id != 0, CCORD_BAD_PARAMETER, "");
     CCORD_EXPECT(client, emoji_id != 0, CCORD_BAD_PARAMETER, "");
 
-    DISCORD_ATTR_INIT(attr, discord_emoji, ret);
+    DISCORD_ATTR_INIT(attr, discord_emoji, ret, NULL);
 
     return discord_rest_run(&client->rest, &attr, NULL, HTTP_GET,
                             "/guilds/%" PRIu64 "/emojis/%" PRIu64, guild_id,
@@ -55,7 +55,7 @@ discord_create_guild_emoji(struct discord *client,
     body.size = discord_create_guild_emoji_to_json(buf, sizeof(buf), params);
     body.start = buf;
 
-    DISCORD_ATTR_INIT(attr, discord_emoji, ret);
+    DISCORD_ATTR_INIT(attr, discord_emoji, ret, params->reason);
 
     return discord_rest_run(&client->rest, &attr, &body, HTTP_POST,
                             "/guilds/%" PRIu64 "/emojis", guild_id);
@@ -79,7 +79,7 @@ discord_modify_guild_emoji(struct discord *client,
     body.size = discord_modify_guild_emoji_to_json(buf, sizeof(buf), params);
     body.start = buf;
 
-    DISCORD_ATTR_INIT(attr, discord_emoji, ret);
+    DISCORD_ATTR_INIT(attr, discord_emoji, ret, params->reason);
 
     return discord_rest_run(&client->rest, &attr, &body, HTTP_PATCH,
                             "/guilds/%" PRIu64 "/emojis/%" PRIu64, guild_id,
@@ -90,6 +90,7 @@ CCORDcode
 discord_delete_guild_emoji(struct discord *client,
                            u64snowflake guild_id,
                            u64snowflake emoji_id,
+                           struct discord_delete_guild_emoji *params,
                            struct discord_ret *ret)
 {
     struct discord_attributes attr = { 0 };
@@ -97,7 +98,7 @@ discord_delete_guild_emoji(struct discord *client,
     CCORD_EXPECT(client, guild_id != 0, CCORD_BAD_PARAMETER, "");
     CCORD_EXPECT(client, emoji_id != 0, CCORD_BAD_PARAMETER, "");
 
-    DISCORD_ATTR_BLANK_INIT(attr, ret);
+    DISCORD_ATTR_BLANK_INIT(attr, ret, params ? params->reason : NULL);
 
     return discord_rest_run(&client->rest, &attr, NULL, HTTP_DELETE,
                             "/guilds/%" PRIu64 "/emojis/%" PRIu64, guild_id,

--- a/src/gateway.c
+++ b/src/gateway.c
@@ -14,6 +14,7 @@ CCORDcode
 discord_disconnect_guild_member(struct discord *client,
                                 u64snowflake guild_id,
                                 u64snowflake user_id,
+                                struct discord_modify_guild_member *params,
                                 struct discord_ret_guild_member *ret)
 {
     struct discord_attributes attr = { 0 };
@@ -36,7 +37,8 @@ discord_disconnect_guild_member(struct discord *client,
     body.start = buf;
     body.size = b.pos;
 
-    DISCORD_ATTR_INIT(attr, discord_guild_member, ret);
+    DISCORD_ATTR_INIT(attr, discord_guild_member, ret,
+                      params ? params->reason : NULL);
 
     return discord_rest_run(&client->rest, &attr, &body, HTTP_PATCH,
                             "/guilds/%" PRIu64 "/members/%" PRIu64, guild_id,

--- a/src/guild.c
+++ b/src/guild.c
@@ -20,7 +20,7 @@ discord_create_guild(struct discord *client,
     body.size = discord_create_guild_to_json(buf, sizeof(buf), params);
     body.start = buf;
 
-    DISCORD_ATTR_INIT(attr, discord_guild, ret);
+    DISCORD_ATTR_INIT(attr, discord_guild, ret, NULL);
 
     return discord_rest_run(&client->rest, &attr, &body, HTTP_POST, "/guilds");
 }
@@ -34,7 +34,7 @@ discord_get_guild(struct discord *client,
 
     CCORD_EXPECT(client, guild_id != 0, CCORD_BAD_PARAMETER, "");
 
-    DISCORD_ATTR_INIT(attr, discord_guild, ret);
+    DISCORD_ATTR_INIT(attr, discord_guild, ret, NULL);
 
     return discord_rest_run(&client->rest, &attr, NULL, HTTP_GET,
                             "/guilds/%" PRIu64, guild_id);
@@ -49,7 +49,7 @@ discord_get_guild_preview(struct discord *client,
 
     CCORD_EXPECT(client, guild_id != 0, CCORD_BAD_PARAMETER, "");
 
-    DISCORD_ATTR_INIT(attr, discord_guild_preview, ret);
+    DISCORD_ATTR_INIT(attr, discord_guild_preview, ret, NULL);
 
     return discord_rest_run(&client->rest, &attr, NULL, HTTP_GET,
                             "/guilds/%" PRIu64 "/preview", guild_id);
@@ -71,7 +71,7 @@ discord_modify_guild(struct discord *client,
     body.size = discord_modify_guild_to_json(buf, sizeof(buf), params);
     body.start = buf;
 
-    DISCORD_ATTR_INIT(attr, discord_guild, ret);
+    DISCORD_ATTR_INIT(attr, discord_guild, ret, params->reason);
 
     return discord_rest_run(&client->rest, &attr, &body, HTTP_PATCH,
                             "/guilds/%" PRIu64, guild_id);
@@ -86,7 +86,7 @@ discord_delete_guild(struct discord *client,
 
     CCORD_EXPECT(client, guild_id != 0, CCORD_BAD_PARAMETER, "");
 
-    DISCORD_ATTR_BLANK_INIT(attr, ret);
+    DISCORD_ATTR_BLANK_INIT(attr, ret, NULL);
 
     return discord_rest_run(&client->rest, &attr, NULL, HTTP_DELETE,
                             "/guilds/%" PRIu64, guild_id);
@@ -101,7 +101,7 @@ discord_get_guild_channels(struct discord *client,
 
     CCORD_EXPECT(client, guild_id != 0, CCORD_BAD_PARAMETER, "");
 
-    DISCORD_ATTR_LIST_INIT(attr, discord_channels, ret);
+    DISCORD_ATTR_LIST_INIT(attr, discord_channels, ret, NULL);
 
     return discord_rest_run(&client->rest, &attr, NULL, HTTP_GET,
                             "/guilds/%" PRIu64 "/channels", guild_id);
@@ -123,7 +123,7 @@ discord_create_guild_channel(struct discord *client,
     body.size = discord_create_guild_channel_to_json(buf, sizeof(buf), params);
     body.start = buf;
 
-    DISCORD_ATTR_INIT(attr, discord_channel, ret);
+    DISCORD_ATTR_INIT(attr, discord_channel, ret, params->reason);
 
     return discord_rest_run(&client->rest, &attr, &body, HTTP_POST,
                             "/guilds/%" PRIu64 "/channels", guild_id);
@@ -147,7 +147,7 @@ discord_modify_guild_channel_positions(
         buf, sizeof(buf), params);
     body.start = buf;
 
-    DISCORD_ATTR_BLANK_INIT(attr, ret);
+    DISCORD_ATTR_BLANK_INIT(attr, ret, NULL);
 
     return discord_rest_run(&client->rest, &attr, &body, HTTP_PATCH,
                             "/guilds/%" PRIu64 "/channels", guild_id);
@@ -164,7 +164,7 @@ discord_get_guild_member(struct discord *client,
     CCORD_EXPECT(client, guild_id != 0, CCORD_BAD_PARAMETER, "");
     CCORD_EXPECT(client, user_id != 0, CCORD_BAD_PARAMETER, "");
 
-    DISCORD_ATTR_INIT(attr, discord_guild_member, ret);
+    DISCORD_ATTR_INIT(attr, discord_guild_member, ret, NULL);
 
     return discord_rest_run(&client->rest, &attr, NULL, HTTP_GET,
                             "/guilds/%" PRIu64 "/members/%" PRIu64, guild_id,
@@ -198,7 +198,7 @@ discord_list_guild_members(struct discord *client,
         }
     }
 
-    DISCORD_ATTR_LIST_INIT(attr, discord_guild_members, ret);
+    DISCORD_ATTR_LIST_INIT(attr, discord_guild_members, ret, NULL);
 
     return discord_rest_run(&client->rest, &attr, NULL, HTTP_GET,
                             "/guilds/%" PRIu64 "/members%s%s", guild_id,
@@ -236,7 +236,7 @@ discord_search_guild_members(struct discord *client,
         }
     }
 
-    DISCORD_ATTR_LIST_INIT(attr, discord_guild_members, ret);
+    DISCORD_ATTR_LIST_INIT(attr, discord_guild_members, ret, NULL);
 
     return discord_rest_run(&client->rest, &attr, NULL, HTTP_GET,
                             "/guilds/%" PRIu64 "/members/search%s%s", guild_id,
@@ -263,7 +263,7 @@ discord_add_guild_member(struct discord *client,
     body.size = discord_add_guild_member_to_json(buf, sizeof(buf), params);
     body.start = buf;
 
-    DISCORD_ATTR_INIT(attr, discord_guild_member, ret);
+    DISCORD_ATTR_INIT(attr, discord_guild_member, ret, NULL);
 
     return discord_rest_run(&client->rest, &attr, &body, HTTP_PUT,
                             "/guilds/%" PRIu64 "/members/%" PRIu64, guild_id,
@@ -288,7 +288,7 @@ discord_modify_guild_member(struct discord *client,
     body.size = discord_modify_guild_member_to_json(buf, sizeof(buf), params);
     body.start = buf;
 
-    DISCORD_ATTR_INIT(attr, discord_guild_member, ret);
+    DISCORD_ATTR_INIT(attr, discord_guild_member, ret, params->reason);
 
     return discord_rest_run(&client->rest, &attr, &body, HTTP_PATCH,
                             "/guilds/%" PRIu64 "/members/%" PRIu64, guild_id,
@@ -312,7 +312,7 @@ discord_modify_current_member(struct discord *client,
         discord_modify_current_member_to_json(buf, sizeof(buf), params);
     body.start = buf;
 
-    DISCORD_ATTR_INIT(attr, discord_guild_member, ret);
+    DISCORD_ATTR_INIT(attr, discord_guild_member, ret, params->reason);
 
     return discord_rest_run(&client->rest, &attr, &body, HTTP_PATCH,
                             "/guilds/%" PRIu64 "/members/@me", guild_id);
@@ -340,7 +340,7 @@ discord_modify_current_user_nick(
         discord_modify_current_user_nick_to_json(buf, sizeof(buf), params);
     body.start = buf;
 
-    DISCORD_ATTR_INIT(attr, discord_guild_member, ret);
+    DISCORD_ATTR_INIT(attr, discord_guild_member, ret, params->reason);
 
     return discord_rest_run(&client->rest, &attr, &body, HTTP_PATCH,
                             "/guilds/%" PRIu64 "/members/@me/nick", guild_id);
@@ -351,6 +351,7 @@ discord_add_guild_member_role(struct discord *client,
                               u64snowflake guild_id,
                               u64snowflake user_id,
                               u64snowflake role_id,
+                              struct discord_add_guild_member_role *params,
                               struct discord_ret *ret)
 {
     struct discord_attributes attr = { 0 };
@@ -359,7 +360,7 @@ discord_add_guild_member_role(struct discord *client,
     CCORD_EXPECT(client, user_id != 0, CCORD_BAD_PARAMETER, "");
     CCORD_EXPECT(client, role_id != 0, CCORD_BAD_PARAMETER, "");
 
-    DISCORD_ATTR_BLANK_INIT(attr, ret);
+    DISCORD_ATTR_BLANK_INIT(attr, ret, params ? params->reason : NULL);
 
     return discord_rest_run(&client->rest, &attr, NULL, HTTP_PUT,
                             "/guilds/%" PRIu64 "/members/%" PRIu64
@@ -368,11 +369,13 @@ discord_add_guild_member_role(struct discord *client,
 }
 
 CCORDcode
-discord_remove_guild_member_role(struct discord *client,
-                                 u64snowflake guild_id,
-                                 u64snowflake user_id,
-                                 u64snowflake role_id,
-                                 struct discord_ret *ret)
+discord_remove_guild_member_role(
+    struct discord *client,
+    u64snowflake guild_id,
+    u64snowflake user_id,
+    u64snowflake role_id,
+    struct discord_remove_guild_member_role *params,
+    struct discord_ret *ret)
 {
     struct discord_attributes attr = { 0 };
 
@@ -380,7 +383,7 @@ discord_remove_guild_member_role(struct discord *client,
     CCORD_EXPECT(client, user_id != 0, CCORD_BAD_PARAMETER, "");
     CCORD_EXPECT(client, role_id != 0, CCORD_BAD_PARAMETER, "");
 
-    DISCORD_ATTR_BLANK_INIT(attr, ret);
+    DISCORD_ATTR_BLANK_INIT(attr, ret, params ? params->reason : NULL);
 
     return discord_rest_run(&client->rest, &attr, NULL, HTTP_DELETE,
                             "/guilds/%" PRIu64 "/members/%" PRIu64
@@ -392,6 +395,7 @@ CCORDcode
 discord_remove_guild_member(struct discord *client,
                             u64snowflake guild_id,
                             u64snowflake user_id,
+                            struct discord_remove_guild_member *params,
                             struct discord_ret *ret)
 {
     struct discord_attributes attr = { 0 };
@@ -399,7 +403,7 @@ discord_remove_guild_member(struct discord *client,
     CCORD_EXPECT(client, guild_id != 0, CCORD_BAD_PARAMETER, "");
     CCORD_EXPECT(client, user_id != 0, CCORD_BAD_PARAMETER, "");
 
-    DISCORD_ATTR_BLANK_INIT(attr, ret);
+    DISCORD_ATTR_BLANK_INIT(attr, ret, params ? params->reason : NULL);
 
     return discord_rest_run(&client->rest, &attr, NULL, HTTP_DELETE,
                             "/guilds/%" PRIu64 "/members/%" PRIu64, guild_id,
@@ -415,7 +419,7 @@ discord_get_guild_bans(struct discord *client,
 
     CCORD_EXPECT(client, guild_id != 0, CCORD_BAD_PARAMETER, "");
 
-    DISCORD_ATTR_LIST_INIT(attr, discord_bans, ret);
+    DISCORD_ATTR_LIST_INIT(attr, discord_bans, ret, NULL);
 
     return discord_rest_run(&client->rest, &attr, NULL, HTTP_GET,
                             "/guilds/%" PRIu64 "/bans", guild_id);
@@ -432,7 +436,7 @@ discord_get_guild_ban(struct discord *client,
     CCORD_EXPECT(client, guild_id != 0, CCORD_BAD_PARAMETER, "");
     CCORD_EXPECT(client, user_id != 0, CCORD_BAD_PARAMETER, "");
 
-    DISCORD_ATTR_INIT(attr, discord_ban, ret);
+    DISCORD_ATTR_INIT(attr, discord_ban, ret, NULL);
 
     return discord_rest_run(&client->rest, &attr, NULL, HTTP_GET,
                             "/guilds/%" PRIu64 "/bans/%" PRIu64, guild_id,
@@ -461,7 +465,7 @@ discord_create_guild_ban(struct discord *client,
     body.size = discord_create_guild_ban_to_json(buf, sizeof(buf), params);
     body.start = buf;
 
-    DISCORD_ATTR_BLANK_INIT(attr, ret);
+    DISCORD_ATTR_BLANK_INIT(attr, ret, params->reason);
 
     return discord_rest_run(&client->rest, &attr, &body, HTTP_PUT,
                             "/guilds/%" PRIu64 "/bans/%" PRIu64, guild_id,
@@ -471,6 +475,7 @@ CCORDcode
 discord_remove_guild_ban(struct discord *client,
                          u64snowflake guild_id,
                          u64snowflake user_id,
+                         struct discord_remove_guild_ban *params,
                          struct discord_ret *ret)
 {
     struct discord_attributes attr = { 0 };
@@ -478,7 +483,7 @@ discord_remove_guild_ban(struct discord *client,
     CCORD_EXPECT(client, guild_id != 0, CCORD_BAD_PARAMETER, "");
     CCORD_EXPECT(client, user_id != 0, CCORD_BAD_PARAMETER, "");
 
-    DISCORD_ATTR_BLANK_INIT(attr, ret);
+    DISCORD_ATTR_BLANK_INIT(attr, ret, params ? params->reason : NULL);
 
     return discord_rest_run(&client->rest, &attr, NULL, HTTP_DELETE,
                             "/guilds/%" PRIu64 "/bans/%" PRIu64, guild_id,
@@ -494,7 +499,7 @@ discord_get_guild_roles(struct discord *client,
 
     CCORD_EXPECT(client, guild_id != 0, CCORD_BAD_PARAMETER, "");
 
-    DISCORD_ATTR_LIST_INIT(attr, discord_roles, ret);
+    DISCORD_ATTR_LIST_INIT(attr, discord_roles, ret, NULL);
 
     return discord_rest_run(&client->rest, &attr, NULL, HTTP_GET,
                             "/guilds/%" PRIu64 "/roles", guild_id);
@@ -515,7 +520,7 @@ discord_create_guild_role(struct discord *client,
     body.size = discord_create_guild_role_to_json(buf, sizeof(buf), params);
     body.start = buf;
 
-    DISCORD_ATTR_INIT(attr, discord_role, ret);
+    DISCORD_ATTR_INIT(attr, discord_role, ret, params ? params->reason : NULL);
 
     return discord_rest_run(&client->rest, &attr, &body, HTTP_POST,
                             "/guilds/%" PRIu64 "/roles", guild_id);
@@ -539,7 +544,7 @@ discord_modify_guild_role_positions(
         discord_modify_guild_role_positions_to_json(buf, sizeof(buf), params);
     body.start = buf;
 
-    DISCORD_ATTR_LIST_INIT(attr, discord_roles, ret);
+    DISCORD_ATTR_LIST_INIT(attr, discord_roles, ret, NULL);
 
     return discord_rest_run(&client->rest, &attr, &body, HTTP_PATCH,
                             "/guilds/%" PRIu64 "/roles", guild_id);
@@ -554,19 +559,15 @@ discord_modify_guild_role(struct discord *client,
 {
     struct discord_attributes attr = { 0 };
     struct ccord_szbuf body;
-    char buf[2048] = "{}";
-    size_t len = 2;
+    char buf[2048];
 
     CCORD_EXPECT(client, guild_id != 0, CCORD_BAD_PARAMETER, "");
     CCORD_EXPECT(client, role_id != 0, CCORD_BAD_PARAMETER, "");
 
-    if (params)
-        len = discord_modify_guild_role_to_json(buf, sizeof(buf), params);
-
-    body.size = len;
+    body.size = discord_modify_guild_role_to_json(buf, sizeof(buf), params);
     body.start = buf;
 
-    DISCORD_ATTR_INIT(attr, discord_role, ret);
+    DISCORD_ATTR_INIT(attr, discord_role, ret, params ? params->reason : NULL);
 
     return discord_rest_run(&client->rest, &attr, &body, HTTP_PATCH,
                             "/guilds/%" PRIu64 "/roles/%" PRIu64, guild_id,
@@ -577,6 +578,7 @@ CCORDcode
 discord_delete_guild_role(struct discord *client,
                           u64snowflake guild_id,
                           u64snowflake role_id,
+                          struct discord_delete_guild_role *params,
                           struct discord_ret *ret)
 {
     struct discord_attributes attr = { 0 };
@@ -584,7 +586,7 @@ discord_delete_guild_role(struct discord *client,
     CCORD_EXPECT(client, guild_id != 0, CCORD_BAD_PARAMETER, "");
     CCORD_EXPECT(client, role_id != 0, CCORD_BAD_PARAMETER, "");
 
-    DISCORD_ATTR_BLANK_INIT(attr, ret);
+    DISCORD_ATTR_BLANK_INIT(attr, ret, params ? params->reason : NULL);
 
     return discord_rest_run(&client->rest, &attr, NULL, HTTP_DELETE,
                             "/guilds/%" PRIu64 "/roles/%" PRIu64, guild_id,
@@ -629,7 +631,7 @@ discord_get_guild_prune_count(struct discord *client,
         }
     }
 
-    DISCORD_ATTR_INIT(attr, discord_prune_count, ret);
+    DISCORD_ATTR_INIT(attr, discord_prune_count, ret, NULL);
 
     return discord_rest_run(&client->rest, &attr, NULL, HTTP_GET,
                             "/guilds/%" PRIu64 "/prune%s%s", guild_id,
@@ -644,18 +646,14 @@ discord_begin_guild_prune(struct discord *client,
 {
     struct discord_attributes attr = { 0 };
     struct ccord_szbuf body;
-    char buf[4096] = "{}";
-    size_t len = 2;
+    char buf[4096];
 
     CCORD_EXPECT(client, guild_id != 0, CCORD_BAD_PARAMETER, "");
 
-    if (params)
-        len = discord_begin_guild_prune_to_json(buf, sizeof(buf), params);
-
-    body.size = len;
+    body.size = discord_begin_guild_prune_to_json(buf, sizeof(buf), params);
     body.start = buf;
 
-    DISCORD_ATTR_BLANK_INIT(attr, ret);
+    DISCORD_ATTR_BLANK_INIT(attr, ret, params ? params->reason : NULL);
 
     return discord_rest_run(&client->rest, &attr, &body, HTTP_POST,
                             "/guilds/%" PRIu64 "/prune", guild_id);
@@ -670,7 +668,7 @@ discord_get_guild_voice_regions(struct discord *client,
 
     CCORD_EXPECT(client, guild_id != 0, CCORD_BAD_PARAMETER, "");
 
-    DISCORD_ATTR_LIST_INIT(attr, discord_voice_regions, ret);
+    DISCORD_ATTR_LIST_INIT(attr, discord_voice_regions, ret, NULL);
 
     return discord_rest_run(&client->rest, &attr, NULL, HTTP_GET,
                             "/guilds/%" PRIu64 "/regions", guild_id);
@@ -685,7 +683,7 @@ discord_get_guild_invites(struct discord *client,
 
     CCORD_EXPECT(client, guild_id != 0, CCORD_BAD_PARAMETER, "");
 
-    DISCORD_ATTR_LIST_INIT(attr, discord_invites, ret);
+    DISCORD_ATTR_LIST_INIT(attr, discord_invites, ret, NULL);
 
     return discord_rest_run(&client->rest, &attr, NULL, HTTP_GET,
                             "/guilds/%" PRIu64 "/invites", guild_id);
@@ -700,24 +698,26 @@ discord_get_guild_integrations(struct discord *client,
 
     CCORD_EXPECT(client, guild_id != 0, CCORD_BAD_PARAMETER, "");
 
-    DISCORD_ATTR_LIST_INIT(attr, discord_integrations, ret);
+    DISCORD_ATTR_LIST_INIT(attr, discord_integrations, ret, NULL);
 
     return discord_rest_run(&client->rest, &attr, NULL, HTTP_GET,
                             "/guilds/%" PRIu64 "/integrations", guild_id);
 }
 
 CCORDcode
-discord_delete_guild_integrations(struct discord *client,
-                                  u64snowflake guild_id,
-                                  u64snowflake integration_id,
-                                  struct discord_ret *ret)
+discord_delete_guild_integrations(
+    struct discord *client,
+    u64snowflake guild_id,
+    u64snowflake integration_id,
+    struct discord_delete_guild_integrations *params,
+    struct discord_ret *ret)
 {
     struct discord_attributes attr = { 0 };
 
     CCORD_EXPECT(client, guild_id != 0, CCORD_BAD_PARAMETER, "");
     CCORD_EXPECT(client, integration_id != 0, CCORD_BAD_PARAMETER, "");
 
-    DISCORD_ATTR_BLANK_INIT(attr, ret);
+    DISCORD_ATTR_BLANK_INIT(attr, ret, params ? params->reason : NULL);
 
     return discord_rest_run(&client->rest, &attr, NULL, HTTP_DELETE,
                             "/guilds/%" PRIu64 "/integrations/%" PRIu64,
@@ -734,7 +734,7 @@ discord_get_guild_widget_settings(
 
     CCORD_EXPECT(client, guild_id != 0, CCORD_BAD_PARAMETER, "");
 
-    DISCORD_ATTR_INIT(attr, discord_guild_widget_settings, ret);
+    DISCORD_ATTR_INIT(attr, discord_guild_widget_settings, ret, NULL);
 
     return discord_rest_run(&client->rest, &attr, NULL, HTTP_GET,
                             "/guilds/%" PRIu64 "/widget", guild_id);
@@ -757,7 +757,8 @@ discord_modify_guild_widget(struct discord *client,
         discord_guild_widget_settings_to_json(buf, sizeof(buf), params);
     body.start = buf;
 
-    DISCORD_ATTR_INIT(attr, discord_guild_widget_settings, ret);
+    DISCORD_ATTR_INIT(attr, discord_guild_widget_settings, ret,
+                      params->reason);
 
     return discord_rest_run(&client->rest, &attr, &body, HTTP_PATCH,
                             "/guilds/%" PRIu64 "/widget", guild_id);
@@ -772,7 +773,7 @@ discord_get_guild_widget(struct discord *client,
 
     CCORD_EXPECT(client, guild_id != 0, CCORD_BAD_PARAMETER, "");
 
-    DISCORD_ATTR_INIT(attr, discord_guild_widget_settings, ret);
+    DISCORD_ATTR_INIT(attr, discord_guild_widget_settings, ret, NULL);
 
     return discord_rest_run(&client->rest, &attr, NULL, HTTP_GET,
                             "/guilds/%" PRIu64 "/widget.json", guild_id);
@@ -787,7 +788,7 @@ discord_get_guild_vanity_url(struct discord *client,
 
     CCORD_EXPECT(client, guild_id != 0, CCORD_BAD_PARAMETER, "");
 
-    DISCORD_ATTR_INIT(attr, discord_invite, ret);
+    DISCORD_ATTR_INIT(attr, discord_invite, ret, NULL);
 
     return discord_rest_run(&client->rest, &attr, NULL, HTTP_GET,
                             "/guilds/%" PRIu64 "/vanity-url", guild_id);
@@ -806,7 +807,7 @@ discord_get_guild_widget_image(struct discord *client,
 
     CCORD_EXPECT(client, guild_id != 0, CCORD_BAD_PARAMETER, "");
 
-    DISCORD_ATTR_BLANK_INIT(attr, ret);
+    DISCORD_ATTR_BLANK_INIT(attr, ret, NULL);
 
     return discord_rest_run(&client->rest, &attr, NULL, HTTP_GET,
                             "/guilds/%" PRIu64 "/widget.png%s%s", guild_id,
@@ -823,7 +824,7 @@ discord_get_guild_welcome_screen(struct discord *client,
 
     CCORD_EXPECT(client, guild_id != 0, CCORD_BAD_PARAMETER, "");
 
-    DISCORD_ATTR_INIT(attr, discord_welcome_screen, ret);
+    DISCORD_ATTR_INIT(attr, discord_welcome_screen, ret, NULL);
 
     return discord_rest_run(&client->rest, &attr, NULL, HTTP_GET,
                             "/guilds/%" PRIu64 "/welcome-screen", guild_id);
@@ -846,7 +847,8 @@ discord_modify_guild_welcome_screen(
         discord_modify_guild_welcome_screen_to_json(buf, sizeof(buf), params);
     body.start = buf;
 
-    DISCORD_ATTR_INIT(attr, discord_welcome_screen, ret);
+    DISCORD_ATTR_INIT(attr, discord_welcome_screen, ret,
+                      params ? params->reason : NULL);
 
     return discord_rest_run(&client->rest, &attr, &body, HTTP_PATCH,
                             "/guilds/%" PRIu64 "/welcome-screen", guild_id);
@@ -869,7 +871,7 @@ discord_modify_current_user_voice_state(
         buf, sizeof(buf), params);
     body.start = buf;
 
-    DISCORD_ATTR_BLANK_INIT(attr, ret);
+    DISCORD_ATTR_BLANK_INIT(attr, ret, NULL);
 
     return discord_rest_run(&client->rest, &attr, &body, HTTP_PATCH,
                             "/guilds/%" PRIu64 "/voice-states/@me", guild_id);
@@ -892,7 +894,7 @@ discord_modify_user_voice_state(struct discord *client,
         discord_modify_user_voice_state_to_json(buf, sizeof(buf), params);
     body.start = buf;
 
-    DISCORD_ATTR_BLANK_INIT(attr, ret);
+    DISCORD_ATTR_BLANK_INIT(attr, ret, NULL);
 
     return discord_rest_run(&client->rest, &attr, &body, HTTP_PATCH,
                             "/guilds/%" PRIu64 "/voice-states/%" PRIu64,

--- a/src/guild_scheduled_event.c
+++ b/src/guild_scheduled_event.c
@@ -19,7 +19,7 @@ discord_list_guild_scheduled_events(
 
     CCORD_EXPECT(client, guild_id != 0, CCORD_BAD_PARAMETER, "");
 
-    DISCORD_ATTR_LIST_INIT(attr, discord_guild_scheduled_events, ret);
+    DISCORD_ATTR_LIST_INIT(attr, discord_guild_scheduled_events, ret, NULL);
 
     return discord_rest_run(&client->rest, &attr, NULL, HTTP_GET,
                             "/guilds/%" PRIu64 "/scheduled-events%s", guild_id,
@@ -45,7 +45,8 @@ discord_create_guild_scheduled_event(
                  CCORD_BAD_PARAMETER, "");
     CCORD_EXPECT(client, params->entity_type != 0, CCORD_BAD_PARAMETER, "");
 
-    DISCORD_ATTR_INIT(attr, discord_guild_scheduled_event, ret);
+    DISCORD_ATTR_INIT(attr, discord_guild_scheduled_event, ret,
+                      params->reason);
 
     body.size =
         discord_create_guild_scheduled_event_to_json(buf, sizeof(buf), params);
@@ -71,7 +72,7 @@ discord_get_guild_scheduled_event(
     CCORD_EXPECT(client, guild_scheduled_event_id != 0, CCORD_BAD_PARAMETER,
                  "");
 
-    DISCORD_ATTR_INIT(attr, discord_guild_scheduled_event, ret);
+    DISCORD_ATTR_INIT(attr, discord_guild_scheduled_event, ret, NULL);
 
     return discord_rest_run(&client->rest, &attr, NULL, HTTP_GET,
                             "/guilds/%" PRIu64 "/scheduled-events/%" PRIu64
@@ -95,7 +96,8 @@ discord_modify_guild_scheduled_event(
     CCORD_EXPECT(client, guild_scheduled_event_id != 0, CCORD_BAD_PARAMETER,
                  "");
 
-    DISCORD_ATTR_INIT(attr, discord_guild_scheduled_event, ret);
+    DISCORD_ATTR_INIT(attr, discord_guild_scheduled_event, ret,
+                      params ? params->reason : NULL);
 
     body.size =
         discord_modify_guild_scheduled_event_to_json(buf, sizeof(buf), params);
@@ -118,7 +120,7 @@ discord_delete_guild_scheduled_event(struct discord *client,
     CCORD_EXPECT(client, guild_scheduled_event_id != 0, CCORD_BAD_PARAMETER,
                  "");
 
-    DISCORD_ATTR_BLANK_INIT(attr, ret);
+    DISCORD_ATTR_BLANK_INIT(attr, ret, NULL);
 
     return discord_rest_run(&client->rest, &attr, NULL, HTTP_DELETE,
                             "/guilds/%" PRIu64 "/scheduled-events/%" PRIu64,
@@ -168,7 +170,8 @@ discord_get_guild_scheduled_event_users(
         }
     }
 
-    DISCORD_ATTR_LIST_INIT(attr, discord_guild_scheduled_event_users, ret);
+    DISCORD_ATTR_LIST_INIT(attr, discord_guild_scheduled_event_users, ret,
+                           NULL);
 
     return discord_rest_run(
         &client->rest, &attr, NULL, HTTP_GET,

--- a/src/guild_template.c
+++ b/src/guild_template.c
@@ -13,10 +13,10 @@ discord_get_guild_template(struct discord *client,
 {
     struct discord_attributes attr = { 0 };
 
-    CCORD_EXPECT(
-        client, NOT_EMPTY_STR(template_code), CCORD_BAD_PARAMETER, "");
+    CCORD_EXPECT(client, NOT_EMPTY_STR(template_code), CCORD_BAD_PARAMETER,
+                 "");
 
-    DISCORD_ATTR_INIT(attr, discord_guild_template, ret);
+    DISCORD_ATTR_INIT(attr, discord_guild_template, ret, NULL);
 
     return discord_rest_run(&client->rest, &attr, NULL, HTTP_GET,
                             "/guilds/templates/%s", template_code);
@@ -33,15 +33,14 @@ discord_create_guild_from_guild_template(
     struct ccord_szbuf body;
     char buf[256] = { 0 };
 
-    CCORD_EXPECT(
-        client,  NOT_EMPTY_STR(template_code), CCORD_BAD_PARAMETER, "");
+    CCORD_EXPECT(client, NOT_EMPTY_STR(template_code), CCORD_BAD_PARAMETER,
+                 "");
 
-    body.size =
-        discord_create_guild_from_guild_template_to_json(
-            buf, sizeof(buf), params);
+    body.size = discord_create_guild_from_guild_template_to_json(
+        buf, sizeof(buf), params);
     body.start = buf;
 
-    DISCORD_ATTR_INIT(attr, discord_guild, ret);
+    DISCORD_ATTR_INIT(attr, discord_guild, ret, NULL);
 
     return discord_rest_run(&client->rest, &attr, &body, HTTP_POST,
                             "/guilds/templates/%s", template_code);
@@ -56,7 +55,7 @@ discord_get_guild_templates(struct discord *client,
 
     CCORD_EXPECT(client, guild_id != 0, CCORD_BAD_PARAMETER, "");
 
-    DISCORD_ATTR_LIST_INIT(attr, discord_guild_templates, ret);
+    DISCORD_ATTR_LIST_INIT(attr, discord_guild_templates, ret, NULL);
 
     return discord_rest_run(&client->rest, &attr, NULL, HTTP_GET,
                             "/guilds/%" PRIu64 "/templates", guild_id);
@@ -78,7 +77,7 @@ discord_create_guild_template(struct discord *client,
         discord_create_guild_template_to_json(buf, sizeof(buf), params);
     body.start = buf;
 
-    DISCORD_ATTR_INIT(attr, discord_guild_template, ret);
+    DISCORD_ATTR_INIT(attr, discord_guild_template, ret, NULL);
 
     return discord_rest_run(&client->rest, &attr, &body, HTTP_POST,
                             "/guilds/%" PRIu64 "/templates", guild_id);
@@ -93,10 +92,10 @@ discord_sync_guild_template(struct discord *client,
     struct discord_attributes attr = { 0 };
 
     CCORD_EXPECT(client, guild_id != 0, CCORD_BAD_PARAMETER, "");
-    CCORD_EXPECT(
-        client, NOT_EMPTY_STR(template_code), CCORD_BAD_PARAMETER, "");
+    CCORD_EXPECT(client, NOT_EMPTY_STR(template_code), CCORD_BAD_PARAMETER,
+                 "");
 
-    DISCORD_ATTR_INIT(attr, discord_guild_template, ret);
+    DISCORD_ATTR_INIT(attr, discord_guild_template, ret, NULL);
 
     return discord_rest_run(&client->rest, &attr, NULL, HTTP_PUT,
                             "/guilds/%" PRIu64 "/templates/%s", guild_id,
@@ -115,14 +114,14 @@ discord_modify_guild_template(struct discord *client,
     char buf[1024] = { 0 };
 
     CCORD_EXPECT(client, guild_id != 0, CCORD_BAD_PARAMETER, "");
-    CCORD_EXPECT(
-        client, NOT_EMPTY_STR(template_code), CCORD_BAD_PARAMETER, "");
+    CCORD_EXPECT(client, NOT_EMPTY_STR(template_code), CCORD_BAD_PARAMETER,
+                 "");
 
     body.size =
         discord_modify_guild_template_from_json(buf, sizeof(buf), params);
     body.start = buf;
 
-    DISCORD_ATTR_INIT(attr, discord_guild_template, ret);
+    DISCORD_ATTR_INIT(attr, discord_guild_template, ret, NULL);
 
     return discord_rest_run(&client->rest, &attr, &body, HTTP_PATCH,
                             "/guilds/%" PRIu64 "/templates/%s", guild_id,
@@ -138,10 +137,10 @@ discord_delete_guild_template(struct discord *client,
     struct discord_attributes attr = { 0 };
 
     CCORD_EXPECT(client, guild_id != 0, CCORD_BAD_PARAMETER, "");
-    CCORD_EXPECT(
-        client, NOT_EMPTY_STR(template_code), CCORD_BAD_PARAMETER, "");
+    CCORD_EXPECT(client, NOT_EMPTY_STR(template_code), CCORD_BAD_PARAMETER,
+                 "");
 
-    DISCORD_ATTR_INIT(attr, discord_guild_template, ret);
+    DISCORD_ATTR_INIT(attr, discord_guild_template, ret, NULL);
 
     return discord_rest_run(&client->rest, &attr, NULL, HTTP_DELETE,
                             "/guilds/%" PRIu64 "/templates/%s", guild_id,

--- a/src/interaction.c
+++ b/src/interaction.c
@@ -36,7 +36,7 @@ discord_create_interaction_response(
     body.size = discord_interaction_response_to_json(buf, sizeof(buf), params);
     body.start = buf;
 
-    DISCORD_ATTR_INIT(attr, discord_interaction_response, ret);
+    DISCORD_ATTR_INIT(attr, discord_interaction_response, ret, NULL);
 
     return discord_rest_run(&client->rest, &attr, &body, method,
                             "/interactions/%" PRIu64 "/%s/callback",
@@ -56,7 +56,7 @@ discord_get_original_interaction_response(
     CCORD_EXPECT(client, NOT_EMPTY_STR(interaction_token), CCORD_BAD_PARAMETER,
                  "");
 
-    DISCORD_ATTR_INIT(attr, discord_interaction_response, ret);
+    DISCORD_ATTR_INIT(attr, discord_interaction_response, ret, NULL);
 
     return discord_rest_run(&client->rest, &attr, NULL, HTTP_GET,
                             "/webhooks/%" PRIu64 "/%s/messages/@original",
@@ -94,7 +94,7 @@ discord_edit_original_interaction_response(
         buf, sizeof(buf), params);
     body.start = buf;
 
-    DISCORD_ATTR_INIT(attr, discord_interaction_response, ret);
+    DISCORD_ATTR_INIT(attr, discord_interaction_response, ret, NULL);
 
     return discord_rest_run(&client->rest, &attr, &body, method,
                             "/webhooks/%" PRIu64 "/%s/messages/@original",
@@ -113,7 +113,7 @@ discord_delete_original_interaction_response(struct discord *client,
     CCORD_EXPECT(client, NOT_EMPTY_STR(interaction_token), CCORD_BAD_PARAMETER,
                  "");
 
-    DISCORD_ATTR_BLANK_INIT(attr, ret);
+    DISCORD_ATTR_BLANK_INIT(attr, ret, NULL);
 
     return discord_rest_run(&client->rest, &attr, NULL, HTTP_DELETE,
                             "/webhooks/%" PRIu64 "/%s/messages/@original",
@@ -157,7 +157,7 @@ discord_create_followup_message(struct discord *client,
         discord_create_followup_message_to_json(buf, sizeof(buf), params);
     body.start = buf;
 
-    DISCORD_ATTR_INIT(attr, discord_webhook, ret);
+    DISCORD_ATTR_INIT(attr, discord_webhook, ret, NULL);
 
     return discord_rest_run(&client->rest, &attr, &body, method,
                             "/webhooks/%" PRIu64 "/%s%s%s", application_id,
@@ -178,7 +178,7 @@ discord_get_followup_message(struct discord *client,
                  "");
     CCORD_EXPECT(client, message_id != 0, CCORD_BAD_PARAMETER, "");
 
-    DISCORD_ATTR_INIT(attr, discord_message, ret);
+    DISCORD_ATTR_INIT(attr, discord_message, ret, NULL);
 
     return discord_rest_run(&client->rest, &attr, NULL, HTTP_GET,
                             "/webhooks/%" PRIu64 "/%s/%" PRIu64,
@@ -217,7 +217,7 @@ discord_edit_followup_message(struct discord *client,
         discord_edit_followup_message_to_json(buf, sizeof(buf), params);
     body.start = buf;
 
-    DISCORD_ATTR_INIT(attr, discord_message, ret);
+    DISCORD_ATTR_INIT(attr, discord_message, ret, NULL);
 
     return discord_rest_run(&client->rest, &attr, &body, method,
                             "/webhooks/%" PRIu64 "/%s/messages/%" PRIu64,
@@ -238,7 +238,7 @@ discord_delete_followup_message(struct discord *client,
                  "");
     CCORD_EXPECT(client, message_id != 0, CCORD_BAD_PARAMETER, "");
 
-    DISCORD_ATTR_BLANK_INIT(attr, ret);
+    DISCORD_ATTR_BLANK_INIT(attr, ret, NULL);
 
     return discord_rest_run(&client->rest, &attr, NULL, HTTP_DELETE,
                             "/webhooks/%" PRIu64 "/%s/messages/%" PRIu64,

--- a/src/invite.c
+++ b/src/invite.c
@@ -22,7 +22,7 @@ discord_get_invite(struct discord *client,
     body.size = discord_get_invite_to_json(buf, sizeof(buf), params);
     body.start = buf;
 
-    DISCORD_ATTR_INIT(attr, discord_invite, ret);
+    DISCORD_ATTR_INIT(attr, discord_invite, ret, NULL);
 
     return discord_rest_run(&client->rest, &attr, &body, HTTP_GET,
                             "/invites/%s", invite_code);
@@ -31,13 +31,15 @@ discord_get_invite(struct discord *client,
 CCORDcode
 discord_delete_invite(struct discord *client,
                       char *invite_code,
+                      struct discord_delete_invite *params,
                       struct discord_ret_invite *ret)
 {
     struct discord_attributes attr = { 0 };
 
     CCORD_EXPECT(client, NOT_EMPTY_STR(invite_code), CCORD_BAD_PARAMETER, "");
 
-    DISCORD_ATTR_INIT(attr, discord_invite, ret);
+    DISCORD_ATTR_INIT(attr, discord_invite, ret,
+                      params ? params->reason : NULL);
 
     return discord_rest_run(&client->rest, &attr, NULL, HTTP_DELETE,
                             "/invites/%s", invite_code);

--- a/src/oauth2.c
+++ b/src/oauth2.c
@@ -12,7 +12,7 @@ discord_get_current_bot_application_information(
 {
     struct discord_attributes attr = { 0 };
 
-    DISCORD_ATTR_INIT(attr, discord_application, ret);
+    DISCORD_ATTR_INIT(attr, discord_application, ret, NULL);
 
     return discord_rest_run(&client->rest, &attr, NULL, HTTP_GET,
                             "/oauth2/applications/@me");
@@ -24,7 +24,7 @@ discord_get_current_authorization_information(
 {
     struct discord_attributes attr = { 0 };
 
-    DISCORD_ATTR_INIT(attr, discord_auth_response, ret);
+    DISCORD_ATTR_INIT(attr, discord_auth_response, ret, NULL);
 
     return discord_rest_run(&client->rest, &attr, NULL, HTTP_GET,
                             "/oauth2/@me");

--- a/src/stage_instance.c
+++ b/src/stage_instance.c
@@ -21,13 +21,13 @@ discord_create_stage_instance(struct discord *client,
 
     CCORD_EXPECT(client, params != NULL, CCORD_BAD_PARAMETER, "");
     CCORD_EXPECT(client, params->channel_id != 0, CCORD_BAD_PARAMETER, "");
-    CCORD_EXPECT(
-        client, IS_NOT_EMPTY_STRING(params->topic), CCORD_BAD_PARAMETER, "");
+    CCORD_EXPECT(client, IS_NOT_EMPTY_STRING(params->topic),
+                 CCORD_BAD_PARAMETER, "");
 
     body.size = discord_create_stage_instance(buf, sizeof(buf), params);
     body.start = buf;
 
-    DISCORD_ATTR_INIT(attr, discord_stage_instance, ret);
+    DISCORD_ATTR_INIT(attr, discord_stage_instance, ret, params->reason);
 
     return discord_rest_run(&client->rest, &attr, &body, HTTP_POST,
                             "/stage-instances");
@@ -42,7 +42,7 @@ discord_get_stage_instance(struct discord *client,
 
     CCORD_EXPECT(client, channel_id != 0, CCORD_BAD_PARAMETER, "");
 
-    DISCORD_ATTR_INIT(attr, discord_stage_instance, ret);
+    DISCORD_ATTR_INIT(attr, discord_stage_instance, ret, NULL);
 
     return discord_rest_run(&client->rest, &attr, NULL, HTTP_GET,
                             "/stage-instances/%" PRIu64, channel_id);
@@ -63,7 +63,7 @@ discord_modify_stage_instance(struct discord *client,
     body.size = discord_modify_stage_instance(buf, sizeof(buf), params);
     body.start = buf;
 
-    DISCORD_ATTR_INIT(attr, discord_stage_instance, ret);
+    DISCORD_ATTR_INIT(attr, discord_stage_instance, ret, params->reason);
 
     return discord_rest_run(&client->rest, &attr, &body, HTTP_PATCH,
                             "/stage-instances/%" PRIu64, channel_id);
@@ -72,13 +72,14 @@ discord_modify_stage_instance(struct discord *client,
 CCORDcode
 discord_delete_stage_instance(struct discord *client,
                               u64snowflake channel_id,
+                              struct discord_delete_stage_instance *params,
                               struct discord_ret *ret)
 {
     struct discord_attributes attr = { 0 };
 
     CCORD_EXPECT(client, channel_id != 0, CCORD_BAD_PARAMETER, "");
 
-    DISCORD_ATTR_BLANK_INIT(attr, ret);
+    DISCORD_ATTR_BLANK_INIT(attr, ret, params ? params->reason : NULL);
 
     return discord_rest_run(&client->rest, &attr, NULL, HTTP_DELETE,
                             "/stage-instances/%" PRIu64, channel_id);

--- a/src/sticker.c
+++ b/src/sticker.c
@@ -19,7 +19,7 @@ discord_get_sticker(struct discord *client,
 
     CCORD_EXPECT(client, sticker_id != 0, CCORD_BAD_PARAMETER, "");
 
-    DISCORD_ATTR_INIT(attr, discord_sticker, ret);
+    DISCORD_ATTR_INIT(attr, discord_sticker, ret, NULL);
 
     return discord_rest_run(&client->rest, &attr, NULL, HTTP_GET,
                             "/stickers/%" PRIu64, sticker_id);
@@ -27,12 +27,11 @@ discord_get_sticker(struct discord *client,
 
 CCORDcode
 discord_list_nitro_sticker_packs(
-    struct discord *client,
-    struct discord_ret_list_nitro_sticker_packs *ret)
+    struct discord *client, struct discord_ret_list_nitro_sticker_packs *ret)
 {
     struct discord_attributes attr = { 0 };
 
-    DISCORD_ATTR_INIT(attr, discord_list_nitro_sticker_packs, ret);
+    DISCORD_ATTR_INIT(attr, discord_list_nitro_sticker_packs, ret, NULL);
 
     return discord_rest_run(&client->rest, &attr, NULL, HTTP_GET,
                             "/sticker-packs");
@@ -47,7 +46,7 @@ discord_list_guild_stickers(struct discord *client,
 
     CCORD_EXPECT(client, guild_id != 0, CCORD_BAD_PARAMETER, "");
 
-    DISCORD_ATTR_LIST_INIT(attr, discord_stickers, ret);
+    DISCORD_ATTR_LIST_INIT(attr, discord_stickers, ret, NULL);
 
     return discord_rest_run(&client->rest, &attr, NULL, HTTP_GET,
                             "/guilds/%" PRIu64 "/stickers", guild_id);
@@ -64,11 +63,11 @@ discord_get_guild_sticker(struct discord *client,
     CCORD_EXPECT(client, guild_id != 0, CCORD_BAD_PARAMETER, "");
     CCORD_EXPECT(client, sticker_id != 0, CCORD_BAD_PARAMETER, "");
 
-    DISCORD_ATTR_INIT(attr, discord_sticker, ret);
+    DISCORD_ATTR_INIT(attr, discord_sticker, ret, NULL);
 
     return discord_rest_run(&client->rest, &attr, NULL, HTTP_GET,
-                            "/guilds/%" PRIu64 "/stickers/%" PRIu64,
-                            guild_id, sticker_id);
+                            "/guilds/%" PRIu64 "/stickers/%" PRIu64, guild_id,
+                            sticker_id);
 }
 
 CCORDcode
@@ -88,17 +87,19 @@ discord_modify_guild_sticker(struct discord *client,
     body.size = discord_modify_guild_sticker_to_json(buf, sizeof(buf), params);
     body.start = buf;
 
-    DISCORD_ATTR_INIT(attr, discord_sticker, ret);
+    DISCORD_ATTR_INIT(attr, discord_sticker, ret,
+                      params ? params->reason : NULL);
 
     return discord_rest_run(&client->rest, &attr, &body, HTTP_PATCH,
-                            "/guilds/%" PRIu64 "/stickers/%" PRIu64,
-                            guild_id, sticker_id);
+                            "/guilds/%" PRIu64 "/stickers/%" PRIu64, guild_id,
+                            sticker_id);
 }
 
 CCORDcode
 discord_delete_guild_sticker(struct discord *client,
                              u64snowflake guild_id,
                              u64snowflake sticker_id,
+                             struct discord_delete_guild_sticker *params,
                              struct discord_ret *ret)
 {
     struct discord_attributes attr = { 0 };
@@ -106,9 +107,9 @@ discord_delete_guild_sticker(struct discord *client,
     CCORD_EXPECT(client, guild_id != 0, CCORD_BAD_PARAMETER, "");
     CCORD_EXPECT(client, sticker_id != 0, CCORD_BAD_PARAMETER, "");
 
-    DISCORD_ATTR_BLANK_INIT(attr, ret);
+    DISCORD_ATTR_BLANK_INIT(attr, ret, params ? params->reason : NULL);
 
     return discord_rest_run(&client->rest, &attr, NULL, HTTP_DELETE,
-                            "/guilds/%" PRIu64 "/stickers/%" PRIu64,
-                            guild_id, sticker_id);
+                            "/guilds/%" PRIu64 "/stickers/%" PRIu64, guild_id,
+                            sticker_id);
 }

--- a/src/user.c
+++ b/src/user.c
@@ -11,7 +11,7 @@ discord_get_current_user(struct discord *client, struct discord_ret_user *ret)
 {
     struct discord_attributes attr = { 0 };
 
-    DISCORD_ATTR_INIT(attr, discord_user, ret);
+    DISCORD_ATTR_INIT(attr, discord_user, ret, NULL);
 
     return discord_rest_run(&client->rest, &attr, NULL, HTTP_GET,
                             "/users/@me");
@@ -26,7 +26,7 @@ discord_get_user(struct discord *client,
 
     CCORD_EXPECT(client, user_id != 0, CCORD_BAD_PARAMETER, "");
 
-    DISCORD_ATTR_INIT(attr, discord_user, ret);
+    DISCORD_ATTR_INIT(attr, discord_user, ret, NULL);
 
     return discord_rest_run(&client->rest, &attr, NULL, HTTP_GET,
                             "/users/%" PRIu64, user_id);
@@ -46,7 +46,7 @@ discord_modify_current_user(struct discord *client,
     body.size = discord_modify_current_user_to_json(buf, sizeof(buf), params);
     body.start = buf;
 
-    DISCORD_ATTR_INIT(attr, discord_user, ret);
+    DISCORD_ATTR_INIT(attr, discord_user, ret, NULL);
 
     return discord_rest_run(&client->rest, &attr, &body, HTTP_PATCH,
                             "/users/@me");
@@ -58,7 +58,7 @@ discord_get_current_user_guilds(struct discord *client,
 {
     struct discord_attributes attr = { 0 };
 
-    DISCORD_ATTR_LIST_INIT(attr, discord_guilds, ret);
+    DISCORD_ATTR_LIST_INIT(attr, discord_guilds, ret, NULL);
 
     return discord_rest_run(&client->rest, &attr, NULL, HTTP_GET,
                             "/users/@me/guilds");
@@ -74,7 +74,7 @@ discord_leave_guild(struct discord *client,
 
     CCORD_EXPECT(client, guild_id != 0, CCORD_BAD_PARAMETER, "");
 
-    DISCORD_ATTR_BLANK_INIT(attr, ret);
+    DISCORD_ATTR_BLANK_INIT(attr, ret, NULL);
 
     return discord_rest_run(&client->rest, &attr, &body, HTTP_DELETE,
                             "/users/@me/guilds/%" PRIu64, guild_id);
@@ -94,7 +94,7 @@ discord_create_dm(struct discord *client,
     body.size = discord_create_dm_to_json(buf, sizeof(buf), params);
     body.start = buf;
 
-    DISCORD_ATTR_INIT(attr, discord_channel, ret);
+    DISCORD_ATTR_INIT(attr, discord_channel, ret, NULL);
 
     return discord_rest_run(&client->rest, &attr, &body, HTTP_POST,
                             "/users/@me/channels");
@@ -117,7 +117,7 @@ discord_create_group_dm(struct discord *client,
     body.size = discord_create_group_dm_to_json(buf, sizeof(buf), params);
     body.start = buf;
 
-    DISCORD_ATTR_INIT(attr, discord_channel, ret);
+    DISCORD_ATTR_INIT(attr, discord_channel, ret, NULL);
 
     return discord_rest_run(&client->rest, &attr, &body, HTTP_POST,
                             "/users/@me/channels");
@@ -129,7 +129,7 @@ discord_get_user_connections(struct discord *client,
 {
     struct discord_attributes attr = { 0 };
 
-    DISCORD_ATTR_LIST_INIT(attr, discord_connections, ret);
+    DISCORD_ATTR_LIST_INIT(attr, discord_connections, ret, NULL);
 
     return discord_rest_run(&client->rest, &attr, NULL, HTTP_GET,
                             "/users/@me/connections");

--- a/src/voice.c
+++ b/src/voice.c
@@ -12,7 +12,7 @@ discord_list_voice_regions(struct discord *client,
 {
     struct discord_attributes attr = { 0 };
 
-    DISCORD_ATTR_LIST_INIT(attr, discord_voice_regions, ret);
+    DISCORD_ATTR_LIST_INIT(attr, discord_voice_regions, ret, NULL);
 
     return discord_rest_run(&client->rest, &attr, NULL, HTTP_GET,
                             "/voice/regions");

--- a/src/webhook.c
+++ b/src/webhook.c
@@ -23,7 +23,7 @@ discord_create_webhook(struct discord *client,
     body.size = discord_create_webhook_to_json(buf, sizeof(buf), params);
     body.start = buf;
 
-    DISCORD_ATTR_INIT(attr, discord_webhook, ret);
+    DISCORD_ATTR_INIT(attr, discord_webhook, ret, params->reason);
 
     return discord_rest_run(&client->rest, &attr, &body, HTTP_POST,
                             "/channels/%" PRIu64 "/webhooks", channel_id);
@@ -38,7 +38,7 @@ discord_get_channel_webhooks(struct discord *client,
 
     CCORD_EXPECT(client, channel_id != 0, CCORD_BAD_PARAMETER, "");
 
-    DISCORD_ATTR_LIST_INIT(attr, discord_webhooks, ret);
+    DISCORD_ATTR_LIST_INIT(attr, discord_webhooks, ret, NULL);
 
     return discord_rest_run(&client->rest, &attr, NULL, HTTP_GET,
                             "/channels/%" PRIu64 "/webhooks", channel_id);
@@ -53,7 +53,7 @@ discord_get_guild_webhooks(struct discord *client,
 
     CCORD_EXPECT(client, guild_id != 0, CCORD_BAD_PARAMETER, "");
 
-    DISCORD_ATTR_LIST_INIT(attr, discord_webhooks, ret);
+    DISCORD_ATTR_LIST_INIT(attr, discord_webhooks, ret, NULL);
 
     return discord_rest_run(&client->rest, &attr, NULL, HTTP_GET,
                             "/guilds/%" PRIu64 "/webhooks", guild_id);
@@ -68,7 +68,7 @@ discord_get_webhook(struct discord *client,
 
     CCORD_EXPECT(client, webhook_id != 0, CCORD_BAD_PARAMETER, "");
 
-    DISCORD_ATTR_INIT(attr, discord_webhook, ret);
+    DISCORD_ATTR_INIT(attr, discord_webhook, ret, NULL);
 
     return discord_rest_run(&client->rest, &attr, NULL, HTTP_GET,
                             "/webhooks/%" PRIu64, webhook_id);
@@ -86,7 +86,7 @@ discord_get_webhook_with_token(struct discord *client,
     CCORD_EXPECT(client, NOT_EMPTY_STR(webhook_token), CCORD_BAD_PARAMETER,
                  "");
 
-    DISCORD_ATTR_INIT(attr, discord_webhook, ret);
+    DISCORD_ATTR_INIT(attr, discord_webhook, ret, NULL);
 
     return discord_rest_run(&client->rest, &attr, NULL, HTTP_GET,
                             "/webhooks/%" PRIu64 "/%s", webhook_id,
@@ -108,7 +108,8 @@ discord_modify_webhook(struct discord *client,
     body.size = discord_modify_webhook_to_json(buf, sizeof(buf), params);
     body.start = buf;
 
-    DISCORD_ATTR_INIT(attr, discord_webhook, ret);
+    DISCORD_ATTR_INIT(attr, discord_webhook, ret,
+                      params ? params->reason : NULL);
 
     return discord_rest_run(&client->rest, &attr, &body, HTTP_PATCH,
                             "/webhooks/%" PRIu64, webhook_id);
@@ -134,7 +135,7 @@ discord_modify_webhook_with_token(
         discord_modify_webhook_with_token_to_json(buf, sizeof(buf), params);
     body.start = buf;
 
-    DISCORD_ATTR_INIT(attr, discord_webhook, ret);
+    DISCORD_ATTR_INIT(attr, discord_webhook, ret, NULL);
 
     return discord_rest_run(&client->rest, &attr, &body, HTTP_PATCH,
                             "/webhooks/%" PRIu64 "/%s", webhook_id,
@@ -144,13 +145,14 @@ discord_modify_webhook_with_token(
 CCORDcode
 discord_delete_webhook(struct discord *client,
                        u64snowflake webhook_id,
+                       struct discord_delete_webhook *params,
                        struct discord_ret *ret)
 {
     struct discord_attributes attr = { 0 };
 
     CCORD_EXPECT(client, webhook_id != 0, CCORD_BAD_PARAMETER, "");
 
-    DISCORD_ATTR_BLANK_INIT(attr, ret);
+    DISCORD_ATTR_BLANK_INIT(attr, ret, params ? params->reason : NULL);
 
     return discord_rest_run(&client->rest, &attr, NULL, HTTP_DELETE,
                             "/webhooks/%" PRIu64, webhook_id);
@@ -168,7 +170,7 @@ discord_delete_webhook_with_token(struct discord *client,
     CCORD_EXPECT(client, NOT_EMPTY_STR(webhook_token), CCORD_BAD_PARAMETER,
                  "");
 
-    DISCORD_ATTR_BLANK_INIT(attr, ret);
+    DISCORD_ATTR_BLANK_INIT(attr, ret, NULL);
 
     return discord_rest_run(&client->rest, &attr, NULL, HTTP_DELETE,
                             "/webhooks/%" PRIu64 "/%s", webhook_id,
@@ -217,7 +219,7 @@ discord_execute_webhook(struct discord *client,
     body.size = discord_execute_webhook_to_json(buf, sizeof(buf), params);
     body.start = buf;
 
-    DISCORD_ATTR_BLANK_INIT(attr, ret);
+    DISCORD_ATTR_BLANK_INIT(attr, ret, NULL);
 
     return discord_rest_run(&client->rest, &attr, &body, method,
                             "/webhooks/%" PRIu64 "/%s%s%s", webhook_id,
@@ -238,7 +240,7 @@ discord_get_webhook_message(struct discord *client,
                  "");
     CCORD_EXPECT(client, message_id != 0, CCORD_BAD_PARAMETER, "");
 
-    DISCORD_ATTR_INIT(attr, discord_message, ret);
+    DISCORD_ATTR_INIT(attr, discord_message, ret, NULL);
 
     return discord_rest_run(&client->rest, &attr, NULL, HTTP_GET,
                             "/webhooks/%" PRIu64 "/%s/%" PRIu64, webhook_id,
@@ -276,7 +278,7 @@ discord_edit_webhook_message(struct discord *client,
     body.size = discord_edit_webhook_message_to_json(buf, sizeof(buf), params);
     body.start = buf;
 
-    DISCORD_ATTR_INIT(attr, discord_message, ret);
+    DISCORD_ATTR_INIT(attr, discord_message, ret, NULL);
 
     return discord_rest_run(&client->rest, &attr, &body, method,
                             "/webhooks/%" PRIu64 "/%s/messages/%" PRIu64,
@@ -297,7 +299,7 @@ discord_delete_webhook_message(struct discord *client,
                  "");
     CCORD_EXPECT(client, message_id != 0, CCORD_BAD_PARAMETER, "");
 
-    DISCORD_ATTR_BLANK_INIT(attr, ret);
+    DISCORD_ATTR_BLANK_INIT(attr, ret, NULL);
 
     return discord_rest_run(&client->rest, &attr, NULL, HTTP_DELETE,
                             "/webhooks/%" PRIu64 "/%s/messages/%" PRIu64,

--- a/test/racecond.c
+++ b/test/racecond.c
@@ -160,7 +160,7 @@ on_force_error(struct discord *client, const struct discord_message *event)
 {
     const u64snowflake FAUX_CHANNEL_ID = 123;
 
-    discord_delete_channel(client, FAUX_CHANNEL_ID,
+    discord_delete_channel(client, FAUX_CHANNEL_ID, NULL,
                            &(struct discord_ret_channel){
                                .fail = &fail_delete_channel,
                                .keep = event,

--- a/test/rest.c
+++ b/test/rest.c
@@ -65,7 +65,7 @@ check_sync_trigger_error_on_bogus_parameter(void)
     struct discord_ret_channel ret = { 0 };
 
     ret.sync = DISCORD_SYNC_FLAG;
-    ASSERT_NEQ(CCORD_OK, discord_delete_channel(CLIENT, BOGUS_ID, &ret));
+    ASSERT_NEQ(CCORD_OK, discord_delete_channel(CLIENT, BOGUS_ID, NULL, &ret));
 
     PASS();
 }
@@ -167,7 +167,7 @@ check_async_trigger_error_on_bogus_parameter(void)
     ret.done = (DONE1_CAST(struct discord_channel))on_done1;
     ret.fail = on_done;
     ret.data = &result;
-    discord_delete_channel(CLIENT, BOGUS_ID, &ret);
+    discord_delete_channel(CLIENT, BOGUS_ID, NULL, &ret);
 
     discord_run(CLIENT);
     ASSERT_NEQ(CCORD_OK, result);


### PR DESCRIPTION
## What?
Add support for the `X-Audit-Log-Reason` header.

## Why?
The `X-Audit-Log-Reason` header allows providing context to the request being performed, which is then added to the guild's Audit Log. This is a great management feature to have.

## How?
Add an optional `reason` parameter for requests that support it. This seemingly small change is breaking since it affects a couple of function signatures that didn't have `params` prior.

## Testing?
`examples/` and `test/` executables have been updated to take advantage of this header, and this new feature has been tested against those.

## Anything Else?
The reason gets logged as expected for `POST` and `PUT` requests. For some reason, there have been `DELETE` requests that didn't get their `reason` logged, even though it's being sent.