### PR TITLE
[WIP] Add Guides section to web documentation

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -32,7 +32,7 @@ DOXYFILE_ENCODING      = UTF-8
 # title of most generated pages and in a few other places.
 # The default value is: My Project.
 
-PROJECT_NAME           = "Concord - C Discord API library"
+PROJECT_NAME           = "Concord"
 
 # The PROJECT_NUMBER tag can be used to enter a project or revision number. This
 # could be handy for archiving the generated documentation or if some version
@@ -44,14 +44,14 @@ PROJECT_NUMBER         =
 # for a project that appears at the top of each page and should give viewer a
 # quick idea about the purpose of the project. Keep the description short.
 
-PROJECT_BRIEF          = "A Discord API wrapper library written in C"
+PROJECT_BRIEF          = "A Discord API wrapper library made in C"
 
 # With the PROJECT_LOGO tag one can specify a logo or an icon that is included
 # in the documentation. The maximum height of the logo should not exceed 55
 # pixels and the maximum width should not exceed 200 pixels. Doxygen will copy
 # the logo to the output directory.
 
-PROJECT_LOGO           = docs/static/icon.ico
+PROJECT_LOGO           = docs/static/concord-small.png
 
 # The OUTPUT_DIRECTORY tag is used to specify the (relative or absolute) path
 # into which the generated documentation will be written. If a relative path is
@@ -835,8 +835,7 @@ WARN_LOGFILE           =
 # Note: If this tag is empty the current directory is searched.
 
 INPUT                  = core/error.h core/types.h include/discord.h include/ \
-                         core/ docs/api README.md docs/DISCORD_ROADMAP.md \
-                         docs/WINDOWS.md
+                         core/ docs/guides docs/PORTABILITY.md
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding. Doxygen uses
@@ -869,7 +868,7 @@ FILE_PATTERNS          = *.h *.md
 # be searched for input files as well.
 # The default value is: NO.
 
-RECURSIVE              = NO
+RECURSIVE              = YES
 
 # The EXCLUDE tag can be used to specify files and/or directories that should be
 # excluded from the INPUT source files. This way you can easily exclude a
@@ -987,7 +986,7 @@ FILTER_SOURCE_PATTERNS =
 # (index.html). This can be useful if you have a project on for instance GitHub
 # and want to reuse the introduction page also for the doxygen output.
 
-USE_MDFILE_AS_MAINPAGE = README.md
+USE_MDFILE_AS_MAINPAGE = INDEX.md
 
 #---------------------------------------------------------------------------
 # Configuration options related to source browsing

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 
 ## About
 
-Concord is an asynchronous C99 Discord API library with minimal external dependencies, and a low-level translation of the Discord official documentation to C code.
+Concord is an asynchronous C (C99) Discord API library with minimal external dependencies and a low-abstraction translation of the Discord official API to C code.
 
 ### Examples
 
@@ -105,7 +105,7 @@ int main(void) {
 
 ## Build Instructions
 
-The only dependency is `curl-7.56.1` or higher. If you are compiling libcurl from source, you will need to build it with SSL support.
+The only dependency is `curl-7.56.1` or higher. If you are compiling libcurl from the source, you will need to build it with SSL support.
 
 ### On Windows
 
@@ -241,8 +241,7 @@ The following outlines `config.json` fields:
 ## Test Copycat-Bot
 
 1. Get your bot token and add it to `config.json`, 
-   by assigning it to discord's "token" field. There are 
-   well written instructions from 
+   by assigning it to discord's "token" field. There are well-written instructions from 
    [discord-irc](https://github.com/reactiflux/discord-irc/wiki/Creating-a-discord-bot-&-getting-a-token)
    explaining how to get your bot token and adding it to a server.
 2. Build example executables:
@@ -269,7 +268,7 @@ The following outlines special flags and targets to override the default Makefil
 ### Special compilation flags
 
 * `-DCCORD_SIGINTCATCH`
-    * By default Concord will not shutdown gracefully when a SIGINT is received (i.e. <kbd>Ctrl</kbd>+<kbd>c</kbd>), enable this flag if you wish it to be handled for you.
+    * By default, Concord will not shutdown gracefully when a SIGINT is received (i.e. <kbd>Ctrl</kbd>+<kbd>c</kbd>), enable this flag if you wish it to be handled for you.
 * `-DCCORD_DEBUG_WEBSOCKETS`
     * Enable verbose debugging for WebSockets communication.
 * `-DCCORD_DEBUG_HTTP`
@@ -306,7 +305,7 @@ This will install the headers and library files into $PREFIX. You can override t
 
 ### Included dependencies
 
-The following are `stable` and well documented dependencies that are packaged with Concord and can be included to your projects:
+The following are `stable` and well-documented dependencies that are packaged with Concord and can be included in your projects:
 
 | File                                                  | Description                                        |
 |-------------------------------------------------------|----------------------------------------------------|
@@ -394,7 +393,7 @@ Problems? Check out our [Discord Server][discord-invite]
 
 ## Contributing
 
-All kinds of contributions are welcome, all we ask is to abide to our [guidelines](docs/CONTRIBUTING.md)! If you want to help but is unsure where to get started then our [Discord API Roadmap](docs/DISCORD_ROADMAP.md) is a good starting point. Check our [links](#links) for more helpful information.
+All kinds of contributions are welcome, all we ask is to abide by our [guidelines](docs/CONTRIBUTING.md)](docs/CONTRIBUTING.md)! If you want to help but are unsure where to get started then our [Discord API Roadmap](docs/DISCORD_ROADMAP.md) is a good starting point. Check our [links](#links) for more helpful information.
 
 ## Getting Started
 

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -1,5 +1,6 @@
 [discord-invite]: https://discord.gg/Y7Xa6MA82v
-[portability]: ../PORTABILITY.md
+[portability]: PORTABILITY.md
+[config_json]: guides/config.json_directives.md
 
 # Concord - A Discord API wrapper library made in C
 
@@ -49,7 +50,6 @@ int main(void) {
 ```
 
 ## Features
-
 - Discord v10 support
 - Fully asynchronous
 - [Portability][portability]
@@ -58,6 +58,7 @@ int main(void) {
 
 ## Getting started
 <!-- List guides to help set up the first bot, concord's workflow, and some of its quirks -->
+- [Configuring your bot][config_json]
 
 ## Guides
 <!-- General purpose guides, how to use embeds, interactions, etc -->

--- a/docs/guides/INDEX.md
+++ b/docs/guides/INDEX.md
@@ -57,7 +57,7 @@ int main(void) {
 - Caching
 
 ## Getting started
-<!-- List guides to help set up the first bot, concord's workflow, some of its quirks -->
+<!-- List guides to help set up the first bot, concord's workflow, and some of its quirks -->
 
 ## Guides
 <!-- General purpose guides, how to use embeds, interactions, etc -->

--- a/docs/guides/INDEX.md
+++ b/docs/guides/INDEX.md
@@ -1,0 +1,66 @@
+[discord-invite]: https://discord.gg/Y7Xa6MA82v
+[portability]: ../PORTABILITY.md
+
+# Concord - A Discord API wrapper library made in C
+
+## About
+
+Concord is an asynchronous C (C99) Discord API library with minimal external dependencies and a low-abstraction translation of the Discord official API to C code.
+
+It is currently maintained by a team of passionate C developers, and is used by a [community][discord-invite] that is always willing to help!
+
+```c
+#include <string.h>
+#include <concord/discord.h>
+
+#define BOT_TOKEN "YOUR-BOT-TOKEN-HERE"
+
+void on_ready(struct discord *client, const struct discord_ready *event) {
+    struct discord_create_guild_application_command params = {
+        .name = "ping",
+        .description = "Ping command!"
+    };
+    discord_create_guild_application_command(client, event->application->id,
+                                             GUILD_ID, &params, NULL);
+}
+
+void on_interaction(struct discord *client, const struct discord_interaction *event) {
+    if (event->type != DISCORD_INTERACTION_APPLICATION_COMMAND)
+        return; /* return if interaction isn't a slash command */
+
+    if (strcmp(event->data->name, "ping") == 0) {
+          struct discord_interaction_response params = {
+                .type = DISCORD_INTERACTION_CHANNEL_MESSAGE_WITH_SOURCE,
+                .data = &(struct discord_interaction_callback_data){
+                      .content = "pong"
+                }
+          };
+          discord_create_interaction_response(client, event->id,
+                                              event->token, &params, NULL);
+    }
+}
+
+int main(void) {
+    struct discord *client = discord_init(BOT_TOKEN);
+    discord_set_on_ready(client, &on_ready);
+    discord_set_on_interaction_create(client, &on_interaction);
+    discord_run(client);
+}
+```
+
+## Features
+
+- Discord v10 support
+- Fully asynchronous
+- [Portability][portability]
+- Timers
+- Caching
+
+## Getting started
+<!-- List guides to help set up the first bot, concord's workflow, some of its quirks -->
+
+## Guides
+<!-- General purpose guides, how to use embeds, interactions, etc -->
+
+## Other topics
+<!-- Links to other useful C resources, such as good debugging practices >

--- a/docs/guides/config.json_directives.md
+++ b/docs/guides/config.json_directives.md
@@ -1,8 +1,12 @@
+[logging_level]: screenshots/config.json_directives/logging_level.png
+[logging_quiet_false]: screenshots/config.json_directives/logging_quiet_false.png
+[logging_quiet_true]: screenshots/config.json_directives/logging_quiet_true.png
+[logging_use_colors_true]: screenshots/config.json_directives/logging_use_color_true.png
+[logging_use_colors_false]: screenshots/config.json_directives/logging_use_color_false.png
+
 # Getting the bot started
-
 ## config.json directives
-
-The `config.json` file is a configuration file that can be used to start your bots from. Since it's read at runtime, it is especially useful if you want to avoid having to recompile your bot application for each small configuration that gets added. This guide outlines some of the configuration options you can modify, and also how to add your own.
+The `config.json` file is a configuration file that can be used to set up your bot. It is read at runtime, so it can be modified without requiring you to recompile your bot application. This guide outlines some of the configuration options you can modify, and also how to add your own.
 
 ```json
 {
@@ -31,115 +35,81 @@ The `config.json` file is a configuration file that can be used to start your bo
 ### logging
 
 #### level
-
-  logging.level defines the type of log that will be used to log if you set quiet to false.
-
-  Screenshot of logging.level set as "debug"
-
-  ![Logging level screenshots](screenshots/config.json_directives/logging_level.png "Logging.level")
+Defines the logging level that will be shown by Concord
+![logging.level set as debug][logging_level]
 
 #### filename
-
-  This sets the file name of the file that you wish your log is saved into it.
+Name of the file that you wish your log to be saved to.
 
 #### quiet
+Disables the default concord logging.
 
-  That configuration disables the default concord logging.
+True: *(Concord's logging messages will disappear)*
+![logging.quiet set to true][logging_quiet_true]
 
-  Screenshot as example:
+False:
+![logging.quiet set to false][logging_quiet_false]
 
-  True:
-
-  ![Logging quiet screenshot false](screenshots/config.json_directives/logging_quiet_false.png "Logging.quiet false")
-
-  False (You can see the Concord's default logging messages disappear):
-
-  ![Logging quiet screenshot true](screenshots/config.json_directives/logging_quiet_true.png "Logging.quiet trut")
 
 #### overwrite
-
-  In case to avoid your logging files getting too big, you can set this to true so that whenever the bot logs in, Concord will empty the logging files.
+To avoid your logging files becoming too large, you can set this to true so that whenever the bot logs in, Concord will overwrite any existing logging file.
   
 #### use_color
+Adds colors to Concord's logging messages, so it will look better and you can see WARNS/ERRORS with ease.
 
-  This adds colors to Concord's logging messages, so it will look better and you can see WARNS/ERRORS with ease.
+Screenshots of logging.use_color set as true and set as false.
 
-  Screenshots of logging.use_color set as true and set as false.
+True:
+![logging.color set to true][logging_use_colors_true]
 
-  True:
-
-  ![Logging use_colors screenshot true](screenshots/config.json_directives/logging_use_color_true.png "Logging.use_colors true")
-
-  False:
-
-  ![Logging use_colors screenshot false](screenshots/config.json_directives/logging_use_color_false.png "Logging.use_colors false")
+False:
+![logging.color set to false][logging_use_colors_false]
 
 #### http.enable
-
-  Enables the capability to log all the information of the HTTP(s) requests made by Concord.
+Whether it should log HTTP(s) requests performed by Concord.
 
 #### http.filename
+The file to log the HTTP(s) requests to.
 
-  The filename of the file that will be used to save the information of the HTTP(s) requests.
+See `logging.http.enable` for more information.
 
-  See `logging.http.enable` for more information.
-
-  This will be obsolete if `logging.http.enable` is set to false.
+This will be obsolete if `logging.http.enable` is set to false.
 
 #### disable_modules
-  
-  Disables one of Concord's default logging instead of disabling all of them like logging.quiet.
+Concord's logging modules that should be disabled
 
-  Screenshots of disabling "WEBSOCKETS" and also not disabling any logging:
+Disabling `WEBSOCKETS`:
+![Logging disable_modules screenshot websockets](screenshots/config.json_directives/logging_disable_modules_websockets.png "Logging.disable_modules websockets")
 
-  Disabling "WEBSOCKETS":
-
-  ![Logging disable_modules screenshot websockets](screenshots/config.json_directives/logging_disable_modules_websockets.png "Logging.disable_modules websockets")
-
-  Not disabling any:
-
-  ![Logging disable_modules screenshot none](screenshots/config.json_directives/logging_disable_modules_none.png "Logging.disable_modules none")
+Not disabling any:
+![Logging disable_modules screenshot none](screenshots/config.json_directives/logging_disable_modules_none.png "Logging.disable_modules none")
 
 ### Discord
-
 #### token
-
-  The token that Concord will use to log in to the bot, in case you use the `discord_config_init` to define the `struct discord *client`.
+The client token that Concord will use to log in
 
 #### default_prefix.enable
-
-  Will enable the opportunity to set a default prefix.
-
-  See `discord.default_prefix.prefix` for more information.
+Enable a default command prefix for your bot
 
 #### default_prefix.prefix
-
-  Set a default prefix, so `discord_set_on_command` function can be used.
-
-  This will not work in case `discord.default_prefix.enable` is set to false.
+Set a default command prefix for your bot (this can be overridden by `discord_set_prefix()`)
 
 ## Observations
+You may also add custom fields to your config.json and then fetch them with the `discord_config_get_field()`:
+```c
+struct ccord_szbuf_readonly discord_config_get_field(struct discord *client, char *const path[], unsigned depth)
+```
+*This function will only work if you initialize your bot with the `discord_config_init()`!*
 
-  You can also put custom fields on your config.json and get its value with the `discord_config_get_field` function. See the following example.
+Fetching your custom fields:
+```c
+const char *fields[] = { "field", "foo" }; // suppose you added `field.foo` to your config.json
+struct ccord_szbuf_readonly value = discord_config_get_field(client, fields, sizeof(fields) / sizeof *fields);
 
-  ```c
-  char foo[16];
+char foo[16];
+snprintf(foo, sizeof(foo), "%.*s", (int)value.size, value.start);
 
-  struct ccord_szbuf_readonly value = discord_config_get_field(client, (char *[2]){ "field", "foo" }, 2);
-
-  snprintf(foo, sizeof(foo), "%.*s", (int)value.size, value.start);
-  ```
-
-  ```c
-  struct ccord_szbuf_readonly discord_config_get_field(struct discord *client, char *const path[], unsigned depth)
-  ```
-
-  Attention: this function will only work if you initialize your bot with the `discord_config_init`.
-
-  The first argument of `discord_config_get_field` is the `struct discord *client` that `discord_init`/`discord_config_init` (or also, in case the code is inside some kind of event, it might be on the event parameters) returns to you.
-
-  The second argument is a `const x[]` (also known as `array`) the path to the field where you want to get its value.
-
-  The third argument is an `int` value of the depth of the path, for example, if the path was `field -> another_field -> foo` it would be 3
+printf("%s\n", foo); // should print field.foo contents
+```
   
 *Written by [ThePedro](https://github.com/ThePedroo)*


### PR DESCRIPTION
## Notice
- [x] I *understand* the code that I have edited, and have the means
to test it before making changes to Concord.

## What?
- Add Guides section and list guides in Concord web documentation
- Improve existing guides wording

## Why?
Plenty of guides have been added (see #109) that need to be added to the web documentation