### PR TITLE
Fix memory leak when using `reason` field

### DIFF
--- a/src/discord-rest_request.c
+++ b/src/discord-rest_request.c
@@ -256,7 +256,8 @@ discord_request_cancel(struct discord_requestor *rqtor,
 
     if (NOT_EMPTY_STR(req->reason)) {
         ua_conn_remove_header(req->conn, "X-Audit-Log-Reason");
-        *req->reason = '\0';
+        free(req->reason);
+        req->reason = NULL;
     }
     if (req->conn) {
         ua_conn_stop(req->conn);


### PR DESCRIPTION
## Notice
- [x] I *understand* the code that I have edited, and have the means
to test it before making changes to Concord.

## What?
This PR fixes a memory leak that happened when setting a `reason` field for requests.

## Why?
This assures that memory won't increase over time.

## How?
By `free`ing on `discord_request_cancel` function.

## Testing?
Testing was done via a small bot that only has the function of deleting a message with a reason.

