### PR TITLE
Include raw json with response

### DIFF
--- a/include/discord-internal.h
+++ b/include/discord-internal.h
@@ -460,6 +460,8 @@ struct discord_request {
     struct ua_conn *conn;
     /** request's status code */
     CCORDcode code;
+    /** response payload */
+    struct ccord_szbuf_readonly json;
     /** current retry attempt (stop at rest->retry_limit) */
     int retry_attempt;
     /** synchronize synchronous requests */

--- a/include/discord-response.h
+++ b/include/discord-response.h
@@ -16,6 +16,11 @@ struct discord_response {
     const void *keep;
     /** request completion status @see @ref ConcordError */
     CCORDcode code;
+    /** the JSON object in case of a @ref CCORD_OK, or the JSON error
+     *      object in case of a @ref CCORD_DISCORD_JSON_CODE
+     *
+     * @see https://discord.com/developers/docs/reference#error-messages */
+    struct ccord_szbuf_readonly json;
 };
 
 /******************************************************************************


### PR DESCRIPTION
## Notice
- [x] I *understand* the code that I have edited, and have the means
to test it before making changes to Concord.

## What?
<!-- Explain the changes you've made - the overall effect of the PR. -->
Include raw JSON with done and fail callback response

## Why?
<!-- Evaluate tangible code changes - explain the reason for the PR. -->
Allow users to parse Discord errors in runtime, as described here:
https://discord.com/developers/docs/reference#error-messages

## How?
<!-- Explain the solution carried out by the PR. -->
Include a new attribute `.json` under `struct discord_response` for `done` and `fail` callbacks

## Testing?
<!--
Explain how you tested your changes - let the reviewer know of any untested 
conditions or edge cases, why they weren't tested, and how likely they are to
occur, and if so, any associated risks.
-->
WIP