### PR TITLE
feat: zombie connection check

### DIFF
--- a/include/discord-internal.h
+++ b/include/discord-internal.h
@@ -750,6 +750,11 @@ struct discord_gateway {
          */
         int64_t hbeat_interval;
         /**
+         * boolean that indicates if the last heartbeat was answered
+         * @note used to detect zombie connections
+        */
+        bool hbeat_acknowledged;
+        /**
          * Gateway's concept of "now"
          * @note updated at discord_gateway_perform()
          */

--- a/src/discord-gateway.c
+++ b/src/discord-gateway.c
@@ -319,6 +319,7 @@ _discord_on_heartbeat_ack(struct discord_gateway *gw)
     /* get request / response interval in milliseconds */
     pthread_rwlock_wrlock(&gw->timer->rwlock);
     gw->timer->ping_ms = (int)(gw->timer->now - gw->timer->hbeat_last);
+    gw->timer->hbeat_acknowledged = true;
     pthread_rwlock_unlock(&gw->timer->rwlock);
 
     logconf_trace(&gw->conf, "PING: %d ms", gw->timer->ping_ms);
@@ -550,6 +551,9 @@ discord_gateway_init(struct discord_gateway *gw,
     gw->timer = calloc(1, sizeof *gw->timer);
     ASSERT_S(!pthread_rwlock_init(&gw->timer->rwlock, NULL),
              "Couldn't initialize Gateway's rwlock");
+
+    /* mark true to not get reconnected each reconnect */
+    gw->timer->hbeat_acknowledged = true;
 
     /* client connection status */
     gw->session = calloc(1, sizeof *gw->session);


### PR DESCRIPTION
## Notice
- [x] I *understand* the code that I have edited, and have the means
to test it before making changes to Concord.

## What?
This PR introduces checks that ensures that the previous heartbeat was responded.

## Why?
This avoids keeping a zombie connection, where the connection is over, however the client (Concord) is unaware of that for some reason. Heartbeats are meant for this, and should be used as it.

## How?
This introduces a `hbeat_answered` field, that defines whether or not the previous heartbeat was answered/responded. 

## Testing?
Basic testing was done. However better testing should be done, and the code should be reviewed as well.

## Anything Else?
While I believe it's important this PR, the reason for a lot of times Concord be unaware of closes may be to cws. I'll investigate further.
