### PR TITLE
pkg-config support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@
 !Makefile
 !config.json
 !.github/**
+!concord.pc

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
 PREFIX          ?= /usr/local
+SHAREDIR        ?= /usr/share
 DESTINCLUDE_DIR  = $(PREFIX)/include/concord
 DESTLIBDIR       = $(PREFIX)/lib
+PKGCONFIGDIR     = $(SHAREDIR)/pkgconfig
 
 SRC_DIR       = src
 INCLUDE_DIR   = include
@@ -43,12 +45,14 @@ install:
 	install -d $(DESTINCLUDE_DIR)
 	install -m 644 $(INCLUDE_DIR)/*.h $(CORE_DIR)/*.h $(GENCODECS_DIR)/*.h \
 	               $(DESTINCLUDE_DIR)
+	install -D concord.pc $(PKGCONFIGDIR)/concord.pc
 
 uninstall:
 	rm -rf $(PREFIX)/include/concord
 	rm -rf $(PREFIX)/lib/libdiscord.a
 	rm -rf $(PREFIX)/lib/libdiscord.so
 	rm -rf $(PREFIX)/lib/libdiscord.dylib
+	rm -f $(PKGCONFIGDIR)/concord.pc
 
 docs:
 	@ $(MAKE) -C $(GENCODECS_DIR) headers

--- a/README.md
+++ b/README.md
@@ -15,6 +15,9 @@
 [ ![discord-shield][] ][discord-invite]
 [ ![migrating-shield][] ][migrating-link]
 
+## 🚨 Concord is not dead! 🚨
+Development has been happening in the dev branch. We are working on new features and improvements. To access the latest version of the library, please check out the dev branch.
+
 ## About
 
 Concord is an asynchronous C99 Discord API library with minimal external dependencies, and a low-level translation of the Discord official documentation to C code.

--- a/concord.pc
+++ b/concord.pc
@@ -1,0 +1,11 @@
+prefix=/usr/local
+exec_prefix=${prefix}
+libdir=${exec_prefix}/lib
+includedir=${exec_prefix}/include
+
+Name: concord
+URL: https://github.com/Cogmasters/concord
+Version: 2.3.0
+Description: A Discord API wrapper library made in C 
+Libs: -L${libdir} -ldiscord
+Cflags: -I${includedir}/concord


### PR DESCRIPTION
## Notice
- [x] I *understand* the code that I have edited, and have the means
to test it before making changes to Concord.

## What?
<!-- Explain the changes you've made - the overall effect of the PR. -->
I made a concord.pc file for pkg-config. The makefile now installs (and uninstalls) it to /usr/share/pkgconfig/concord.pc. I also had to add it to the .gitignore.

## Why?
<!-- Evaluate tangible code changes - explain the reason for the PR. -->
I added this because, at least for me, it makes integrating concord with cmake a lot easier. I imagine that it might help some others as well.

## How?
<!-- Explain the solution carried out by the PR. -->
I created a concord.pc file.

## Testing?
<!--
Explain how you tested your changes - let the reviewer know of any untested 
conditions or edge cases, why they weren't tested, and how likely they are to
occur, and if so, any associated risks.
-->
I have actually been using the pkg-config file for a month or two without issue. Just figured now that it might be helpful to others.
