### PR TITLE
feat: in-code specification of logging settings

### DIFF
--- a/core/logconf.c
+++ b/core/logconf.c
@@ -14,8 +14,8 @@
 #include "jsmn.h"
 #include "jsmn-find.h"
 
-static int
-_logconf_eval_level(char level[])
+int
+_logconf_eval_level(const char *level)
 {
     if (0 == strcasecmp(level, "TRACE")) return LOG_TRACE;
     if (0 == strcasecmp(level, "DEBUG")) return LOG_DEBUG;
@@ -27,7 +27,7 @@ _logconf_eval_level(char level[])
     return 0; /* make compiler happy */
 }
 
-static void
+void
 _log_nocolor_cb(log_Event *ev)
 {
     char buf[16];
@@ -42,7 +42,7 @@ _log_nocolor_cb(log_Event *ev)
     fflush(ev->udata);
 }
 
-static void
+void
 _log_color_cb(log_Event *ev)
 {
     char buf[16];

--- a/core/logconf.c
+++ b/core/logconf.c
@@ -58,7 +58,7 @@ _log_color_cb(log_Event *ev)
     fflush(ev->udata);
 }
 
-static void
+void
 _logconf_check_disabled(struct logconf *conf)
 {
     int i;

--- a/core/logconf.h
+++ b/core/logconf.h
@@ -383,6 +383,28 @@ void logconf_add_callback(struct logconf *conf,
  */
 int logconf_add_fp(struct logconf *conf, FILE *fp, int level);
 
+/**
+ * @brief Log to an event without using colored data
+ *
+ * @param log_Event the log event to log to
+ */
+void _log_nocolor_cb(log_Event *ev);
+
+
+/**
+ * @brief Log to an event using colored data
+ *
+ * @param log_Event the log event to log to
+ */
+void _log_color_cb(log_Event *ev);
+
+/**
+ * @brief Convert a string log level to its integer form
+ *
+ * @param level the level string to convert
+ */
+int _logconf_eval_level(const char *level);
+
 #ifdef __cplusplus
 }
 #endif /* __cplusplus */

--- a/core/logconf.h
+++ b/core/logconf.h
@@ -405,6 +405,14 @@ void _log_color_cb(log_Event *ev);
  */
 int _logconf_eval_level(const char *level);
 
+/**
+ * @brief Disable the logger irregardless of the settings
+ *  brief provided by the user if the module is disabled.
+ *
+ * @param conf the logconf structure to check
+ */
+void _logconf_check_disabled(struct logconf *conf);
+
 #ifdef __cplusplus
 }
 #endif /* __cplusplus */

--- a/include/discord.h
+++ b/include/discord.h
@@ -97,6 +97,14 @@ struct discord;
 /** Couldn't establish connection to Discord */
 #define CCORD_DISCORD_CONNECTION 4
 
+/* TODO:
+ *
+ * - Make enumerations for log level
+ * - Document settings structure
+ * - Document discord_settings_init function
+ * - Modify discord_config_init to use discord_settings_init
+*/
+
 struct discord_settings {
     struct {
         const char *level;
@@ -120,6 +128,8 @@ struct discord_settings {
         } default_prefix;
     } discord;
 };
+
+struct discord *discord_settings_init(struct discord_settings *settings);
 
 /**
  * @brief Return a Concord's error

--- a/include/discord.h
+++ b/include/discord.h
@@ -97,6 +97,30 @@ struct discord;
 /** Couldn't establish connection to Discord */
 #define CCORD_DISCORD_CONNECTION 4
 
+struct discord_settings {
+    struct {
+        const char *level;
+        const char *filename;
+        bool quiet;
+        bool overwrite;
+        bool use_color;
+        const char **disable_modules;
+
+        struct {
+            bool enable;
+            const char *filename;
+        } http;
+    } logging;
+
+    struct {
+        const char *token;
+        struct {
+            bool enable;
+            const char *prefix; 
+        } default_prefix;
+    } discord;
+};
+
 /**
  * @brief Return a Concord's error
  * @note used to log and return an error

--- a/src/discord-client.c
+++ b/src/discord-client.c
@@ -102,6 +102,38 @@ discord_init(const char token[])
     return new_client;
 }
 
+struct discord *discord_settings_init(struct discord_settings *settings) {
+    struct discord *new_client;
+
+    /* TODO: validate all settings provided to make sure they're 
+     * not troublesome */
+
+    /* Transfer the settings from the settings structure into the
+     * configuration structure. */
+
+    new_client = calloc(1, sizeof *new_client);
+    _discord_init(new_client);
+
+    /* Set basic output file configuration if we have a
+     * filename configured. This tells the logger the actual name
+     * of the logging file, as well as a file pointer to it. */
+    if(settings->logging.filename) {
+        new_client->conf.logger->fname = strdup(settings->logging.filename);
+
+        /* We open in w+ if we want to overwrite it, since w+ flushes the
+         * file */
+        new_client->conf.logger->f = fopen(new_client->conf.logger->fname, settings->logging.overwrite ? "w+" : "a+");
+
+        /* We now add a callback for the client's logger configuration,
+         * which needs to know whether or not it can show color. */
+        logconf_add_callback(&(new_client->conf),
+                             settings->logging.use_color ? _log_color_cb : _log_nocolor_cb,
+                             new_client->conf.logger->f, _logconf_eval_level(settings->logging.level));
+    }
+
+    return new_client;
+}
+
 struct discord *
 discord_config_init(const char config_file[])
 {


### PR DESCRIPTION
## Notice
- [x] I *understand* the code that I have edited, and have the means
to test it before making changes to Concord.

## What?
Add in-code specification of logging settings like logging level, filename, etc.

## Why?
To satisfy issue #100 

## How?
I have done this by introducing two new main things:
- A new structure (`discord_settings`)
- A new function (`discord_settings_init`)

The `discord_settings` structure will hold all of the in-code settings that should be used to
initialize a new client, while `discord_settings_init` function will apply those settings and
initialize a new client.

## Testing?
Currently, I have not written any sanity checks for the contents of the settings array. That will be done
at a later time.