### PR TITLE
Several additional guides and a documentation overhaul

### DIFF
--- a/docs/guides/compiling_on_windows.md
+++ b/docs/guides/compiling_on_windows.md
@@ -3,7 +3,10 @@
 Concord supports Windows natively using Cygwin and Mingw64. It is preferred 
 that you use Cygwin if possible, even if it requires runtime dependencies 
 (a variety of DLLs from /bin, namely `cygwin1.dll`). Mingw64 will produce a 
-build that runs without any dependencies. 
+build that runs without any dependencies. However, you should note that
+Mingw64's wrapping of the `poll` and `select` functions is inferior compared
+to how Cygwin does it, so, Cygwin will yield much better results for
+"production-quality bots."
 
 ## Cygwin and Dependencies
 
@@ -14,14 +17,22 @@ to install. The following packages are required at a minimum:
 - make
 - libcurl-devel
 
+This will cause all of the associated dependencies (like OpenSSL and a few 
+others) to be automatically installed. Simply follow through the dialog and
+wait for everything to install. **Remember to keep that installer program
+handy, you will need it to install any further packages.**
+
 You might also want to install git and vim. Please note that because Cygwin 
 stores its files on your Windows machine's filesystem, you can run 
-`explorer.exe .` anytime to open a Windows Explorer window in your current 
+`explorer.exe .` at any time to open a Windows Explorer window in your current 
 directory. You can use any IDE you would like to use, but you will still have
- to enter `make` to recompile your changes from the Cygwin terminal.
+to enter `make` to recompile your changes from the Cygwin terminal. If you'd
+like to open Visual Studio Code, enter `code .` into the shell, and, assuming
+VS Code is in your path, it'll open at the current directory path from which
+it was ran. 
 
 It is also possible to use a clang-based compiler, but there is little reason 
-to do so. Simply pass `CC=clang make` to your Cygwin shell and Clang will be 
+to do so. Simply pass `make CC=clang` to your Cygwin shell and Clang will be 
 used in lieu of GNU C.
 
 ## Microsoft Visual C/C++
@@ -29,7 +40,8 @@ used in lieu of GNU C.
 As it stands right now, MSVC is not supported at all. At the current instant, 
 Concord's Makefiles are for UNIX systems, and does not produce anything when
 ran with `nmake`. This will change in the near future.  However, Concord itself
-cannot be compiled with MSVC, due to a lack of POSIX compliance on behalf of Windows. 
+cannot be compiled with MSVC, due to a lack of POSIX compliance on behalf of 
+Windows. 
 
 ## Other compilers
 
@@ -41,4 +53,6 @@ The following compilers are **not** supported:
 - Intel C++
 - AMD Optimizing C++ (Clang-based, untested)
 
-Generally speaking, your compiler must implement C99 features. The compilers listed above don't support C99 completely.
+Generally speaking, your compiler must implement C99 features. The compilers 
+listed above don't support C99 completely, or lack POSIX compatibility where
+it matters (POSIX threads, `poll` and `select`, and headers being nonstandard).

--- a/docs/guides/concord_on_old_systems.md
+++ b/docs/guides/concord_on_old_systems.md
@@ -1,0 +1,91 @@
+# Running Concord on old systems
+
+*This guide will show you how to run Concord on some really out-of-date machines, mainly old UNIX systems. This guide will assume
+that you are already familiar with the operation of the old UNIX system you wish to run this on.*
+
+## Sun Workstations and Servers -- Solaris: Sun Solaris 9 on SPARC or x86
+
+For the most part, running Concord on old versions of Solaris is not too difficult. Compilation with GCC is trivial, but, somewhat
+boring. For this guide, we will use the Sun C compiler; this compiler is derived from the UNIX System V Release 4.2 "acomp" compiler
+(as it is named by the error messages, source code, and internal UNIX documentation). Now, this guide will already assume that you
+have Sun WorkShop or Sun Studio installed (you *do* need a C99 compiler here, so, Sun Studio 11 from 2008 will do). 
+
+Once you've gotten Sun Studio installed somewhere, presumably /opt/SUNWspro, add /opt/SUNWspro/bin to your path. Make a test 
+program to verify that the compiler works, and compile the following programs, in this order:
+- GNU Make 3.77+
+- GNU Bash 2.4+
+- OpenSSL 0.9+
+- cURL 4.74.1+
+
+Please note that you **must** compile cURL with some kind of SSL certificate directory, as it is always a bad idea to disable
+certificate verification. Since you are probably running Solaris 9, you will definitely need updated SSL certificates. You can 
+get these from NetBSD's pkgsrc project, search for a root certificates package. Once you have those installed to somewhere
+suitable, like, `/etc/ssl/certificates`, configure cURL with that SSL certificate directory; don't forget to tell it to use 
+OpenSSL. You will need to run the configure script with Bash, and build it using GNU Make. 
+
+Once all of that is done, you can now build Concord. You *will* need to supply a different set of LDFLAGS, like so:
+```
+LDFLAGS=-L/usr/local/lib -ldiscord -lcurl -lpthread -lssl -lsocket -lcrypto -lnsl -lz -lrt
+```
+This is assuming that your OpenSSL and cURL libraries are in `/usr/local/lib`. If they aren't, supply the correct path. Once you
+have made the edits to that Makefile, simply run `make` and verify that everything worked. Once it finishes, run `make install`
+(as root) and you should now have a working Concord installation on Solaris, compiled with a compiler besides GCC. 
+
+### Caveats and problems you might have
+
+While Concord can compile under old Solaris systems using Sun Studio's compiler, you might need to make some adjustments to the 
+source to get it to compile perfectly. The `gencodecs` system will be, for sure, the biggest source of trouble. While it can be
+preprocessed right on Solaris, you might need to use the GNU C preprocessor. `cc -E` might not work (depending on your compiler
+version), so, substitute in `cpp` for `cc -E` and try that too. **You are probably going to run into SSL problems.** Welcome to
+old versions of OpenSSL; you might want to try the newest version you can. If all else fails, point it at a Fosscord instance, and
+don't expose it to the open internet.
+
+
+
+### DEC Alpha Systems -- OSF/1: DEC OSF/1 AXP, DEC DIGITAL UNIX, Compaq/HP Tru64 UNIX
+For the most part, the instructions listed above will also apply here. The hard part is going to be finding and installing the
+latest version of the compiler. Tru64 5.1B6 is the latest OS version, and the compiler that is included with the OS is fully
+C99 compliant. Fortunately, the compiler for Tru64 5.1B works on 5.0, and, if you are very clever, 4.0G. Nonetheless, I recommend
+that you compile a binary on 5.1 and run it on anything older if you must use an older OS version. 
+
+
+
+### HP 9000 UNIX Systems -- HP-UX: HP-UX 11.11 on PA-RISC
+HP aCC is supposed to be C99 compliant, but, you might run into problems. If you have a GCC toolchain available on your machine,
+I highly recommend that you just use that, as aCC is slow and painful. Either way, you'll need to compile everything shown above,
+especially OpenSSL.
+
+
+### DEC VAX Systems -- NetBSD: NetBSD 9 on a MicroVAX, VAXstation, or VAX-11
+*I am going to say right off the bat that you are not going to be able to do this on real hardware. The CPU is simply too slow
+to run real-time SSL, and the machine you probably have likely does not have enough RAM. Doing this on real hardware will limit
+you to having to use an external proxy (like retro-proxy) or forgo SSL entirely and use Fosscord.*
+
+Assuming you are still determined to do this, this is probably the easiest system. Since Concord compiles fine and very easily
+under NetBSD, all you need to do is install a binary package of (or compile) OpenSSL, cURL, and install the SSL certificates.
+Once you've done that, simply run `make` and `make install`. 
+
+
+### IBM RISC System/6000 (RS/6000) Workstations/Servers and POWER Series -- AIX: AIX 7.2 on a POWER8
+For the most part, follow the Solaris installation instructions, but, make sure that you've got IBM XL C/C++ installed. It likes
+to install itself in weird locations, like `/opt/IBM/xlc/16.0.0/bin/cc`. You will **definitely** want GNU Make, as AIX's ancient
+UNIX SVR3 `make` is far too crippled to compile Concord. 
+
+
+### IBM System/390 and System Z Mainframes -- z/OS: any Z system
+The entirety of the compilation and running here happens under the UNIX environment (USS). Either SSH into your z/OS host, telnet
+in on port 1023, or run OMVS from TSO to get at it.
+
+As before, we are going to use the IBM-provided XL C/C++ compiler. If you follow the instructions for AIX, they are pretty much
+100% applicable to z/OS. However, watch out for endianess conversion! Again, I am assuming that you are a skilled user of the 
+z/OS UNIX System Services environment. When you extract a tar file, use `pax -rv -o to=IBM-1047 < file.tar` in order to convert
+the character set over to EBCDIC. If you want to run it as a batch job, use the BPXBATCH program. This looks something like this:
+```
+//useridC JOB (1),CLASS=A,MSGCLASS=H,MSGLEVEL=(1,1)
+//STEP1 EXEC PGM=BPXBATCH,REGION=128M,PARM='SH'
+//STDIN DD PATH='/path/to/bot/startup/script.sh`,PATHOPTS=(ORDONLY)
+//STDOUT DD SYSOUT=*
+//STDERR DD SYSOUT=*
+```
+
+

--- a/docs/guides/msys2_and_mingw64.md
+++ b/docs/guides/msys2_and_mingw64.md
@@ -3,6 +3,6 @@ At the present, there are a few issues that prevent Concord from working properl
 neither environment's libcurl implementation will natively fetch SSL certificates from the Windows SSL root chain by 
 default. There is a way to rectify this, but it is rather inopportune and should not be done. However, neither environment
 can easily link against a Windows-native MSVC-compiled version of libcurl. This is due to object file differences. It *is*
-possible, but __highly__ unrecommended. For now, please consider using Cygwin. 
+possible, but __highly__ unrecommended to use Mingw64 or Msys2. Please consider using Cygwin instead. 
 
 #### WSL is not considered Windows, but Linux entirely. 


### PR DESCRIPTION
## Notice
- [X] I *understand* the code that I have edited, and have the means
to test it before making changes to Concord.

## What?
This PR improves the documentation situation of the project, especially when it comes to some of the more exotic platforms that Concord has been ran on in the past.

## Why?
Concord is in dire need of guides.

## Testing?
The instructions mentioned in the "weird platforms" guide has been tested on Solaris 10 with Sun Studio 11; the others were either partially tested (HP-UX) or successful (AIX, z/OS)

These will eventually need to be thrown onto the GitHub Pages system.
