### PR TITLE
fix: allow async client shutdowns for multithreading safety.

### DIFF
--- a/include/concord-once.h
+++ b/include/concord-once.h
@@ -6,20 +6,18 @@
 
 #ifndef CONCORD_ONCE_H
 
-/**
- * @brief If `SIGINT` is detected client(s) will be disconnected from their
- *      on-going session
- *
- * This global shall be set if a `SIGINT` is detected, running clients will
- *      then attempt to perform a clean disconnect, rather then just letting
- *      the program end abruptly.
- * @note client shall only attempt to disconnect if there aren't any active
- *      events waiting to be listened or reacted to
- */
-extern int ccord_has_sigint;
-
 /** @brief Asynchronously shutdown all client(s) from their on-going sessions */
 void ccord_shutdown_async();
+
+/**
+ * @brief Whether or not concord is currently shutting down
+ *
+ * If true, clients will then attempt to perform a clean disconnect, rather than
+ *    just letting the program end abruptly (e.g. in the case of a SIGINT).
+ * @note client shall only attempt to disconnect if there aren't any active
+ *    events waiting to be listened or reacted to
+ */
+int ccord_shutting_down();
 
 /**
  * @brief Initialize global shared-resources not API-specific

--- a/include/concord-once.h
+++ b/include/concord-once.h
@@ -18,6 +18,9 @@
  */
 extern int ccord_has_sigint;
 
+/** @brief Asynchronously shutdown all client(s) from their on-going sessions */
+void ccord_shutdown_async();
+
 /**
  * @brief Initialize global shared-resources not API-specific
  *

--- a/src/concord-once.c
+++ b/src/concord-once.c
@@ -9,6 +9,12 @@ int ccord_has_sigint = 0;
 
 static int once;
 
+void
+ccord_shutdown_async(void)
+{
+    ccord_has_sigint = 1;
+}
+
 #ifdef CCORD_SIGINTCATCH
 /* shutdown gracefully on SIGINT received */
 static void

--- a/src/concord-once.c
+++ b/src/concord-once.c
@@ -1,18 +1,33 @@
 #include <signal.h>
 #include <curl/curl.h>
+#include <pthread.h>
 
 #include "error.h"
 #include "discord-worker.h"
 
+static pthread_mutex_t shutdown_lock = PTHREAD_MUTEX_INITIALIZER;
+
 /* if set to 1 then client(s) will be disconnected */
-int ccord_has_sigint = 0;
+int ccord_should_shutdown = 0;
 
 static int once;
 
 void
 ccord_shutdown_async(void)
 {
-    ccord_has_sigint = 1;
+    pthread_mutex_lock(&shutdown_lock);
+    ccord_should_shutdown = 1;
+    pthread_mutex_unlock(&shutdown_lock);
+}
+
+int
+ccord_shutting_down(void)
+{
+    int retval;
+    pthread_mutex_lock(&shutdown_lock);
+    retval = ccord_should_shutdown;
+    pthread_mutex_unlock(&shutdown_lock);
+    return retval;
 }
 
 #ifdef CCORD_SIGINTCATCH
@@ -22,7 +37,9 @@ _ccord_sigint_handler(int signum)
 {
     (void)signum;
     fputs("\nSIGINT: Disconnecting running concord client(s) ...\n", stderr);
-    ccord_has_sigint = 1;
+    pthread_mutex_lock(&shutdown_lock);
+    ccord_should_shutdown = 1;
+    pthread_mutex_unlock(&shutdown_lock);
 }
 #endif /* CCORD_SIGINTCATCH */
 
@@ -55,5 +72,7 @@ ccord_global_cleanup()
     curl_global_cleanup();
     discord_worker_global_cleanup();
     once = 0;
-    ccord_has_sigint = 0;
+    pthread_mutex_lock(&shutdown_lock);
+    ccord_should_shutdown = 0;
+    pthread_mutex_unlock(&shutdown_lock);
 }

--- a/src/discord-loop.c
+++ b/src/discord-loop.c
@@ -111,7 +111,7 @@ discord_run(struct discord *client)
                 CALL_IO_POLLER_POLL(poll_errno, poll_result, client->io_poller,
                                     0);
 
-            if (ccord_has_sigint != 0) discord_shutdown(client);
+            if (ccord_shutting_down()) discord_shutdown(client);
             if (-1 == poll_result) {
                 /* TODO: handle poll error here */
                 /* use poll_errno instead of errno */


### PR DESCRIPTION
Currently, if users attempt to compel concord to exit, e.g. using discord_shutdown, this will result in thread unsafe operations that can lead to a segfault.

This allows users to safely cause concord to exit, leveraging the existing flag used for SIGINT handling.

Fixes #135

## Notice
- [X ] I *understand* the code that I have edited, and have the means
to test it before making changes to Concord.

## What?

This allows for multithread safe shutdowns, using the same functionality that the SIGINT handler uses.

## Why?
Prevents segfaults on shutdown.

## How?
Uses the same functionality as SIGINT handler.

## Testing?
Tested locally and successfully prevents segfaults. Users can call pthread_join on any client threads and they will exit momentarily on their own, cleanly.
