### PR TITLE
Fix: Unnecessary warnings

### DIFF
--- a/core/attributes.h
+++ b/core/attributes.h
@@ -1,5 +1,8 @@
-#if defined(__MINGW32__) || (defined (__GNUC__) && __GNUC__ > 4 ? true : __GNUC_PATCHLEVEL__ >= 4) || defined(__USE_MINGW_ANSI_STDIO)
+#if defined(__MINGW32__) || (defined (__GNUC__) &&      \
+		__GNUC__ > 4 ? true : __GNUC_PATCHLEVEL__ >= 4) \
+		|| defined(__USE_MINGW_ANSI_STDIO)
 #  define PRINTF_LIKE(a, b) __attribute__((format(gnu_printf, a, b)))
 #else
 #  define PRINTF_LIKE(a, b)
 #endif
+

--- a/core/queriec.h
+++ b/core/queriec.h
@@ -17,10 +17,14 @@ struct queriec {
 void
 queriec_init(struct queriec *queriec, size_t size);
 
-int queriec_snprintf_add(struct queriec *queriec, char *query, const char key[], size_t keySize, 
-                         char buffer[], size_t bufferLen, const char *format, ...) PRINTF_LIKE(7, 8);
+int queriec_snprintf_add(struct queriec *queriec, char *query, 
+		const char key[], size_t keySize, 
+		char buffer[], size_t bufferLen, 
+		const char *format, ...) PRINTF_LIKE(7, 8);
 
 int
-queriec_add(struct queriec *queriec, char *query, char key[], size_t keySize, char value[], size_t valueSize);
+queriec_add(struct queriec *queriec, char *query, char key[], 
+		size_t keySize, char value[], size_t valueSize);
 
 #endif
+

--- a/include/concord-once.h
+++ b/include/concord-once.h
@@ -7,7 +7,7 @@
 #ifndef CONCORD_ONCE_H
 
 /** @brief Asynchronously shutdown all client(s) from their on-going sessions */
-void ccord_shutdown_async();
+void ccord_shutdown_async(void);
 
 /**
  * @brief Whether or not concord is currently shutting down
@@ -17,16 +17,17 @@ void ccord_shutdown_async();
  * @note client shall only attempt to disconnect if there aren't any active
  *    events waiting to be listened or reacted to
  */
-int ccord_shutting_down();
+int ccord_shutting_down(void);
 
 /**
  * @brief Initialize global shared-resources not API-specific
  *
  * @return CCORD_OK on success, CCORD_GLOBAL_INIT on error
  */
-CCORDcode ccord_global_init();
+CCORDcode ccord_global_init(void);
 
 /** @brief Cleanup global shared-resources */
-void ccord_global_cleanup();
+void ccord_global_cleanup(void);
 
 #endif /* CONCORD_ONCE_H */
+

--- a/src/concord-once.c
+++ b/src/concord-once.c
@@ -51,7 +51,7 @@ _ccord_sigint_handler(int signum)
 #endif /* CCORD_SIGINTCATCH */
 
 CCORDcode
-ccord_global_init()
+ccord_global_init(void)
 {
     pthread_mutex_lock(&lock);
     if (0 == init_counter++) {
@@ -80,8 +80,16 @@ ccord_global_init()
                     goto fail_pipe_init;
                 }
             #endif
-
-            if (0 != ioctl(shutdown_fds[i], (int)FIONBIO, &on)) {
+/*BSD based systems and glibc use unsigned long for ioctl*/
+#if defined __FreeBSD__ || defined __NetBSD__ || \
+				defined __DragonFly__ || defined __bsdi__ || \
+				defined __APPLE__ || defined __GLIBC__
+			if (0 != ioctl(shutdown_fds[i], FIONBIO, &on)) {
+#elif OSCLASS == UNIX
+			if (0 != ioctl(shutdown_fds[i], (int)FIONBIO, &on)) {
+#else
+			if (0 != ioctl(shutdown_fds[i], FIONBIO, &on)) {
+#endif
                 fputs("Failed to make shutdown pipe nonblocking\n", stderr);
                 goto fail_pipe_init;
             }
@@ -108,7 +116,7 @@ fail_curl_init:
 }
 
 void
-ccord_global_cleanup()
+ccord_global_cleanup(void)
 {
     pthread_mutex_lock(&lock);
     if (init_counter && 0 == --init_counter) {
@@ -137,7 +145,16 @@ discord_dup_shutdown_fd(void)
             }
         #endif
 
-        if (0 != ioctl(fd, (int)FIONBIO, &on)) {
+/*BSD based systems and glibc use unsigned long for ioctl*/
+#if defined __FReeBSD__ || defined __NetBSD__ || \
+				defined __DragonFly__ || defined __bsdi__ || \
+				defined __APPLE__ || defined __GLIBC__
+		if (0 != ioctl(fd, FIONBIO, &on)) {
+#elif OSCLASS == UNIX
+		if (0 != ioctl(fd, (int)FIONBIO, &on)) {
+#else
+		if (0 != ioctl(fd, FIONBIO, &on)) {
+#endif
             close(fd);
             return -1;
         }


### PR DESCRIPTION
## Notice
- [x] I *understand* the code that I have edited, and have the means
to test it before making changes to Concord.

## What?
<!-- Explain the changes you've made - the overall effect of the PR. -->

* Fixes the most of the warnings generated, and also some spots I noticed went over 80 characters.
* Note: We still need to fix the few depreciated Curl warnings.
* Another Note: ``(size_t)src->size`` is fine, and realistically the warning should not be there. (discord-rest_request.c:532)

## Why?
<!-- Evaluate tangible code changes - explain the reason for the PR. -->

* To stop the spam of warnings on most systems.
* To save lives.

## How?
<!-- Explain the solution carried out by the PR. -->

* void arguments in prototypes.
* Checks the system for the correct castings with ioctl.

## Testing?
<!--
Explain how you tested your changes - let the reviewer know of any untested 
conditions or edge cases, why they weren't tested, and how likely they are to
occur, and if so, any associated risks.
-->

Ran the builds, and tested on a bot.

## Anything Else?
<!--
(optional) Delve into possible architecture changes - call out challenges,
optimizations, etc. Use this as an opportunity to call out setbacks encountered
because of the current codebase.
-->
Let's rewrite concord in rugbust.