### PR TITLE
Removed extra %s & added compile-time check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,9 @@
 # But these
 !AUTHORS
 !.vscode
-!core
+!core/
+!core/*.c
+!core/*.h
 !docs
 !docs/*
 !doxygen-awesome-css

--- a/core/attributes.h
+++ b/core/attributes.h
@@ -1,0 +1,5 @@
+#if defined(__MINGW32__) || (defined (__GNUC__) && __GNUC__ > 4 ? true : __GNUC_PATCHLEVEL__ >= 4) || defined(__USE_MINGW_ANSI_STDIO)
+#  define PRINTF_LIKE(a, b) __attribute__((format(gnu_printf, a, b)))
+#else
+#  define PRINTF_LIKE(a, b)
+#endif

--- a/core/cog-utils.h
+++ b/core/cog-utils.h
@@ -3,6 +3,7 @@
 
 #include <stdio.h>
 #include <stdint.h>
+#include "attributes.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -97,7 +98,7 @@ size_t cog_strndup(const char src[], size_t len, char **p_dest);
  * @param ... variadic arguments to be matched to `fmt` specifiers
  * @return length of copied string on success, -1 on failure
  */
-size_t cog_asprintf(char **strp, const char fmt[], ...);
+size_t cog_asprintf(char **strp, const char fmt[], ...) PRINTF_LIKE(2, 3);
 
 /**
  * @brief Sleep for amount of milliseconds

--- a/core/logconf.h
+++ b/core/logconf.h
@@ -7,6 +7,7 @@ extern "C" {
 
 #include <stdint.h> /* uint64_t */
 
+#include "attributes.h"
 #include "log.h"
 
 #define __ERR(fmt, ...) log_fatal(fmt "%s", __VA_ARGS__)
@@ -318,7 +319,7 @@ void logconf_http(struct logconf *conf,
                   struct logconf_szbuf header,
                   struct logconf_szbuf body,
                   char label_fmt[],
-                  ...);
+                  ...) PRINTF_LIKE(6, 7);
 
 /**
  * @brief If the log will be written to from multiple threads a lock function

--- a/core/queriec.h
+++ b/core/queriec.h
@@ -6,6 +6,8 @@
 #define QUERIEC_ERROR_NOMEM -1
 #define QUERIEC_OK 0
 
+#include "attributes.h"
+
 struct queriec {
     int state;
     size_t size;
@@ -16,7 +18,7 @@ void
 queriec_init(struct queriec *queriec, size_t size);
 
 int queriec_snprintf_add(struct queriec *queriec, char *query, const char key[], size_t keySize, 
-                         char buffer[], size_t bufferLen, const char *format, ...);
+                         char buffer[], size_t bufferLen, const char *format, ...) PRINTF_LIKE(7, 8);
 
 int
 queriec_add(struct queriec *queriec, char *query, char key[], size_t keySize, char value[], size_t valueSize);

--- a/core/user-agent.c
+++ b/core/user-agent.c
@@ -522,7 +522,7 @@ _ua_info_populate(struct ua_info *info, struct ua_conn *conn)
     curl_easy_getinfo(conn->ehandle, CURLINFO_EFFECTIVE_URL, &resp_url);
 
     logconf_http(&conn->ua->conf, &conn->info.loginfo, resp_url, logheader,
-                 logbody, "HTTP_RCV_%s(%d)", http_code_print(info->httpcode),
+                 logbody, "HTTP_RCV_%s(%ld)", http_code_print(info->httpcode),
                  info->httpcode);
 }
 

--- a/include/discord-internal.h
+++ b/include/discord-internal.h
@@ -28,6 +28,7 @@ extern "C" {
 #include "io_poller.h"
 #include "queue.h"
 #include "priority_queue.h"
+#include "attributes.h"
 
 /** @brief Return 1 if string isn't considered empty */
 #define NOT_EMPTY_STR(str) ((str) && *(str))
@@ -634,7 +635,7 @@ CCORDcode discord_rest_run(struct discord_rest *rest,
                            struct ccord_szbuf *body,
                            enum http_method method,
                            char endpoint_fmt[],
-                           ...);
+                           ...) PRINTF_LIKE(5, 6);
 
 /**
  * @brief Stop all bucket's on-going, pending and timed-out requests

--- a/src/channel.c
+++ b/src/channel.c
@@ -171,7 +171,7 @@ discord_get_channel_messages(struct discord *client,
         char buf[32];
         if (params->limit) {
             res = queriec_snprintf_add(&queriec, query, "limit", sizeof("limit"),
-                                       buf, sizeof(buf), "%" PRIu64, params->limit);
+                                       buf, sizeof(buf), "%d", params->limit);
             ASSERT_S(res != QUERIEC_ERROR_NOMEM, "Out of bounds write attempt");
         }
         if (params->around) {
@@ -882,7 +882,7 @@ discord_add_thread_member(struct discord *client,
     DISCORD_ATTR_BLANK_INIT(attr, ret, NULL);
 
     return discord_rest_run(&client->rest, &attr, NULL, HTTP_PUT,
-                            "/channels/%" PRIu64 "/thread-members/" PRIu64,
+                            "/channels/%" PRIu64 "/thread-members/%" PRIu64,
                             channel_id, user_id);
 }
 
@@ -916,7 +916,7 @@ discord_remove_thread_member(struct discord *client,
     DISCORD_ATTR_BLANK_INIT(attr, ret, NULL);
 
     return discord_rest_run(&client->rest, &attr, NULL, HTTP_DELETE,
-                            "/channels/%" PRIu64 "/thread-members/" PRIu64,
+                            "/channels/%" PRIu64 "/thread-members/%" PRIu64,
                             channel_id, user_id);
 }
 
@@ -985,7 +985,7 @@ discord_list_public_archived_threads(
 
     return discord_rest_run(&client->rest, &attr, NULL, HTTP_GET,
                             "/channels/%" PRIu64
-                            "/threads/archived/public%s%s",
+                            "/threads/archived/public%s",
                             channel_id, query);
 }
 
@@ -1022,7 +1022,7 @@ discord_list_private_archived_threads(
 
     return discord_rest_run(&client->rest, &attr, NULL, HTTP_GET,
                             "/channels/%" PRIu64
-                            "/threads/archived/private%s%s",
+                            "/threads/archived/private%s",
                             channel_id, query);
 }
 
@@ -1059,6 +1059,6 @@ discord_list_joined_private_archived_threads(
 
     return discord_rest_run(&client->rest, &attr, NULL, HTTP_GET,
                             "/channels/%" PRIu64
-                            "/users/@me/threads/archived/private%s%s",
+                            "/users/@me/threads/archived/private%s",
                             channel_id, query);
 }

--- a/src/guild.c
+++ b/src/guild.c
@@ -206,7 +206,7 @@ discord_list_guild_members(struct discord *client,
     DISCORD_ATTR_LIST_INIT(attr, discord_guild_members, ret, NULL);
 
     return discord_rest_run(&client->rest, &attr, NULL, HTTP_GET,
-                            "/guilds/%" PRIu64 "/members%s%s", guild_id,
+                            "/guilds/%" PRIu64 "/members%s", guild_id,
                             query);
 }
 
@@ -249,7 +249,7 @@ discord_search_guild_members(struct discord *client,
     DISCORD_ATTR_LIST_INIT(attr, discord_guild_members, ret, NULL);
 
     return discord_rest_run(&client->rest, &attr, NULL, HTTP_GET,
-                            "/guilds/%" PRIu64 "/members/search%s%s", guild_id,
+                            "/guilds/%" PRIu64 "/members/search%s", guild_id,
                             query);
 }
 
@@ -649,7 +649,7 @@ discord_get_guild_prune_count(struct discord *client,
     DISCORD_ATTR_INIT(attr, discord_prune_count, ret, NULL);
 
     return discord_rest_run(&client->rest, &attr, NULL, HTTP_GET,
-                            "/guilds/%" PRIu64 "/prune%s%s", guild_id,
+                            "/guilds/%" PRIu64 "/prune%s", guild_id,
                             query);
 }
 

--- a/src/guild_scheduled_event.c
+++ b/src/guild_scheduled_event.c
@@ -152,7 +152,7 @@ discord_get_guild_scheduled_event_users(
         char buf[32];
         if (params->limit) {
             res = queriec_snprintf_add(&queriec, query, "limit", sizeof("limit"),
-                                       buf, sizeof(buf), "%" PRIu64, params->limit);
+                                       buf, sizeof(buf), "%d", params->limit);
             ASSERT_S(res != QUERIEC_ERROR_NOMEM, "Out of bounds write attempt");
         }
         if (params->with_member) {
@@ -177,6 +177,6 @@ discord_get_guild_scheduled_event_users(
 
     return discord_rest_run(
         &client->rest, &attr, NULL, HTTP_GET,
-        "/guilds/%" PRIu64 "/scheduled-events/%" PRIu64 "/users%s%s", guild_id,
+        "/guilds/%" PRIu64 "/scheduled-events/%" PRIu64 "/users%s", guild_id,
         guild_scheduled_event_id, query);
 }

--- a/src/interaction.c
+++ b/src/interaction.c
@@ -165,7 +165,7 @@ discord_create_followup_message(struct discord *client,
     DISCORD_ATTR_INIT(attr, discord_webhook, ret, NULL);
 
     return discord_rest_run(&client->rest, &attr, &body, method,
-                            "/webhooks/%" PRIu64 "/%s%s%s", application_id,
+                            "/webhooks/%" PRIu64 "/%s%s", application_id,
                             interaction_token, query);
 }
 

--- a/src/webhook.c
+++ b/src/webhook.c
@@ -226,7 +226,7 @@ discord_execute_webhook(struct discord *client,
     DISCORD_ATTR_BLANK_INIT(attr, ret, NULL);
 
     return discord_rest_run(&client->rest, &attr, &body, method,
-                            "/webhooks/%" PRIu64 "/%s%s%s", webhook_id,
+                            "/webhooks/%" PRIu64 "/%s%s", webhook_id,
                             webhook_token, query);
 }
 


### PR DESCRIPTION
## Notice
- [x] I *understand* the code that I have edited, and have the means
to test it before making changes to Concord.

## What?
This code adds fixes for bugs caused on [this PR](https://github.com/Cogmasters/concord/pull/136) (and fix for missing % on other places), and adds compile-time checks (GCC) for not causing this anymore.

## How?
By adding `__attribute__((format(printf, x, y)));` at function definitions inside a #if to check if compiler supports it.
