### PR TITLE
Examples-Makefile optional compiler assignment

### DIFF
--- a/examples/Makefile
+++ b/examples/Makefile
@@ -1,6 +1,6 @@
 # This Makefile assumes the top folder has been built
 TOP = ..
-CC = gcc
+CC ?= gcc
 
 CORE_DIR      = $(TOP)/core
 INCLUDE_DIR   = $(TOP)/include


### PR DESCRIPTION
## Notice
- [x] I *understand* the code that I have edited, and have the means
to test it before making changes to Concord.

## What?
<!-- Explain the changes you've made - the overall effect of the PR. -->
This pull request changes the assignment of the `CC` variable to `gcc` only if `CC` is not already set to something.

## Why?
<!-- Evaluate tangible code changes - explain the reason for the PR. -->
No other Makefile in this project includes a specific assignment for the `CC` variable and uses the one defined by the system or the user.
If no `gcc` is installed on the system, e.g. `clang` concord will build but the examples not.

## How?
<!-- Explain the solution carried out by the PR. -->
The assignment is optional and will be set to `gcc` if `CC` is not defined.

## Testing?
<!--
Explain how you tested your changes - let the reviewer know of any untested 
conditions or edge cases, why they weren't tested, and how likely they are to
occur, and if so, any associated risks.
-->
Testing was done by building Concord and the examples.
