### PR TITLE
Fix permanent shutdowns (TLS & 1000 close code)

### DIFF
--- a/core/websockets.c
+++ b/core/websockets.c
@@ -99,6 +99,11 @@ _ws_curl_tls_check(
                       reason, url, ws->info.loginfo.counter);
 
         _ws_set_status(ws, WS_DISCONNECTED);
+
+        if (ws->cbs.on_close)
+          ws->cbs.on_close(ws->cbs.data, ws, &ws->info,
+                           WS_CLOSE_REASON_ABRUPTLY, reason, sizeof(reason) - 1);
+
     }
     return 0;
 }

--- a/core/websockets.c
+++ b/core/websockets.c
@@ -866,6 +866,13 @@ ws_close(struct websockets *ws,
          const char reason[],
          const size_t len)
 {
+    if (WS_DISCONNECTED == ws->status) {
+        logconf_warn(&ws->conf,
+                     "Attemped to close WebSockets connection already closed");
+
+        return;
+    }
+
     logconf_warn(&ws->conf,
                  "Attempting to close WebSockets connection with %s : %.*s",
                  ws_close_opcode_print(code), (int)len, reason);

--- a/core/websockets.c
+++ b/core/websockets.c
@@ -873,7 +873,7 @@ ws_close(struct websockets *ws,
 {
     if (WS_DISCONNECTED == ws->status) {
         logconf_warn(&ws->conf,
-                     "Attemped to close WebSockets connection already closed");
+                     "Attempt to close WebSockets connection that has already ended");
 
         return;
     }

--- a/src/discord-client.c
+++ b/src/discord-client.c
@@ -67,8 +67,6 @@ _discord_init(struct discord *new_client)
     discord_refcounter_init(&new_client->refcounter, &new_client->conf);
     discord_message_commands_init(&new_client->commands, &new_client->conf);
     discord_rest_init(&new_client->rest, &new_client->conf, new_client->token);
-    discord_gateway_init(&new_client->gw, &new_client->conf,
-                         new_client->token);
 #ifdef CCORD_VOICE
     discord_voice_connections_init(new_client);
 #endif
@@ -216,7 +214,6 @@ discord_cleanup(struct discord *client)
     else {
         discord_worker_join(client);
         discord_rest_cleanup(&client->rest);
-        discord_gateway_cleanup(&client->gw);
         discord_message_commands_cleanup(&client->commands);
 #ifdef CCORD_VOICE
         discord_voice_connections_cleanup(client);

--- a/src/discord-client.c
+++ b/src/discord-client.c
@@ -67,6 +67,8 @@ _discord_init(struct discord *new_client)
     discord_refcounter_init(&new_client->refcounter, &new_client->conf);
     discord_message_commands_init(&new_client->commands, &new_client->conf);
     discord_rest_init(&new_client->rest, &new_client->conf, new_client->token);
+    discord_gateway_init(&new_client->gw, &new_client->conf,
+                         new_client->token);
 #ifdef CCORD_VOICE
     discord_voice_connections_init(new_client);
 #endif
@@ -214,6 +216,7 @@ discord_cleanup(struct discord *client)
     else {
         discord_worker_join(client);
         discord_rest_cleanup(&client->rest);
+        discord_gateway_cleanup(&client->gw);
         discord_message_commands_cleanup(&client->commands);
 #ifdef CCORD_VOICE
         discord_voice_connections_cleanup(client);

--- a/src/discord-gateway.c
+++ b/src/discord-gateway.c
@@ -729,6 +729,8 @@ discord_gateway_start(struct discord_gateway *gw)
 {
     struct ccord_szbuf json = { 0 };
 
+    discord_gateway_init(gw, &gw->conf, CLIENT(gw, gw)->token); // lazy init
+
     if (gw->session->retry.attempt == gw->session->retry.limit) {
         logconf_fatal(&gw->conf,
                       "Failed reconnecting to Discord after %d tries",
@@ -783,6 +785,7 @@ bool
 discord_gateway_end(struct discord_gateway *gw)
 {
     ws_end(gw->ws);
+    discord_gateway_cleanup(gw);
 
     /* keep only resumable information */
     gw->session->status &= DISCORD_SESSION_RESUMABLE;

--- a/src/discord-gateway.c
+++ b/src/discord-gateway.c
@@ -789,8 +789,6 @@ discord_gateway_end(struct discord_gateway *gw)
     gw->session->is_ready = false;
 
     if (!gw->session->retry.enable) {
-        discord_gateway_cleanup(gw);
-
         logconf_warn(&gw->conf, "Discord Gateway Shutdown");
 
         /* reset for next run */

--- a/src/discord-gateway.c
+++ b/src/discord-gateway.c
@@ -729,8 +729,6 @@ discord_gateway_start(struct discord_gateway *gw)
 {
     struct ccord_szbuf json = { 0 };
 
-    discord_gateway_init(gw, &gw->conf, CLIENT(gw, gw)->token); // lazy init
-
     if (gw->session->retry.attempt == gw->session->retry.limit) {
         logconf_fatal(&gw->conf,
                       "Failed reconnecting to Discord after %d tries",
@@ -785,13 +783,14 @@ bool
 discord_gateway_end(struct discord_gateway *gw)
 {
     ws_end(gw->ws);
-    discord_gateway_cleanup(gw);
 
     /* keep only resumable information */
     gw->session->status &= DISCORD_SESSION_RESUMABLE;
     gw->session->is_ready = false;
 
     if (!gw->session->retry.enable) {
+        discord_gateway_cleanup(gw);
+
         logconf_warn(&gw->conf, "Discord Gateway Shutdown");
 
         /* reset for next run */

--- a/src/discord-gateway.c
+++ b/src/discord-gateway.c
@@ -373,7 +373,7 @@ _ws_on_close(void *p_gw,
     default: /* websocket/clouflare opcodes */
         if (WS_CLOSE_REASON_NORMAL == (enum ws_close_reason)opcode) {
             gw->session->status |= DISCORD_SESSION_RESUMABLE;
-            gw->session->retry.enable = false;
+            gw->session->retry.enable = true;
             break;
         }
         /* fall-through */

--- a/src/discord-loop.c
+++ b/src/discord-loop.c
@@ -118,6 +118,8 @@ discord_run(struct discord *client)
                 (void)poll_errno;
             }
 
+            if (client->gw.session->status & DISCORD_SESSION_SHUTDOWN) break;
+
             BREAK_ON_FAIL(code, io_poller_perform(client->io_poller));
 
             discord_requestor_dispatch_responses(&client->rest.requestor);


### PR DESCRIPTION
## Notice
- [x] I *understand* the code that I have edited, and have the means
to test it before making changes to Concord.

## What?
This PR fixes an fatal issue that would block Concord from reconnecting to the gateway.

## Why?
To allow bots to run for a long time, not being disconnecting without reconnecting.

## How?
This includes various fixes about connections, both TLS and 1000 WS status code.

## Testing?
It was tested by persons on Cogmaster's Discord and verified that the fix is working, properly reconnecting when disconnected abruptly.
