### PR TITLE
Update message_components.PRE.h

### DIFF
--- a/gencodecs/api/message_components.PRE.h
+++ b/gencodecs/api/message_components.PRE.h
@@ -85,7 +85,9 @@ PUB_STRUCT(discord_component)
   /** whether this componentis required to be filled */
     FIELD(required, bool, false)
   /** a pre-filled value for this component */
+  COND_WRITE(self->value != NULL)
     FIELD_PTR(value, char, *)
+  COND_END
 STRUCT_END
 #endif
 


### PR DESCRIPTION
Fix required value in sending modal

## Notice
- [x] I *understand* the code that I have edited, and have the means
to test it before making changes to Concord.

## What?
<!-- Explain the changes you've made - the overall effect of the PR. -->
Add extra condition to creating JSON for message components value field

## Why?
<!-- Evaluate tangible code changes - explain the reason for the PR. -->
When adding a field to a modal if you did not properly specify a default value it would cause the API error below
```
[DISCORD_REQUEST] {"message": "Invalid Form Body", "code": 50035, "errors": {"data": {"components": {"0": {"components": {"0": {"value": {"_errors": [{"code": "BASE_TYPE_MIN_LENGTH", "message": "Must be 17 or more in length."}]}}}}}}}}
```

By not adding the `value` field it doesn't use a default value and doesn't return this error

## How?
<!-- Explain the solution carried out by the PR. -->
Add is not NULL condition to adding the value field

## Testing?
<!--
Explain how you tested your changes - let the reviewer know of any untested 
conditions or edge cases, why they weren't tested, and how likely they are to
occur, and if so, any associated risks.
-->
Compiled changes in commit tested sending a modal with a NULL. All of which worked perfectly
