### PR TITLE
fix: fix makefiles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ EXAMPLES_DIR  = examples
 TEST_DIR      = test
 
 SOFLAGS     = -fPIC
-DYFLAGS     = -fPIC 
+DYFLAGS     = -fPIC
 DEBUG_FLAGS = -O0 -g
 
 GIT_BRANCHES = master dev
@@ -35,7 +35,7 @@ shared_osx:
 	@ CFLAGS="$(DYFLAGS)" $(MAKE) -C $(GENCODECS_DIR)
 	@ CFLAGS="$(CFLAGS)" $(MAKE) -C $(SRC_DIR) $@
 
-install:
+install: all
 	@ mkdir -p $(DESTLIBDIR)
 	@ mkdir -p $(DESTINCLUDE_DIR)
 	install -d $(DESTLIBDIR)
@@ -54,9 +54,9 @@ docs:
 	@ $(MAKE) -C $(GENCODECS_DIR) headers
 
 echo:
-	@ echo -e 'CC: $(CC)\n'
-	@ echo -e 'PREFIX: $(PREFIX)\n'
-	@ echo -e 'CFLAGS: $(CFLAGS)\n'
+	@ echo 'CC: $(CC)'
+	@ echo 'PREFIX: $(PREFIX)'
+	@ echo 'CFLAGS: $(CFLAGS)'
 
 voice:
 	@ CFLAGS="$(CFLAGS)" $(MAKE) -C $(SRC_DIR) $@
@@ -68,14 +68,13 @@ test: debug
 examples: all
 	@ $(MAKE) -C $(EXAMPLES_DIR)
 
-clean: 
+clean:
 	@ $(MAKE) -C $(SRC_DIR) $@
 	@ $(MAKE) -C $(TEST_DIR) $@
 	@ $(MAKE) -C $(EXAMPLES_DIR) $@
-	@ $(MAKE) -C $(GENCODECS_DIR) $@
 
 purge: clean
-	@ $(MAKE) -C $(SRC_DIR) $@
+	@ $(MAKE) -C $(GENCODECS_DIR) clean
 
 latest: master
 latest-dev: dev

--- a/core/Makefile
+++ b/core/Makefile
@@ -22,11 +22,11 @@ CFLAGS += -std=c99 -pthread -D_XOPEN_SOURCE=600 -DLOG_USE_COLOR \
 all: $(OBJS)
 
 echo:
-	@ echo -e 'CC: $(CC)\n'
-	@ echo -e 'CFLAGS: $(CFLAGS)\n'
-	@ echo -e 'OBJS: $(OBJS)\n'
+	@ echo 'CC: $(CC)'
+	@ echo 'CFLAGS: $(CFLAGS)'
+	@ echo 'OBJS: $(OBJS)'
 
-clean: 
+clean:
 	@ rm -f $(OBJS)
 
 .PHONY: echo clean

--- a/src/Makefile
+++ b/src/Makefile
@@ -92,22 +92,20 @@ deps:
 	@ $(MAKE) $(OBJS)
 
 echo:
-	@ echo -e 'CC: $(CC)\n'
-	@ echo -e 'PREFIX: $(PREFIX)\n'
-	@ echo -e 'CFLAGS: $(CFLAGS)\n'
-	@ echo -e 'GENCODECS_OBJ: $(GENCODECS_OBJ)\n'
-	@ echo -e 'CORE_OBJS: $(CORE_OBJS)\n'
-	@ echo -e 'VOICE_OBJS: $(VOICE_OBJS)\n'
-	@ echo -e 'OBJS: $(OBJS)\n'
+	@ echo 'CC: $(CC)'
+	@ echo 'PREFIX: $(PREFIX)'
+	@ echo 'CFLAGS: $(CFLAGS)'
+	@ echo 'GENCODECS_OBJ: $(GENCODECS_OBJ)'
+	@ echo 'CORE_OBJS: $(CORE_OBJS)'
+	@ echo 'VOICE_OBJS: $(VOICE_OBJS)'
+	@ echo 'OBJS: $(OBJS)'
 
 voice:
 	@ CFLAGS="-DCCORD_VOICE" OBJS="$(VOICE_OBJS)" $(MAKE)
 
-clean: 
+clean:
 	@ rm -rf $(LIBDIR)/*
 	@ rm -f $(OBJS) $(VOICE_OBJS)
 	@ $(MAKE) -C $(CORE_DIR) clean
-purge: clean
-	@ $(MAKE) -C $(GENCODECS_DIR) clean
 
 .PHONY: test examples install echo clean purge docs deps static shared shared_osx


### PR DESCRIPTION
## Notice
- [x] I *understand* the code that I have edited, and have the means
to test it before making changes to Concord.

## What?
(commit message)
Clean some whitespaces.
Remove -e for echo because it is non-standard (bmake).
Add 'all' dependency for main Makefile's 'install' so it is possible to directly do `make install` instead of `make all install`.
Fix clean so it doesn't delete gencodecs objects and fix purge so it 'clean' and call 'clean' for gencodecs as I assume it was how it supposed to work.
<!-- Explain the changes you've made - the overall effect of the PR. -->

## Why?
Because "make clean install" is less to type than "make clean all install" and gencodecs takes a long time to compile.
<!-- Evaluate tangible code changes - explain the reason for the PR. -->

## How?
<!-- Explain the solution carried out by the PR. -->

## Testing?
<!--
Explain how you tested your changes - let the reviewer know of any untested 
conditions or edge cases, why they weren't tested, and how likely they are to
occur, and if so, any associated risks.
-->

## Screenshots
<!-- (optional) Screenshots that may be helpful further demonstrating your PR. -->

## Anything Else?
<!--
(optional) Delve into possible architecture changes - call out challenges,
optimizations, etc. Use this as an opportunity to call out setbacks encountered
because of the current codebase.
-->
