### PR TITLE
fix(websockets): fix tls related bug

### DIFF
--- a/core/websockets.c
+++ b/core/websockets.c
@@ -91,7 +91,9 @@ _ws_curl_tls_check(
     {
         const char reason[] = "TLS ended connection with a close notify (256)";
 
-        ws_close(ws, WS_CLOSE_REASON_ABRUPTLY, reason, sizeof(reason));
+        logconf_error(&ws->conf, "%s [@@@_%zu_@@@]", reason, ws->info.loginfo.counter);
+
+        ws_end(ws);
     }
     return 0;
 }


### PR DESCRIPTION
## Notice
- [x] I *understand* the code that I have edited, and have the means
to test it before making changes to Concord.

## What?
This PR comes with edits that should fix the issue that when TLS ends for some reasons, will proceed to close connection.

## Why?
Since the connection is already closed, will proceed to only end connection without trying to close.

## Testing?
Changes were not tested, should be done soon. But is successfully compiling.