### PR TITLE
chore(core/sha1): removed SHA1 helper function

### DIFF
--- a/core/sha1.c
+++ b/core/sha1.c
@@ -278,18 +278,3 @@ void SHA1Final(
     memset(context, '\0', sizeof(*context));
     memset(&finalcount, '\0', sizeof(finalcount));
 }
-
-void SHA1(
-    char *hash_out,
-    const char *str,
-    int len)
-{
-    SHA1_CTX ctx;
-    unsigned int ii;
-
-    SHA1Init(&ctx);
-    for (ii=0; ii<len; ii+=1)
-        SHA1Update(&ctx, (const unsigned char*)str + ii, 1);
-    SHA1Final((unsigned char *)hash_out, &ctx);
-}
-

--- a/core/sha1.h
+++ b/core/sha1.h
@@ -36,9 +36,4 @@ void SHA1Final(
     SHA1_CTX * context
     );
 
-void SHA1(
-    char *hash_out,
-    const char *str,
-    int len);
-
 #endif /* SHA1_H */


### PR DESCRIPTION
This function is obsolete and the name causes problems when linking with OpenSSL statically.

## Notice
- [x] I *understand* the code that I have edited, and have the means
to test it before making changes to Concord.

## What?
<!-- Explain the changes you've made - the overall effect of the PR. -->
Removed the SHA1 helper function.
## Why?
<!-- Evaluate tangible code changes - explain the reason for the PR. -->
The naming of this function causes problems when linking statically with OpenSSL.
## How?
<!-- Explain the solution carried out by the PR. -->
Rather than renaming it, it can be deleted since it is obsolete and not used.
## Testing?
<!--
Explain how you tested your changes - let the reviewer know of any untested 
conditions or edge cases, why they weren't tested, and how likely they are to
occur, and if so, any associated risks.
-->
The function is never used and does not change the resulting code.