### PR TITLE
Fix cURL deprecated warning

### DIFF
--- a/core/websockets.c
+++ b/core/websockets.c
@@ -834,9 +834,15 @@ ws_multi_socket_run(struct websockets *ws, uint64_t *tstamp)
     /** update WebSockets concept of "now" */
     *tstamp = ws_timestamp_update(ws);
 
-    mcode = curl_multi_socket_all(ws->mhandle, &is_running);
+    mcode = curl_multi_socket_action(ws->mhandle, CURL_SOCKET_TIMEOUT, 0, &is_running);
 
     if (mcode != CURLM_OK) CURLM_LOG(ws, mcode);
+
+    if (CURLM_OK != curl_multi_perform(ws->mhandle, &is_running)) {
+        logconf_error(&ws->conf, "curl_multi_perform() failed");
+
+        return false;
+    }
 
     return is_running != 0;
 }

--- a/src/discord-rest_request.c
+++ b/src/discord-rest_request.c
@@ -360,7 +360,7 @@ discord_requestor_info_read(struct discord_requestor *rqtor)
 {
     int alive = 0;
 
-    if (CURLM_OK != curl_multi_socket_all(rqtor->mhandle, &alive))
+    if (CURLM_OK != curl_multi_socket_action(rqtor->mhandle, CURL_SOCKET_TIMEOUT, 0, &alive))
         return CCORD_CURLM_INTERNAL;
 
     /* ask for any messages/informationals from the individual transfers */
@@ -444,6 +444,12 @@ discord_requestor_info_read(struct discord_requestor *rqtor)
             }
         }
     }
+
+    int still_running = 0;
+
+    /* Check if there are still running transfers */
+    if (CURLM_OK != curl_multi_perform(rqtor->mhandle, &still_running))
+        return CCORD_CURLM_INTERNAL;
 
     return CCORD_OK;
 }


### PR DESCRIPTION
## Notice
- [x] I *understand* the code that I have edited, and have the means
to test it before making changes to Concord.

## What?
This PR "replaces" (deprecated) [curl_multi_socket_all](https://curl.se/libcurl/c/curl_multi_socket.html) with [curl_multi_socket_action](https://curl.se/libcurl/c/curl_multi_socket_action.html).

## Why?
As mentioned before, `_all` is deprecated since 7.19.5. In other words, versions above or equal 7.19.5 *should not* use it, and *should* use `_action` instead.  [Concord requires libcurl 7.56.1 minimum](https://github.com/Cogmasters/concord/blob/master/README.md?plain=1#L108), which makes its usage not recommended.

## How?
This PR introduces the usage of `curl_multi_socket_action` (as per "recommended" by libcurl documentation) together with `curl_multi_perform`, replacing `curl_multi_socket_all`.

## Testing?
To test the minimum "workability" of this PR, a bot was compiled with this PR.

## Anything Else?
Those changes are slightly experimental, as no explicit replacement is made in libcurl documentation, only for `curl_multi_socket`.

I may also point out that even if this PR is not introduced, [curl_multi_socket_all usage is not recommended](https://github.com/curl/curl/blob/curl-7_19_2/docs/libcurl/curl_multi_socket.3#L65-L68).
