### PR TITLE
Buffer for interaction response too small

### DIFF
--- a/src/discord-gateway.c
+++ b/src/discord-gateway.c
@@ -207,7 +207,7 @@ _discord_on_dispatch(struct discord_gateway *gw)
     case DISCORD_EV_READY: {
         jsmnf_pair *f;
 
-        logconf_info(&gw->conf, "Succesfully started a Discord session!");
+        logconf_info(&gw->conf, "Successfully started a Discord session!");
 
         if ((f = jsmnf_find(gw->payload.data, gw->payload.json.start,
                             "session_id", 10)))

--- a/src/interaction.c
+++ b/src/interaction.c
@@ -17,7 +17,7 @@ discord_create_interaction_response(
     struct discord_attributes attr = { 0 };
     struct ccord_szbuf body;
     enum http_method method;
-    char buf[4096];
+    char buf[16384];
 
     CCORD_EXPECT(client, interaction_id != 0, CCORD_BAD_PARAMETER, "");
     CCORD_EXPECT(client, NOT_EMPTY_STR(interaction_token), CCORD_BAD_PARAMETER,


### PR DESCRIPTION
## Notice
- [x] I *understand* the code that I have edited, and have the means
to test it before making changes to Concord.

Adjusted `buf` in `discord_create_interaction_response()` to be the size of 16384 like the others.