### PR TITLE
docs(README.md): fix a typo in 'Build Instructions' section

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ The only dependency is `curl-7.56.1` or higher. If you are compiling libcurl fro
 #### FreeBSD
 
 ```console
-$ pkg install curl
+# pkg install curl
 ```
 
 #### OS X


### PR DESCRIPTION
## Notice
- [x] I *understand* the code that I have edited, and have the means to test it before making changes to Concord.

## What?
This pull request fixes a typo in 'Build Instructions' section of README.md.

## Why?

I believe root privilege is required to install packages via `pkg`.

```console
jdeokkim@freebsd:~ % pkg install curl
pkg: Insufficient privileges to install packages
```