### PR TITLE
Add new method for initializing client

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ void on_interaction(struct discord *client, const struct discord_interaction *ev
 }
 
 int main(void) {
-    struct discord *client = discord_init(BOT_TOKEN);
+    struct discord *client = discord_from_token(BOT_TOKEN);
     discord_set_on_ready(client, &on_ready);
     discord_set_on_interaction_create(client, &on_interaction);
     discord_run(client);
@@ -125,7 +125,7 @@ void on_message(struct discord *client, const struct discord_message *event) {
 }
 
 int main(void) {
-    struct discord *client = discord_init(BOT_TOKEN);
+    struct discord *client = discord_from_token(BOT_TOKEN);
     discord_add_intents(client, DISCORD_GATEWAY_MESSAGE_CONTENT);
     discord_set_on_ready(client, &on_ready);
     discord_set_on_message_create(client, &on_message);

--- a/docs/guides/config.json_directives.md
+++ b/docs/guides/config.json_directives.md
@@ -22,7 +22,7 @@ The `config.json` file is a configuration file that can be used to start your bo
 
 ### token
 
-The token that Concord will use to log in to the bot, in case you use the `discord_config_init` to define the `struct discord *client`.
+The token that Concord will use to log in to the bot, in case you use the `discord_from_json` to define the `struct discord *client`.
 
 ### log
 
@@ -111,9 +111,9 @@ snprintf(foo, sizeof(foo), "%.*s", (int)value.size, value.start);
 struct ccord_szbuf_readonly discord_config_get_field(struct discord *client, char *const path[], unsigned depth)
 ```
 
-Attention: this function will only work if you initialize your bot with the `discord_config_init`.
+Attention: this function will only work if you initialize your bot with the `discord_from_json`.
 
-The first argument of `discord_config_get_field` is the `struct discord *client` that `discord_init`/`discord_config_init` (or also, in case the code is inside some kind of event, it might be on the event parameters) returns to you.
+The first argument of `discord_config_get_field` is the `struct discord *client` that `discord_from_token`/`discord_from_json` (or also, in case the code is inside some kind of event, it might be on the event parameters) returns to you.
 
 The second argument is a `const x[]` (also known as `array`) the path to the field where you want to get its value.
 

--- a/docs/guides/embeds.md
+++ b/docs/guides/embeds.md
@@ -195,7 +195,7 @@ void on_sendembed(struct discord *client, const struct discord_message *msg) {
 }
 
 int main(void) {
-    struct discord *client = discord_config_init("config.json");
+    struct discord *client = discord_from_json("config.json");
 
     discord_add_intents(client, DISCORD_GATEWAY_MESSAGE_CONTENT);
 

--- a/docs/guides/setup_concord_with_env.md
+++ b/docs/guides/setup_concord_with_env.md
@@ -118,7 +118,7 @@ int main() {
 }
 ```
 
-Using `${}` (this only applies to [discord_config](https://cogmasters.github.io/concord/group__DiscordClient.html#gacd52a9fc58a1fcb9b4719a5cedd70f5d) and [discord_config_init](https://cogmasters.github.io/concord/group__DiscordClient.html#ga75bbe1d3eb9e6d03953b6313e5543afb)):
+Using `${}` (this only applies to [discord_config](https://cogmasters.github.io/concord/group__DiscordClient.html#gacd52a9fc58a1fcb9b4719a5cedd70f5d) and [discord_from_json](https://cogmasters.github.io/concord/group__DiscordClient.html#ga75bbe1d3eb9e6d03953b6313e5543afb)):
 
 ```c
 #include <stdio.h>
@@ -133,7 +133,7 @@ void on_ready(struct discord *client, const struct discord_ready *event) {
 }
 
 int main() {
-    struct discord *client = discord_init("${" ENV_VARIABLE_NAME "}");
+    struct discord *client = discord_from_token("${" ENV_VARIABLE_NAME "}");
 
     discord_set_on_ready(client, &on_ready);
 

--- a/docs/guides/slash-commands.md
+++ b/docs/guides/slash-commands.md
@@ -360,7 +360,7 @@ void on_interaction(struct discord *client, const struct discord_interaction *in
 }
 
 int main(void) {
-    struct discord *client = discord_config_init("config.json");
+    struct discord *client = discord_from_json("config.json");
     
     // Register event handlers
     discord_set_on_ready(client, &on_ready);

--- a/docs/guides/sqlite3_db_with_concord.md
+++ b/docs/guides/sqlite3_db_with_concord.md
@@ -522,7 +522,7 @@ int main(void) {
     }
     
     // Initialize Discord bot
-    struct discord *client = discord_config_init("config.json");
+    struct discord *client = discord_from_json("config.json");
     discord_add_intents(client, DISCORD_GATEWAY_MESSAGE_CONTENT);
     
     // Set up event handlers

--- a/examples/8ball.c
+++ b/examples/8ball.c
@@ -81,7 +81,7 @@ main(int argc, char *argv[])
     srand(time(0));
 
     ccord_global_init();
-    struct discord *client = discord_config_init(config_file);
+    struct discord *client = discord_from_json(config_file);
     assert(NULL != client && "Couldn't initialize client");
 
     discord_set_on_ready(client, &on_ready);

--- a/examples/audit-log.c
+++ b/examples/audit-log.c
@@ -120,7 +120,7 @@ main(int argc, char *argv[])
         config_file = "../config.json";
 
     ccord_global_init();
-    struct discord *client = discord_config_init(config_file);
+    struct discord *client = discord_from_json(config_file);
     assert(NULL != client && "Couldn't initialize client");
 
     discord_add_intents(client, 32767); // subscribe to all events

--- a/examples/ban.c
+++ b/examples/ban.c
@@ -119,7 +119,7 @@ main(int argc, char *argv[])
         config_file = "../config.json";
 
     ccord_global_init();
-    struct discord *client = discord_config_init(config_file);
+    struct discord *client = discord_from_json(config_file);
     assert(NULL != client && "Couldn't initialize client");
 
     discord_set_on_ready(client, &on_ready);

--- a/examples/cache.c
+++ b/examples/cache.c
@@ -36,7 +36,7 @@ main(int argc, char *argv[])
 {
     const char *const config_file = argc > 1 ? argv[1] : "../config.json";
     ccord_global_init();
-    struct discord *client = discord_config_init(config_file);
+    struct discord *client = discord_from_json(config_file);
 
     // enable message caching
     discord_cache_enable(client,

--- a/examples/channel.c
+++ b/examples/channel.c
@@ -261,7 +261,7 @@ main(int argc, char *argv[])
         config_file = "../config.json";
 
     ccord_global_init();
-    struct discord *client = discord_config_init(config_file);
+    struct discord *client = discord_from_json(config_file);
     assert(NULL != client && "Could not initialize client");
 
     discord_set_on_ready(client, &on_ready);

--- a/examples/components.c
+++ b/examples/components.c
@@ -211,7 +211,7 @@ main(int argc, char *argv[])
         config_file = "../config.json";
 
     ccord_global_init();
-    struct discord *client = discord_config_init(config_file);
+    struct discord *client = discord_from_json(config_file);
     assert(NULL != client && "Couldn't initialize client");
 
     discord_set_on_ready(client, &on_ready);

--- a/examples/copycat.c
+++ b/examples/copycat.c
@@ -97,7 +97,7 @@ main(int argc, char *argv[])
         config_file = "../config.json";
 
     ccord_global_init();
-    struct discord *client = discord_config_init(config_file);
+    struct discord *client = discord_from_json(config_file);
     assert(NULL != client && "Couldn't initialize client");
 
     discord_add_intents(client, DISCORD_GATEWAY_MESSAGE_CONTENT);

--- a/examples/embed.c
+++ b/examples/embed.c
@@ -157,7 +157,7 @@ main(int argc, char *argv[])
         config_file = "../config.json";
 
     ccord_global_init();
-    struct discord *client = discord_config_init(config_file);
+    struct discord *client = discord_from_json(config_file);
     assert(NULL != client && "Couldn't initialize client");
 
     discord_set_on_ready(client, &on_ready);

--- a/examples/emoji.c
+++ b/examples/emoji.c
@@ -151,7 +151,7 @@ main(int argc, char *argv[])
         config_file = "../config.json";
 
     ccord_global_init();
-    struct discord *client = discord_config_init(config_file);
+    struct discord *client = discord_from_json(config_file);
     assert(NULL != client && "Could not initialize client");
 
     discord_set_on_ready(client, &on_ready);

--- a/examples/fetch-messages.c
+++ b/examples/fetch-messages.c
@@ -153,7 +153,7 @@ main(int argc, char *argv[])
         config_file = "../config.json";
 
     ccord_global_init();
-    struct discord *client = discord_config_init(config_file);
+    struct discord *client = discord_from_json(config_file);
     assert(NULL != client && "Couldn't initialize client");
 
     print_usage();

--- a/examples/guild-template.c
+++ b/examples/guild-template.c
@@ -110,7 +110,7 @@ main(int argc, char *argv[])
         config_file = "../config.json";
 
     ccord_global_init();
-    struct discord *client = discord_config_init(config_file);
+    struct discord *client = discord_from_json(config_file);
     assert(NULL != client && "Couldn't initialize client");
 
     discord_set_on_ready(client, &on_ready);

--- a/examples/guild.c
+++ b/examples/guild.c
@@ -287,7 +287,7 @@ main(int argc, char *argv[])
         config_file = "../config.json";
 
     ccord_global_init();
-    struct discord *client = discord_config_init(config_file);
+    struct discord *client = discord_from_json(config_file);
     assert(NULL != client && "Couldn't initialize client");
 
     discord_set_on_ready(client, &on_ready);

--- a/examples/invite.c
+++ b/examples/invite.c
@@ -94,7 +94,7 @@ main(int argc, char *argv[])
         config_file = "../config.json";
 
     ccord_global_init();
-    struct discord *client = discord_config_init(config_file);
+    struct discord *client = discord_from_json(config_file);
     assert(NULL != client && "Could not initialize client");
 
     discord_set_on_ready(client, &on_ready);

--- a/examples/manual-dm.c
+++ b/examples/manual-dm.c
@@ -99,7 +99,7 @@ main(int argc, char *argv[])
         config_file = "../config.json";
 
     ccord_global_init();
-    struct discord *client = discord_config_init(config_file);
+    struct discord *client = discord_from_json(config_file);
     assert(NULL != client && "Couldn't initialize client");
 
     discord_add_intents(client, DISCORD_GATEWAY_MESSAGE_CONTENT);

--- a/examples/pin.c
+++ b/examples/pin.c
@@ -127,7 +127,7 @@ main(int argc, char *argv[])
         config_file = "../config.json";
 
     ccord_global_init();
-    struct discord *client = discord_config_init(config_file);
+    struct discord *client = discord_from_json(config_file);
     assert(NULL != client && "Couldn't initialize client");
 
     discord_set_on_ready(client, &on_ready);

--- a/examples/ping-pong.c
+++ b/examples/ping-pong.c
@@ -49,7 +49,7 @@ main(int argc, char *argv[])
         config_file = "../config.json";
 
     ccord_global_init();
-    struct discord *client = discord_config_init(config_file);
+    struct discord *client = discord_from_json(config_file);
 
     discord_set_on_ready(client, &on_ready);
     discord_set_on_command(client, "ping", &on_ping);

--- a/examples/presence.c
+++ b/examples/presence.c
@@ -55,7 +55,7 @@ main(int argc, char *argv[])
         config_file = "../config.json";
 
     ccord_global_init();
-    struct discord *client = discord_config_init(config_file);
+    struct discord *client = discord_from_json(config_file);
     assert(NULL != client && "Couldn't initialize client");
 
     discord_set_on_ready(client, &on_ready);

--- a/examples/reaction.c
+++ b/examples/reaction.c
@@ -157,7 +157,7 @@ main(int argc, char *argv[])
         config_file = "../config.json";
 
     ccord_global_init();
-    struct discord *client = discord_config_init(config_file);
+    struct discord *client = discord_from_json(config_file);
     assert(NULL != client && "Couldn't initialize client");
 
     discord_set_on_ready(client, &on_ready);

--- a/examples/shell.c
+++ b/examples/shell.c
@@ -137,7 +137,7 @@ main(int argc, char *argv[])
         config_file = "../config.json";
 
     ccord_global_init();
-    struct discord *client = discord_config_init(config_file);
+    struct discord *client = discord_from_json(config_file);
     assert(NULL != client && "Couldn't initialize client");
 
     discord_set_prefix(client, "$");

--- a/examples/slash-commands.c
+++ b/examples/slash-commands.c
@@ -160,7 +160,7 @@ main(int argc, char *argv[])
         config_file = "../config.json";
 
     ccord_global_init();
-    struct discord *client = discord_config_init(config_file);
+    struct discord *client = discord_from_json(config_file);
     assert(NULL != client && "Could not initialize client");
 
     discord_set_on_command(client, "!slash_create", &on_slash_command_create);

--- a/examples/slash-commands2.c
+++ b/examples/slash-commands2.c
@@ -271,7 +271,7 @@ main(int argc, char *argv[])
         config_file = "../config.json";
 
     ccord_global_init();
-    struct discord *client = discord_config_init(config_file);
+    struct discord *client = discord_from_json(config_file);
     assert(NULL != client && "Could not initialize client");
 
     discord_set_on_ready(client, &on_ready);

--- a/examples/spam.c
+++ b/examples/spam.c
@@ -63,7 +63,7 @@ main(int argc, char *argv[])
         config_file = "../config.json";
 
     ccord_global_init();
-    struct discord *client = discord_config_init(config_file);
+    struct discord *client = discord_from_json(config_file);
     assert(NULL != client && "Couldn't initialize client");
 
     discord_set_on_command(client, "!spam-async", &on_spam_async);

--- a/examples/timers.c
+++ b/examples/timers.c
@@ -60,7 +60,7 @@ main(int argc, char *argv[])
 {
     const char *config_file = argc > 1 ? argv[1] : "../config.json";
     ccord_global_init();
-    struct discord *client = discord_config_init(config_file);
+    struct discord *client = discord_from_json(config_file);
 
     for (int i = 0; i < 10; i++)
         // one shot auto deleting timer

--- a/examples/webhook.c
+++ b/examples/webhook.c
@@ -41,7 +41,7 @@ main(int argc, char *argv[])
     fgetc(stdin); // wait for input
 
     ccord_global_init();
-    struct discord *client = discord_init(NULL);
+    struct discord *client = discord_from_token(NULL);
     assert(NULL != client && "Couldn't initialize client");
 
     /* Get Webhook */

--- a/include/application_command.h
+++ b/include/application_command.h
@@ -16,7 +16,7 @@
 /**
  * @brief Fetch all of the global commands for your application
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param application_id the unique id of the parent application
  * @CCORD_ret_obj{ret,application_commands}
  * @CCORD_return
@@ -30,7 +30,7 @@ CCORDcode discord_get_global_application_commands(
  * @brief Create a new global command
  * @note New global commands will be available in all guilds after 1 hour
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param application_id the unique id of the parent application
  * @param params request parameters
  * @CCORD_ret_obj{ret,application_command}
@@ -45,7 +45,7 @@ CCORDcode discord_create_global_application_command(
 /**
  * @brief Fetch a global command for your application
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param application_id the unique id of the parent application
  * @param command_id the registered command id
  * @CCORD_ret_obj{ret,application_command}
@@ -61,7 +61,7 @@ CCORDcode discord_get_global_application_command(
  * @brief Edit a global command
  * @note Updates will be available in all guilds after 1 hour
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param application_id the unique id of the parent application
  * @param command_id the registered command id
  * @param params request parameters
@@ -78,7 +78,7 @@ CCORDcode discord_edit_global_application_command(
 /**
  * @brief Deletes a global command
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param application_id the unique id of the parent application
  * @param command_id the registered command id
  * @CCORD_ret{ret}
@@ -96,7 +96,7 @@ CCORDcode discord_delete_global_application_command(
  * @warning Will overwrite all types of application commands: slash
  *        commands, user commands, and message commands
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param application_id the unique id of the parent application
  * @param params the request parameters, a list of application commands
  * @CCORD_ret_obj{ret,application_commands}
@@ -111,7 +111,7 @@ CCORDcode discord_bulk_overwrite_global_application_commands(
 /**
  * @brief Fetch all of the guild commands of a given guild
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param application_id the unique id of the parent application
  * @param guild_id the guild where the commands are located
  * @CCORD_ret_obj{ret,application_commands}
@@ -128,7 +128,7 @@ CCORDcode discord_get_guild_application_commands(
  * @note Commands will be available in the guild immediately
  * @note Will overwrite any existing guild command with the same name
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param application_id the unique id of the parent application
  * @param guild_id the guild where the command is located
  * @param params request parameters
@@ -145,7 +145,7 @@ CCORDcode discord_create_guild_application_command(
 /**
  * @brief Fetch a guild command for your application
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param application_id the unique id of the parent application
  * @param guild_id the guild where the command is located
  * @param command_id the registered command id
@@ -163,7 +163,7 @@ CCORDcode discord_get_guild_application_command(
  * @brief Edit a guild command
  * @note Updates for guild commands will be available immediately
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param application_id the unique id of the parent application
  * @param guild_id the guild where the command is located
  * @param command_id the registered command id
@@ -182,7 +182,7 @@ CCORDcode discord_edit_guild_application_command(
 /**
  * @brief Deletes a guild command
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param application_id the unique id of the parent application
  * @param guild_id the guild where the command is located
  * @param command_id the registered command id
@@ -200,7 +200,7 @@ CCORDcode discord_delete_guild_application_command(struct discord *client,
  * @warning This will overwrite all types of application commands: slash
  *        commands, user commands, and message commands
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param application_id the unique id of the parent application
  * @param guild_id the guild where the commands are located
  * @param params the request parameters, a list of application commands
@@ -217,7 +217,7 @@ CCORDcode discord_bulk_overwrite_guild_application_commands(
 /**
  * @brief Fetches command permissions for all commands in a given guild
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param application_id the unique id of the parent application
  * @param guild_id the guild where the commands are located
  * @CCORD_ret_obj{ret,guild_application_command_permissions}
@@ -232,7 +232,7 @@ CCORDcode discord_get_guild_application_command_permissions(
 /**
  * @brief Fetches command permissions for a specific command in a given guild
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param application_id the unique id of the parent application
  * @param guild_id the guild where the command is located
  * @param command_id the registered command id

--- a/include/audit_log.h
+++ b/include/audit_log.h
@@ -16,7 +16,7 @@
  * @brief Get audit log for a given guild
  *
  * @note Requires the 'VIEW_AUDIT_LOG' permission
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param guild_id the guild to retrieve the audit log from
  * @param params request parameters
  * @CCORD_ret_obj{ret,audit_log}

--- a/include/auto_moderation.h
+++ b/include/auto_moderation.h
@@ -16,7 +16,7 @@
  * @brief Get a list of all rules currently configured for the guild
  * @note Requires the `MANAGE_GUILD` permission
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param guild_id the guild to fetch the rules from
  * @CCORD_ret_obj{ret,auto_moderation_rules}
  * @CCORD_return
@@ -30,7 +30,7 @@ CCORDcode discord_list_auto_moderation_rules_for_guild(
  * @brief Get a single rule
  * @note Requires the `MANAGE_GUILD` permission
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param guild_id the guild to fetch the rule from
  * @param auto_moderation_rule_id the rule to be fetched
  * @CCORD_ret_obj{ret,auto_moderation_rule}
@@ -46,7 +46,7 @@ CCORDcode discord_get_auto_moderation_rule(
  * @brief Create a new rule
  * @note Requires the `MANAGE_GUILD` permission
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param guild_id the guild to create the rule in
  * @param params request parameters
  * @CCORD_ret_obj{ret,auto_moderation_rule}
@@ -62,7 +62,7 @@ CCORDcode discord_create_auto_moderation_rule(
  * @brief Modify an existing rule
  * @note Requires the `MANAGE_GUILD` permission
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param guild_id the guild where the rule to be modified is at
  * @param auto_moderation_rule_id the rule to be modified
  * @param params request parameters
@@ -80,7 +80,7 @@ CCORDcode discord_modify_auto_moderation_rule(
  * @brief Delete a rule
  * @note Requires the `MANAGE_GUILD` permission
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param guild_id the guild where the rule to be deleted is at
  * @param auto_moderation_rule_id the rule to be deleted
  * @param params request parameters

--- a/include/channel.h
+++ b/include/channel.h
@@ -21,7 +21,7 @@ struct discord_ret_users;
  * @note If the channel is a thread, a thread member object is included in the
  * returned result
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param channel_id the channel to be retrieved
  * @CCORD_ret_obj{ret,channel}
  * @CCORD_return
@@ -33,7 +33,7 @@ CCORDcode discord_get_channel(struct discord *client,
 /**
  * @brief Update a channel's settings
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param channel_id the channel to be modified
  * @param params request parameters
  * @CCORD_ret_obj{ret,channel}
@@ -54,7 +54,7 @@ CCORDcode discord_modify_channel(struct discord *client,
  * @note Fires a `Channel Delete` event (or `Thread Delete` if the channel
  *       was a thread)
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param channel_id the channel to be deleted
  * @param params request parameters
  * @CCORD_ret_obj{ret,channel}
@@ -75,7 +75,7 @@ CCORDcode discord_delete_channel(struct discord *client,
  * @note The before, after, and around keys are mutually exclusive, only one
  *       may be passed at a time
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param channel_id the channel to get messages from
  * @param params request parameters
  * @CCORD_ret_obj{ret,messages}
@@ -91,7 +91,7 @@ CCORDcode discord_get_channel_messages(
  * @brief Get a specific message in the channel
  * @note If operating on a guild channel, this endpoint requires the
  * 'READ_MESSAGE_HISTORY' permission to be present on the current user
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param channel_id the channel where the message resides
  * @param message_id the message itself
  * @CCORD_ret_obj{ret,message}
@@ -106,7 +106,7 @@ CCORDcode discord_get_channel_message(struct discord *client,
  * @brief Post a message to a guild text or DM channel
  * @note Fires a `Message Create` event
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param channel_id the channel to send the message at
  * @param params request parameters
  * @CCORD_ret_obj{ret,message}
@@ -124,7 +124,7 @@ CCORDcode discord_create_message(struct discord *client,
  *        permission, for all other messages, to be present for the current
  *        user
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param channel_id the news channel that will crosspost
  * @param message_id the message that will crospost
  * @CCORD_ret_obj{ret,message}
@@ -138,7 +138,7 @@ CCORDcode discord_crosspost_message(struct discord *client,
 /**
  * @brief Create a reaction for the message
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param channel_id the channel that the message belongs to
  * @param message_id the message to receive a reaction
  * @param emoji_id the emoji id (leave as 0 if not a custom emoji)
@@ -156,7 +156,7 @@ CCORDcode discord_create_reaction(struct discord *client,
 /**
  * @brief Delete a reaction the current user has made for the message
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param channel_id the channel that the message belongs to
  * @param message_id the message to have a reaction deleted
  * @param emoji_id the emoji id (leave as 0 if not a custom emoji)
@@ -174,7 +174,7 @@ CCORDcode discord_delete_own_reaction(struct discord *client,
 /**
  * @brief Deletes another user's reaction
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param channel_id the channel that the message belongs to
  * @param message_id the message to have a reaction deleted
  * @param user_id the user the reaction belongs to
@@ -194,7 +194,7 @@ CCORDcode discord_delete_user_reaction(struct discord *client,
 /**
  * @brief Get a list of users that reacted with given emoji
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param channel_id the channel that the message belongs to
  * @param message_id the message reacted to
  * @param emoji_id the emoji id (leave as 0 if not a custom emoji)
@@ -214,7 +214,7 @@ CCORDcode discord_get_reactions(struct discord *client,
 /**
  * @brief Deletes all reactions from message
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param channel_id the channel that the message belongs to
  * @param message_id the message that will be purged of reactions
  * @CCORD_ret{ret}
@@ -228,7 +228,7 @@ CCORDcode discord_delete_all_reactions(struct discord *client,
 /**
  * @brief Deletes all the reactions for a given emoji on message
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param channel_id the channel that the message belongs to
  * @param message_id the message that will be purged of reactions from
  *       particular emoji
@@ -247,7 +247,7 @@ CCORDcode discord_delete_all_reactions_for_emoji(struct discord *client,
 /**
  * @brief Edit a previously sent message
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param channel_id the channel that the message belongs to
  * @param message_id the message that will be purged of reactions from
  *       particular emoji
@@ -264,7 +264,7 @@ CCORDcode discord_edit_message(struct discord *client,
 /**
  * @brief Delete a message
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param channel_id the channel that the message belongs to
  * @param message_id the message that will be purged of reactions from
  *       particular emoji
@@ -280,7 +280,7 @@ CCORDcode discord_delete_message(struct discord *client,
 /**
  * @brief Delete multiple messages in a single request
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param channel_id the channel that the message belongs to
  * @param params request parameters
  * @CCORD_ret{ret}
@@ -296,7 +296,7 @@ CCORDcode discord_bulk_delete_messages(
  * @brief Edit the channel permission overwrites for a user or role in a
  *        channel
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param channel_id the channel that the message belongs to
  * @param overwrite_id
  * @param params request parameters
@@ -313,7 +313,7 @@ CCORDcode discord_edit_channel_permissions(
 /**
  * @brief Get invites (with invite metadata) for the channel
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param channel_id the channel that the message belongs to
  * @CCORD_ret_obj{ret,invites}
  * @CCORD_return
@@ -325,7 +325,7 @@ CCORDcode discord_get_channel_invites(struct discord *client,
 /**
  * @brief Create a new invite for the channel
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param channel_id the channel that the message belongs to
  * @param params request parameters
  * @CCORD_ret_obj{ret,invite}
@@ -341,7 +341,7 @@ CCORDcode discord_create_channel_invite(
  * @brief Delete a channel permission overwrite for a user or role in a
  *        channel
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param channel_id the channel to the permission deleted
  * @param overwrite_id the id of the overwritten permission
  * @param params request parameters
@@ -358,7 +358,7 @@ CCORDcode discord_delete_channel_permission(
 /**
  * @brief Post a typing indicator for the specified channel
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param channel_id the channel to post the typing indicator to
  * @CCORD_ret{ret}
  * @CCORD_return
@@ -372,7 +372,7 @@ CCORDcode discord_trigger_typing_indicator(struct discord *client,
  * @note Requires MANAGE_WEBHOOKS permission in the target channel
  *        MANAGE_WEBHOOKS permission in the target channel
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param channel_id the channel to be followed
  * @CCORD_ret_obj{ret,followed_channel}
  * @CCORD_return
@@ -386,7 +386,7 @@ CCORDcode discord_follow_news_channel(
 /**
  * @brief Get all pinned messages in the channel
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param channel_id the channel where the get pinned messages from
  * @CCORD_ret_obj{ret,messages}
  * @CCORD_return
@@ -398,7 +398,7 @@ CCORDcode discord_get_pinned_messages(struct discord *client,
 /**
  * @brief Pin a message to a channel
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param channel_id channel to pin the message on
  * @param message_id message to be pinned
  * @param params request parameters
@@ -414,7 +414,7 @@ CCORDcode discord_pin_message(struct discord *client,
 /**
  * @brief Unpin a message from a channel
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param channel_id channel for the message to be unpinned
  * @param message_id message to be unpinned
  * @param params request parameters
@@ -430,7 +430,7 @@ CCORDcode discord_unpin_message(struct discord *client,
 /**
  * @brief Adds a recipient to a Group DM using their access token
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param channel_id group to add the user in
  * @param user_id user to be added
  * @param params request parameters
@@ -447,7 +447,7 @@ CCORDcode discord_group_dm_add_recipient(
 /**
  * @brief Removes a recipient from a Group DM
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param channel_id channel for the user to be removed from
  * @param user_id user to be removed
  * @CCORD_ret{ret}
@@ -462,7 +462,7 @@ CCORDcode discord_group_dm_remove_recipient(struct discord *client,
  * @brief Creates a new thread from an existing message
  * @note Fires a `Thread Create` event
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param channel_id channel to start a thread on
  * @param message_id message to start a thread from
  * @param params request parameters
@@ -480,7 +480,7 @@ CCORDcode discord_start_thread_with_message(
  * @brief Creates a new thread that is not connected to an existing message
  * @note Fires a `Thread Create` event
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param channel_id channel to start a thread on
  * @param params request parameters
  * @CCORD_ret_obj{ret,channel}
@@ -496,7 +496,7 @@ CCORDcode discord_start_thread_without_message(
  * @brief Adds the current user to an un-archived thread
  * @note Fires a `Thread Members Update` event
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param channel_id the thread to be joined
  * @CCORD_ret{ret}
  * @CCORD_return
@@ -509,7 +509,7 @@ CCORDcode discord_join_thread(struct discord *client,
  * @brief Adds another member to an un-archived thread
  * @note Fires a `Thread Members Update` event
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param channel_id the thread to be joined
  * @param user_id user to be added to thread
  * @CCORD_ret{ret}
@@ -524,7 +524,7 @@ CCORDcode discord_add_thread_member(struct discord *client,
  * @brief Removes the current user from a un-archived thread
  * @note Fires a `Thread Members Update` event
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param channel_id the thread to be removed from
  * @CCORD_ret{ret}
  * @CCORD_return
@@ -538,7 +538,7 @@ CCORDcode discord_leave_thread(struct discord *client,
  * @note Fires a `Thread Members Update` event
  * @note Requires `MANAGE_THREADS` permission
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param channel_id the thread to be removed from
  * @param user_id user to be removed
  * @CCORD_ret{ret}
@@ -554,7 +554,7 @@ CCORDcode discord_remove_thread_member(struct discord *client,
  * @note Fires a `Thread Members Update` event
  * @note Requires `MANAGE_THREADS` permission
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param channel_id the thread to be joined
  * @CCORD_ret_obj{ret,thread_members}
  * @CCORD_return
@@ -569,7 +569,7 @@ CCORDcode discord_list_thread_members(struct discord *client,
  * @deprecated Discord will deprecate this in V10
  * @brief Get all active threads in a given channel
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param channel_id the channel to be searched for threads
  * @CCORD_ret_obj{ret,thread_response_body}
  * @CCORD_return
@@ -582,7 +582,7 @@ CCORDcode discord_list_active_threads(
 /**
  * @brief Get public archived threads in a given channel
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param channel_id the channel to be searched for threads
  * @param before return threads before this timestamp
  * @param limit maximum number of threads to return
@@ -599,7 +599,7 @@ CCORDcode discord_list_public_archived_threads(
 /**
  * @brief Get private archived threads in a given channel
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param channel_id the channel to be searched for threads
  * @param before return threads before this timestamp
  * @param limit maximum number of threads to return
@@ -616,7 +616,7 @@ CCORDcode discord_list_private_archived_threads(
 /**
  * @brief Get private archived threads that current user has joined
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param channel_id the channel to be searched for threads
  * @param before return threads before this timestamp
  * @param limit maximum number of threads to return
@@ -637,7 +637,7 @@ CCORDcode discord_list_joined_private_archived_threads(
 /**
  * @brief Get a guild's channel from its given numerical position
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param guild_id guild the channel belongs to
  * @param type the channel type where to take position reference from
  * @CCORD_ret_obj{ret,channel}

--- a/include/discord-cache.h
+++ b/include/discord-cache.h
@@ -24,7 +24,7 @@ void discord_cache_enable(struct discord *client,
  * @brief Get a message from cache, only if locally available in RAM
  * @note When done, discord_unclaim() must be called on the message resource
  *
- * @param client the client initialized with discord_init()
+ * @param client the client initialized with discord_from_token()
  * @param channel_id the channel id the message is in
  * @param message_id the id of the message
  * @return `NULL` if not found, or a cache'd message
@@ -36,7 +36,7 @@ const struct discord_message *discord_cache_get_channel_message(
  * @brief Get a guild from cache, only if locally available in RAM
  * @note When done, discord_unclaim() must be called on the guild resource
  *
- * @param client the client initialized with discord_init()
+ * @param client the client initialized with discord_from_token()
  * @param guild_id the id of the guild
  * @return `NULL` if not found, or a cache'd guild
  */

--- a/include/discord-events.h
+++ b/include/discord-events.h
@@ -17,7 +17,7 @@
  * @see
  * https://discord.com/developers/docs/topics/gateway#request-guild-members
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param request request guild members information
  */
 void discord_request_guild_members(
@@ -27,7 +27,7 @@ void discord_request_guild_members(
  * @brief Sent when a client wants to join, move or disconnect from a voice
  *      channel
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param update request guild members information
  */
 void discord_update_voice_state(struct discord *client,
@@ -37,7 +37,7 @@ void discord_update_voice_state(struct discord *client,
  * @brief Update the client presence status
  * @see discord_presence_add_activity()
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param presence status to update the client's to
  */
 void discord_update_presence(struct discord *client,
@@ -48,7 +48,7 @@ void discord_update_presence(struct discord *client,
  * @deprecated since v2.0.0, use discord_update_presence() instead
  * @see discord_presence_add_activity()
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param presence status to update the client's to
  */
 void discord_set_presence(struct discord *client,
@@ -164,7 +164,7 @@ typedef enum discord_event_scheduler (*discord_ev_scheduler)(
  *
  * Allows the user to scan the preliminary raw JSON event payload, and control
  *      whether it should trigger callbacks
- * @param client the client created_with discord_init()
+ * @param client the client created_with discord_from_token()
  * @param fn the function that will be executed
  * @warning The user is responsible for providing their own locking mechanism
  *      to avoid race-condition on sensitive data
@@ -175,7 +175,7 @@ void discord_set_event_scheduler(struct discord *client,
 /**
  * @brief Subscribe to Discord Events
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param code the intents opcode, can be set as a bitmask operation
  */
 void discord_add_intents(struct discord *client, uint64_t code);
@@ -183,7 +183,7 @@ void discord_add_intents(struct discord *client, uint64_t code);
 /**
  * @brief Unsubscribe from Discord Events
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param code the intents opcode, can be set as bitmask operation
  *        Ex: 1 << 0 | 1 << 1 | 1 << 4
  */
@@ -195,7 +195,7 @@ void discord_remove_intents(struct discord *client, uint64_t code);
  *
  * Example: If @a 'help' is a command and @a '!' prefix is set, the command
  *       will only be validated if @a '!help' is sent
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param prefix the mandatory command prefix
  */
 void discord_set_prefix(struct discord *client, const char prefix[]);
@@ -205,7 +205,7 @@ void discord_set_prefix(struct discord *client, const char prefix[]);
  *
  * The callback is triggered when a user types the assigned command in a
  *        chat visible to the client
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param command the command to trigger the callback
  * @param callback the callback to be triggered on event
  * @note The command and any subjacent empty space is left out of
@@ -222,7 +222,7 @@ void discord_set_on_command(
  *
  * The callback is triggered when a user types one of the assigned commands in
  *        a chat visble to the client
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param commands array of commands to trigger the callback
  * @param amount amount of commands provided
  * @param callback the callback to be triggered on event
@@ -251,7 +251,7 @@ void discord_set_next_wakeup(struct discord *client, int64_t delay);
  * @note This is a Concord custom event
  * @deprecated since v2.1.0, rely on @ref DiscordTimer instead
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param callback the callback to be triggered on event
  */
 void discord_set_on_wakeup(struct discord *client,
@@ -261,7 +261,7 @@ void discord_set_on_wakeup(struct discord *client,
  * @brief Triggers when idle
  * @note This is a Concord custom event
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param callback the callback to be triggered on event
  */
 void discord_set_on_idle(struct discord *client,
@@ -271,7 +271,7 @@ void discord_set_on_idle(struct discord *client,
  * @brief Triggers once per event-loop cycle
  * @note This is a Concord custom event
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param callback the callback to be triggered on event
  */
 void discord_set_on_cycle(struct discord *client,
@@ -280,7 +280,7 @@ void discord_set_on_cycle(struct discord *client,
 /**
  * @brief Triggers when the client session is ready
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param callback the callback to be triggered on event
  */
 void discord_set_on_ready(struct discord *client,
@@ -290,7 +290,7 @@ void discord_set_on_ready(struct discord *client,
 /**
  * @brief Triggers when an application command permission is updated
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param callback the callback to be triggered on event
  */
 void discord_set_on_application_command_permissions_update(
@@ -304,7 +304,7 @@ void discord_set_on_application_command_permissions_update(
  * @note This implicitly sets
  *      @ref DISCORD_GATEWAY_AUTO_MODERATION_CONFIGURATION intent
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param callback the callback to be triggered on event
  */
 void discord_set_on_auto_moderation_rule_create(
@@ -317,7 +317,7 @@ void discord_set_on_auto_moderation_rule_create(
  * @note This implicitly sets
  *      @ref DISCORD_GATEWAY_AUTO_MODERATION_CONFIGURATION intent
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param callback the callback to be triggered on event
  */
 void discord_set_on_auto_moderation_rule_update(
@@ -330,7 +330,7 @@ void discord_set_on_auto_moderation_rule_update(
  * @note This implicitly sets
  *      @ref DISCORD_GATEWAY_AUTO_MODERATION_CONFIGURATION intent
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param callback the callback to be triggered on event
  */
 void discord_set_on_auto_moderation_rule_delete(
@@ -344,7 +344,7 @@ void discord_set_on_auto_moderation_rule_delete(
  * @note This implicitly sets @ref DISCORD_GATEWAY_AUTO_MODERATION_EXECUTION
  *      intent
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param callback the callback to be triggered on event
  */
 void discord_set_on_auto_moderation_action_execution(
@@ -357,7 +357,7 @@ void discord_set_on_auto_moderation_action_execution(
  * @brief Triggers when a channel is created
  * @note This implicitly sets @ref DISCORD_GATEWAY_GUILDS intent
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param callback the callback to be triggered on event
  */
 void discord_set_on_channel_create(
@@ -369,7 +369,7 @@ void discord_set_on_channel_create(
  * @brief Triggers when a channel is updated
  * @note This implicitly sets @ref DISCORD_GATEWAY_GUILDS intent
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param callback the callback to be triggered on event
  */
 void discord_set_on_channel_update(
@@ -381,7 +381,7 @@ void discord_set_on_channel_update(
  * @brief Triggers when a channel is deleted
  * @note This implicitly sets @ref DISCORD_GATEWAY_GUILDS intent
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param callback the callback to be triggered on event
  */
 void discord_set_on_channel_delete(
@@ -394,7 +394,7 @@ void discord_set_on_channel_delete(
  * @note This implicitly sets @ref DISCORD_GATEWAY_GUILDS and
  *      @ref DISCORD_GATEWAY_DIRECT_MESSAGES intents
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param callback the callback to be triggered on event
  */
 void discord_set_on_channel_pins_update(
@@ -406,7 +406,7 @@ void discord_set_on_channel_pins_update(
  * @brief Triggers when a thread is created
  * @note This implicitly sets @ref DISCORD_GATEWAY_GUILDS intent
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param callback the callback to be triggered on event
  */
 void discord_set_on_thread_create(
@@ -418,7 +418,7 @@ void discord_set_on_thread_create(
  * @brief Triggers when a thread is updated
  * @note This implicitly sets @ref DISCORD_GATEWAY_GUILDS intent
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param callback the callback to be triggered on event
  */
 void discord_set_on_thread_update(
@@ -430,7 +430,7 @@ void discord_set_on_thread_update(
  * @brief Triggers when a thread is deleted
  * @note This implicitly sets @ref DISCORD_GATEWAY_GUILDS intent
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param callback the callback to be triggered on event
  */
 void discord_set_on_thread_delete(
@@ -442,7 +442,7 @@ void discord_set_on_thread_delete(
  * @brief Triggers when the current user gains access to a channel
  * @note This implicitly sets @ref DISCORD_GATEWAY_GUILDS intent
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param callback the callback to be triggered on event
  */
 void discord_set_on_thread_list_sync(
@@ -456,7 +456,7 @@ void discord_set_on_thread_list_sync(
  *      the thread
  * @note This implicitly sets @ref DISCORD_GATEWAY_GUILDS intent
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param callback the callback to be triggered on event
  */
 void discord_set_on_thread_member_update(
@@ -469,7 +469,7 @@ void discord_set_on_thread_member_update(
  * @note This implicitly sets @ref DISCORD_GATEWAY_GUILDS and
  *      @ref DISCORD_GATEWAY_GUILD_MEMBERS intents
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param callback the callback to be triggered on event
  */
 void discord_set_on_thread_members_update(
@@ -481,7 +481,7 @@ void discord_set_on_thread_members_update(
  * @brief Triggers when a guild is created
  * @note This implicitly sets @ref DISCORD_GATEWAY_GUILDS intent
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param callback the callback to be triggered on event
  */
 void discord_set_on_guild_create(
@@ -493,7 +493,7 @@ void discord_set_on_guild_create(
  * @brief Triggers when a guild is updated
  * @note This implicitly sets @ref DISCORD_GATEWAY_GUILDS intent
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param callback the callback to be triggered on event
  */
 void discord_set_on_guild_update(
@@ -505,7 +505,7 @@ void discord_set_on_guild_update(
  * @brief Triggers when a guild is deleted
  * @note This implicitly sets @ref DISCORD_GATEWAY_GUILDS intent
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param callback the callback to be triggered on event
  */
 void discord_set_on_guild_delete(
@@ -517,7 +517,7 @@ void discord_set_on_guild_delete(
  * @brief Triggers when a user is banned from a guild
  * @note This implicitly sets @ref DISCORD_GATEWAY_GUILD_BANS intent
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param callback the callback to be triggered on event
  */
 void discord_set_on_guild_ban_add(
@@ -529,7 +529,7 @@ void discord_set_on_guild_ban_add(
  * @brief Triggers when a user is unbanned from a guild
  * @note This implicitly sets @ref DISCORD_GATEWAY_GUILD_BANS intent
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param callback the callback to be triggered on event
  */
 void discord_set_on_guild_ban_remove(
@@ -542,7 +542,7 @@ void discord_set_on_guild_ban_remove(
  * @note This implicitly sets
  *      @ref DISCORD_GATEWAY_GUILD_EMOJIS_AND_STICKERS intent
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param callback the callback to be triggered on event
  */
 void discord_set_on_guild_emojis_update(
@@ -555,7 +555,7 @@ void discord_set_on_guild_emojis_update(
  * @note This implicitly sets
  *      @ref DISCORD_GATEWAY_GUILD_EMOJIS_AND_STICKERS intent
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param callback the callback to be triggered on event
  */
 void discord_set_on_guild_stickers_update(
@@ -568,7 +568,7 @@ void discord_set_on_guild_stickers_update(
  * @note This implicitly sets @ref DISCORD_GATEWAY_GUILD_INTEGRATIONS
  *      intent
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param callback the callback to be triggered on event
  */
 void discord_set_on_guild_integrations_update(
@@ -580,7 +580,7 @@ void discord_set_on_guild_integrations_update(
  * @brief Triggers when a guild member is added
  * @note This implicitly sets @ref DISCORD_GATEWAY_GUILD_MEMBERS intent
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param callback the callback to be triggered on event
  */
 void discord_set_on_guild_member_add(
@@ -592,7 +592,7 @@ void discord_set_on_guild_member_add(
  * @brief Triggers when a guild member is updated
  * @note This implicitly sets @ref DISCORD_GATEWAY_GUILD_MEMBERS intent
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param callback the callback to be triggered on event
  */
 void discord_set_on_guild_member_update(
@@ -604,7 +604,7 @@ void discord_set_on_guild_member_update(
  * @brief Triggers when a guild member is removed
  * @note This implicitly sets @ref DISCORD_GATEWAY_GUILD_MEMBERS intent
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param callback the callback to be triggered on event
  */
 void discord_set_on_guild_member_remove(
@@ -615,7 +615,7 @@ void discord_set_on_guild_member_remove(
 /**
  * @brief Triggers in response to discord_request_guild_members()
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param callback the callback to be triggered on event
  */
 void discord_set_on_guild_members_chunk(
@@ -627,7 +627,7 @@ void discord_set_on_guild_members_chunk(
  * @brief Triggers when a guild role is created
  * @note This implicitly sets @ref DISCORD_GATEWAY_GUILDS intent
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param callback the callback to be triggered on event
  */
 void discord_set_on_guild_role_create(
@@ -639,7 +639,7 @@ void discord_set_on_guild_role_create(
  * @brief Triggers when a guild role is updated
  * @note This implicitly sets @ref DISCORD_GATEWAY_GUILDS intent
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param callback the callback to be triggered on event
  */
 void discord_set_on_guild_role_update(
@@ -651,7 +651,7 @@ void discord_set_on_guild_role_update(
  * @brief Triggers when a guild role is deleted
  * @note This implicitly sets @ref DISCORD_GATEWAY_GUILDS intent
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param callback the callback to be triggered on event
  */
 void discord_set_on_guild_role_delete(
@@ -664,7 +664,7 @@ void discord_set_on_guild_role_delete(
  * @note This implicitly sets @ref DISCORD_GATEWAY_GUILD_SCHEDULED_EVENTS
  * intent
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param callback the callback to be triggered on event
  */
 void discord_set_on_guild_scheduled_event_create(
@@ -677,7 +677,7 @@ void discord_set_on_guild_scheduled_event_create(
  * @note This implicitly sets @ref DISCORD_GATEWAY_GUILD_SCHEDULED_EVENTS
  * intent
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param callback the callback to be triggered on event
  */
 void discord_set_on_guild_scheduled_event_update(
@@ -690,7 +690,7 @@ void discord_set_on_guild_scheduled_event_update(
  * @note This implicitly sets @ref DISCORD_GATEWAY_GUILD_SCHEDULED_EVENTS
  * intent
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param callback the callback to be triggered on event
  */
 void discord_set_on_guild_scheduled_event_delete(
@@ -703,7 +703,7 @@ void discord_set_on_guild_scheduled_event_delete(
  * @note This implicitly sets @ref DISCORD_GATEWAY_GUILD_SCHEDULED_EVENTS
  * intent
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param callback the callback to be triggered on event
  */
 void discord_set_on_guild_scheduled_event_user_add(
@@ -717,7 +717,7 @@ void discord_set_on_guild_scheduled_event_user_add(
  * @note This implicitly sets @ref DISCORD_GATEWAY_GUILD_SCHEDULED_EVENTS
  * intent
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param callback the callback to be triggered on event
  */
 void discord_set_on_guild_scheduled_event_user_remove(
@@ -731,7 +731,7 @@ void discord_set_on_guild_scheduled_event_user_remove(
  * @note This implicitly sets @ref DISCORD_GATEWAY_GUILD_INTEGRATIONS
  * intent
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param callback the callback to be triggered on event
  */
 void discord_set_on_integration_create(
@@ -744,7 +744,7 @@ void discord_set_on_integration_create(
  * @note This implicitly sets @ref DISCORD_GATEWAY_GUILD_INTEGRATIONS
  * intent
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param callback the callback to be triggered on event
  */
 void discord_set_on_integration_update(
@@ -757,7 +757,7 @@ void discord_set_on_integration_update(
  * @note This implicitly sets @ref DISCORD_GATEWAY_GUILD_INTEGRATIONS
  *      intent
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param callback the callback to be triggered on event
  */
 void discord_set_on_integration_delete(
@@ -769,7 +769,7 @@ void discord_set_on_integration_delete(
  * @brief Triggers when user has used an interaction, such as an application
  *      command
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param callback the callback to be triggered on event
  */
 void discord_set_on_interaction_create(
@@ -781,7 +781,7 @@ void discord_set_on_interaction_create(
  * @brief Triggers when an invite to a channel has been created
  * @note This implicitly sets @ref DISCORD_GATEWAY_GUILD_INVITES intent
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param callback the callback to be triggered on event
  */
 void discord_set_on_invite_create(
@@ -793,7 +793,7 @@ void discord_set_on_invite_create(
  * @brief Triggers when an invite to a channel has been deleted
  * @note This implicitly sets @ref DISCORD_GATEWAY_GUILD_INVITES intent
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param callback the callback to be triggered on event
  */
 void discord_set_on_invite_delete(
@@ -806,7 +806,7 @@ void discord_set_on_invite_delete(
  * @note This implicitly sets @ref DISCORD_GATEWAY_GUILD_MESSAGES and
  *      @ref DISCORD_GATEWAY_DIRECT_MESSAGES intents
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param callback the callback to be triggered on event
  */
 void discord_set_on_message_create(
@@ -819,7 +819,7 @@ void discord_set_on_message_create(
  * @note This implicitly sets @ref DISCORD_GATEWAY_GUILD_MESSAGES and
  *      @ref DISCORD_GATEWAY_DIRECT_MESSAGES intents
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param callback the callback to be triggered on event
  */
 void discord_set_on_message_update(
@@ -832,7 +832,7 @@ void discord_set_on_message_update(
  * @note This implicitly sets @ref DISCORD_GATEWAY_GUILD_MESSAGES and
  *      @ref DISCORD_GATEWAY_DIRECT_MESSAGES intents
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param callback the callback to be triggered on event
  */
 void discord_set_on_message_delete(
@@ -845,7 +845,7 @@ void discord_set_on_message_delete(
  * @note This implicitly sets @ref DISCORD_GATEWAY_GUILD_MESSAGES
  *      intent
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param callback the callback to be triggered on event
  */
 void discord_set_on_message_delete_bulk(
@@ -859,7 +859,7 @@ void discord_set_on_message_delete_bulk(
  *      @ref DISCORD_GATEWAY_GUILD_MESSAGE_REACTIONS and
  *      @ref DISCORD_GATEWAY_DIRECT_MESSAGE_REACTIONS intents
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param callback the callback to be triggered on event
  */
 void discord_set_on_message_reaction_add(
@@ -873,7 +873,7 @@ void discord_set_on_message_reaction_add(
  *      @ref DISCORD_GATEWAY_GUILD_MESSAGE_REACTIONS and
  *      @ref DISCORD_GATEWAY_DIRECT_MESSAGE_REACTIONS intents
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param callback the callback to be triggered on event
  */
 void discord_set_on_message_reaction_remove(
@@ -887,7 +887,7 @@ void discord_set_on_message_reaction_remove(
  *      @ref DISCORD_GATEWAY_GUILD_MESSAGE_REACTIONS and
  *      @ref DISCORD_GATEWAY_DIRECT_MESSAGE_REACTIONS intents
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param callback the callback to be triggered on event
  */
 void discord_set_on_message_reaction_remove_all(
@@ -904,7 +904,7 @@ void discord_set_on_message_reaction_remove_all(
  *      @ref DISCORD_GATEWAY_GUILD_MESSAGE_REACTIONS and
  *      @ref DISCORD_GATEWAY_DIRECT_MESSAGE_REACTIONS intents
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param callback the callback to be triggered on event
  */
 void discord_set_on_message_reaction_remove_emoji(
@@ -917,7 +917,7 @@ void discord_set_on_message_reaction_remove_emoji(
  * @brief Triggers when user presence is updated
  * @note This implicitly sets @ref DISCORD_GATEWAY_GUILD_PRESENCES intent
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param callback the callback to be triggered on event
  */
 void discord_set_on_presence_update(
@@ -929,7 +929,7 @@ void discord_set_on_presence_update(
  * @brief Triggers when a stage instance is created
  * @note This implicitly sets @ref DISCORD_GATEWAY_GUILDS intent
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param callback the callback to be triggered on event
  */
 void discord_set_on_stage_instance_create(
@@ -941,7 +941,7 @@ void discord_set_on_stage_instance_create(
  * @brief Triggers when a stage instance is updated
  * @note This implicitly sets @ref DISCORD_GATEWAY_GUILDS intent
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param callback the callback to be triggered on event
  */
 void discord_set_on_stage_instance_update(
@@ -953,7 +953,7 @@ void discord_set_on_stage_instance_update(
  * @brief Triggers when a stage instance is deleted
  * @note This implicitly sets @ref DISCORD_GATEWAY_GUILDS intent
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param callback the callback to be triggered on event
  */
 void discord_set_on_stage_instance_delete(
@@ -966,7 +966,7 @@ void discord_set_on_stage_instance_delete(
  * @note This implicitly sets @ref DISCORD_GATEWAY_GUILD_MESSAGE_TYPING and
  *      @ref DISCORD_GATEWAY_DIRECT_MESSAGE_TYPING intents
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param callback the callback to be triggered on event
  */
 void discord_set_on_typing_start(
@@ -977,7 +977,7 @@ void discord_set_on_typing_start(
 /**
  * @brief Triggers when properties about a user changed
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param callback the callback to be triggered on event
  */
 void discord_set_on_user_update(
@@ -988,7 +988,7 @@ void discord_set_on_user_update(
 /**
  * @brief Triggers when a voice state is updated
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param callback the callback to be triggered on event
  */
 void discord_set_on_voice_state_update(
@@ -999,7 +999,7 @@ void discord_set_on_voice_state_update(
 /**
  * @brief Triggers when voice server is updated
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param callback the callback to be triggered on event
  */
 void discord_set_on_voice_server_update(
@@ -1011,7 +1011,7 @@ void discord_set_on_voice_server_update(
  * @brief Triggers when guild channel has been created, updated or deleted
  * @note This implicitly sets @ref DISCORD_GATEWAY_GUILD_WEBHOOKS intent
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param callback the callback to be triggered on event
  */
 void discord_set_on_webhooks_update(

--- a/include/discord-internal.h
+++ b/include/discord-internal.h
@@ -1188,37 +1188,6 @@ struct discord_cache {
 /** @} DiscordInternalCache */
 
 /**
- * @brief The Discord configuration handler
- *
- * This struct is used to store the Discord client configuration
- */
-struct discord_config {
-    /** config file contents */
-    struct ccord_szbuf file;
-    /** minimum logging level */
-    enum logmod_levels level;
-    /** silence terminal logging */
-    bool quiet;
-    /** enable color to terminal logging */
-    bool color;
-    /** overwrite existing files */
-    bool overwrite;
-    /** the bot token */
-    char *token;
-    /* the trace log file */
-    FILE *trace;
-    /* the http log file */
-    FILE *http;
-    /* the ws log file */
-    FILE *ws;
-    /** list of 'id' that should be ignored */
-    struct {
-        size_t size;
-        char **ids;
-    } disable;
-};
-
-/**
  * @brief The Discord client handler
  *
  * Used to access/perform public functions from discord.h
@@ -1287,6 +1256,10 @@ struct discord {
         /** notify of `count` decrement */
         pthread_cond_t cond;
     } *workers;
+
+    /** config.json file contents if client was initialized with
+     *      discord_from_json() */
+    struct ccord_szbuf file;
 };
 
 /** @} DiscordInternal */

--- a/include/emoji.h
+++ b/include/emoji.h
@@ -15,7 +15,7 @@
 /**
  * @brief Get emojis of a given guild
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param guild_id guild to get emojis from
  * @CCORD_ret_obj{ret,emojis}
  * @CCORD_return
@@ -27,7 +27,7 @@ CCORDcode discord_list_guild_emojis(struct discord *client,
 /**
  * @brief Get a specific emoji from a guild
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param guild_id guild the emoji belongs to
  * @param emoji_id the emoji to be fetched
  * @CCORD_ret_obj{ret,emoji}
@@ -42,7 +42,7 @@ CCORDcode discord_get_guild_emoji(struct discord *client,
  * @brief Create a new emoji for the guild
  * @note Fires a `Guild Emojis Update` event
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param guild_id guild to add the new emoji to
  * @param params request parameters
  * @CCORD_ret_obj{ret,emoji}
@@ -57,7 +57,7 @@ CCORDcode discord_create_guild_emoji(struct discord *client,
  * @brief Modify the given emoji
  * @note Fires a `Guild Emojis Update` event
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param guild_id guild the emoji belongs to
  * @param emoji_id the emoji to be modified
  * @param params request parameters
@@ -74,7 +74,7 @@ CCORDcode discord_modify_guild_emoji(struct discord *client,
  * @brief Deletes the given emoji
  * @note Fires a `Guild Emojis Update` event
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param guild_id guild the emoji belongs to
  * @param emoji_id the emoji to be deleted
  * @param params request parameters

--- a/include/gateway.h
+++ b/include/gateway.h
@@ -18,7 +18,7 @@
  *        unable to properly establishing a connection with the cached version
  * @warning This function blocks the running thread
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param ret if successful, a @ref ccord_szbuf containing the JSON response
  * @param ret a sized buffer containing the response JSON
  * @CCORD_return
@@ -33,7 +33,7 @@ CCORDcode discord_get_gateway(struct discord *client, struct ccord_szbuf *ret);
  *        bot joins/leaves guilds
  * @warning This function blocks the running thread
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param ret if successful, a @ref ccord_szbuf containing the JSON response
  * @param ret a sized buffer containing the response JSON
  * @CCORD_return
@@ -48,7 +48,7 @@ CCORDcode discord_get_gateway_bot(struct discord *client,
 /**
  * @brief Disconnect a member from voice channel
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param guild_id the guild the member belongs to
  * @param user_id the user to be disconnected
  * @param params request parameters

--- a/include/guild.h
+++ b/include/guild.h
@@ -16,7 +16,7 @@
  * @brief Create a new guild
  * @note Fires a `Guild Create` event
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param params request parameters
  * @CCORD_ret_obj{ret,guild}
  * @CCORD_return
@@ -32,7 +32,7 @@ CCORDcode discord_create_guild(struct discord *client,
  *        approximate_member_count and approximate_presence_count for the
  *        guild
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param guild_id the unique id of the guild to retrieve
  * @CCORD_ret_obj{ret,guild}
  * @CCORD_return
@@ -45,7 +45,7 @@ CCORDcode discord_get_guild(struct discord *client,
  * @brief Get the preview for the given guild
  * @note If the user is not in the guild, then the guild must be lurkable
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param guild_id guild to get preview from
  * @CCORD_ret_obj{ret,guild_preview}
  * @CCORD_return
@@ -59,7 +59,7 @@ CCORDcode discord_get_guild_preview(struct discord *client,
  * @note Requires the MANAGE_GUILD permission
  * @note Fires a `Guild Update` event
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param guild_id the unique id of the guild to modify
  * @param params request parameters
  * @CCORD_ret_obj{ret,guild}
@@ -74,7 +74,7 @@ CCORDcode discord_modify_guild(struct discord *client,
  * @brief Delete a guild permanently, user must be owner
  * @note Fires a `Guild Delete` event
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param guild_id id of guild to delete
  * @CCORD_ret{ret}
  * @CCORD_return
@@ -86,7 +86,7 @@ CCORDcode discord_delete_guild(struct discord *client,
 /**
  * @brief Fetch channels from given guild. Does not include threads
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param guild_id id of guild to fetch channels from
  * @CCORD_ret_obj{ret,channels}
  * @CCORD_return
@@ -103,7 +103,7 @@ CCORDcode discord_get_guild_channels(struct discord *client,
  *       permission in channels is only possible for guild administrators
  * @note Fires a `Channel Create` event
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param guild_id id of the guild to create a channel at
  * @param params request parameters
  * @CCORD_ret_obj{ret,channel}
@@ -119,7 +119,7 @@ CCORDcode discord_create_guild_channel(
  * @brief Modify guild channel positions
  * @note Requires MANAGE_CHANNELS permission
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param guild_id the unique id of the guild to change the positions of the
  *       channels in
  * @param params request parameters
@@ -135,7 +135,7 @@ CCORDcode discord_modify_guild_channel_positions(
 /**
  * @brief Get guild member of a guild from given user id
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param guild_id guild the member belongs to
  * @param user_id unique user id of member
  * @CCORD_ret_obj{ret,guild_member}
@@ -149,7 +149,7 @@ CCORDcode discord_get_guild_member(struct discord *client,
 /**
  * @brief Get guild members of a guild
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param guild_id guild the members belongs to
  * @param request parameters
  * @CCORD_ret_obj{ret,guild_members}
@@ -164,7 +164,7 @@ CCORDcode discord_list_guild_members(struct discord *client,
  * @brief Get guild members whose username or nickname starts with a provided
  *        string
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param guild_id guild the members belongs to
  * @param request parameters
  * @CCORD_ret_obj{ret,guild_members}
@@ -184,7 +184,7 @@ CCORDcode discord_search_guild_members(
  * @note The bot must be a member of the guild with CREATE_INSTANT_INVITE
  *       permission
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param guild_id guild to add the member to
  * @param user_id the user to be added
  * @param request parameters
@@ -202,7 +202,7 @@ CCORDcode discord_add_guild_member(struct discord *client,
  * @note Fires a `Guild Member Update` event
  * @see discord_disconnect_guild_member()
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param guild_id guild the member belongs to
  * @param user_id the user id of member
  * @param request parameters
@@ -220,7 +220,7 @@ CCORDcode discord_modify_guild_member(
  * @brief Modifies the current member in the guild
  * @note Fires a `Guild Member Update` event
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param guild_id the unique id of the guild where the member exists
  * @param params request parameters
  * @CCORD_ret_obj{ret,guild_member}
@@ -236,7 +236,7 @@ CCORDcode discord_modify_current_member(
  * @brief Adds a role to a guild member
  * @note Fires a `Guild Member Update` event
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param guild_id the unique id of the guild where the member exists
  * @param user_id the unique id of the user
  * @param role_id the unique id of the role to be added
@@ -257,7 +257,7 @@ CCORDcode discord_add_guild_member_role(
  * @note Requires the MANAGE_ROLES permission
  * @note Fires a `Guild Member Update` event
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param guild_id the unique id of the guild where the member exists
  * @param user_id the unique id of the user
  * @param role_id the unique id of the role to be removed
@@ -278,7 +278,7 @@ CCORDcode discord_remove_guild_member_role(
  * @note Requires the KICK_MEMBERS permission
  * @note Fires a `Guild Member Update` event
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param guild_id the guild to remove the member from
  * @param user_id the user to be removed
  * @param params request parameters
@@ -296,7 +296,7 @@ CCORDcode discord_remove_guild_member(
  * @brief Fetch banned users for given guild
  * @note Requires the BAN_MEMBERS permission
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param guild_id the guild to get the list from
  * @CCORD_ret_obj{ret,bans}
  * @CCORD_return
@@ -309,7 +309,7 @@ CCORDcode discord_get_guild_bans(struct discord *client,
  * @brief Fetch banned user from given guild
  * @note Requires the BAN_MEMBERS permission
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param guild_id the guild to return the ban from
  * @param user_id the user that is banned
  * @CCORD_ret_obj{ret,ban}
@@ -325,7 +325,7 @@ CCORDcode discord_get_guild_ban(struct discord *client,
  * @note Requires the BAN_MEMBERS permission
  * @note Fires a `Guild Ban Add` event
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param guild_id guild the user belongs to
  * @param user_id the user to be banned
  * @param params request parameters
@@ -343,7 +343,7 @@ CCORDcode discord_create_guild_ban(struct discord *client,
  * @note Requires the BAN_MEMBERS permission
  * @note Fires a `Guild Ban Remove` event
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param guild_id guild the user belonged to
  * @param user_id the user to have its ban revoked
  * @param params request parameters
@@ -359,7 +359,7 @@ CCORDcode discord_remove_guild_ban(struct discord *client,
 /**
  * @brief Get guild roles
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param guild_id guild to get roles from
  * @CCORD_ret_obj{ret,roles}
  * @CCORD_return
@@ -373,7 +373,7 @@ CCORDcode discord_get_guild_roles(struct discord *client,
  * @note Requires MANAGE_ROLES permission
  * @note Fires a `Guild Role Create` event
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param guild_id guild to add a role to
  * @param params request parameters
  * @CCORD_ret_obj{ret,role}
@@ -391,7 +391,7 @@ CCORDcode discord_create_guild_role(struct discord *client,
  * @note By default will not remove users with roles. You can include specific
  *      roles in your prune by providing the `params.include_roles` value
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param guild_id the unique id of the guild to be checked
  * @param params request parameters
  * @CCORD_ret_obj{ret,prune_count}
@@ -410,7 +410,7 @@ CCORDcode discord_get_guild_prune_count(
  * @note Requires the KICK_MEMBERS permission
  * @note Fires multiple `Guild Member Remove` events
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param guild_id the unique id of the guild to start the prune
  * @param params request parameters
  * @CCORD_ret{ret}
@@ -425,7 +425,7 @@ CCORDcode discord_begin_guild_prune(struct discord *client,
  * @brief Get voice regions (includes VIP servers when the guild is
  *      VIP-enabled)
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param guild_id the unique id of the guild to get voice regions from
  * @CCORD_ret_obj{ret,voice_regions}
  * @CCORD_return
@@ -439,7 +439,7 @@ CCORDcode discord_get_guild_voice_regions(
  * @brief Get guild invites
  * @note requires the `MANAGE_GUILD` permission
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param guild_id the unique id of the guild to get invites from
  * @CCORD_ret_obj{ret,invites}
  * @CCORD_return
@@ -452,7 +452,7 @@ CCORDcode discord_get_guild_invites(struct discord *client,
  * @brief Get guild integrations
  * @note requires the `MANAGE_GUILD` permission
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param guild_id the unique id of the guild to get integrations from
  * @CCORD_ret_obj{ret,integrations}
  * @CCORD_return
@@ -467,7 +467,7 @@ CCORDcode discord_get_guild_integrations(struct discord *client,
  * @note Requires the MANAGE_GUILD permission
  * @note Fires a `Guild Integrations Update` event
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param guild_id the unique id of the guild to delete the integrations from
  * @param integration_id the id of the integration to delete
  * @param params request parameters
@@ -485,7 +485,7 @@ CCORDcode discord_delete_guild_integrations(
  * @brief Get a guild widget settings
  * @note requires the `MANAGE_GUILD` permission
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param guild_id the unique id of the guild to get widget settings from
  * @CCORD_ret_obj{ret,guild_widget_settings}
  * @CCORD_return
@@ -499,7 +499,7 @@ CCORDcode discord_get_guild_widget_settings(
  * @brief Modify a guild widget settings
  * @note requires the `MANAGE_GUILD` permission
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param guild_id the unique id of the guild to modify the widget settings
  *      from
  * @param param request parameters
@@ -515,7 +515,7 @@ CCORDcode discord_modify_guild_widget(
 /**
  * @brief Get the widget for the guild
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param guild_id the unique id of the guild to get the widget from
  * @CCORD_ret_obj{ret,guild_widget}
  * @CCORD_return
@@ -527,7 +527,7 @@ CCORDcode discord_get_guild_widget(struct discord *client,
 /**
  * @brief Get invite from a given guild
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param guild_id the unique id of the guild to get vanity url from
  * @CCORD_ret_obj{ret,invite}
  * @CCORD_return
@@ -541,7 +541,7 @@ CCORDcode discord_get_guild_vanity_url(struct discord *client,
 /**
  * @brief Get a PNG image widget for the guild
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param guild_id the unique id of the guild to get a PNG widget image from
  * @param params request parameters
  * @CCORD_ret_obj{ret,png}
@@ -557,7 +557,7 @@ CCORDcode discord_get_guild_widget_image(
 /**
  * @brief Get the Welcome Screen for the guild
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param guild_id the unique id of the guild to get welcome screen of
  * @CCORD_ret_obj{ret,welcome_screen}
  * @CCORD_return
@@ -571,7 +571,7 @@ CCORDcode discord_get_guild_welcome_screen(
  * @brief Modify the Welcome Screen for the guild
  * @note requires the `MANAGE_GUILD` permission
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param guild_id the unique id of the guild to modify welcome screen of
  * @param params request parameters
  * @CCORD_ret_obj{ret,welcome_screen}
@@ -588,7 +588,7 @@ CCORDcode discord_modify_guild_welcome_screen(
  * @see Caveats
  * https://discord.com/developers/docs/resources/guild#modify-current-user-voice-state-caveats
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param guild_id the unique id of the guild to modify the current user's
  *      voice state
  * @param params request parameters
@@ -606,7 +606,7 @@ CCORDcode discord_modify_current_user_voice_state(
  * @see Caveats
  * https://discord.com/developers/docs/resources/guild#modify-user-voice-state-caveats
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param guild_id the unique id of the guild to modify the user's voice state
  * @param user_id the unique id of user to have its voice state modified
  * @param params request parameters
@@ -625,7 +625,7 @@ CCORDcode discord_modify_user_voice_state(
  * @note Requires the MANAGE_ROLES permission
  * @note Fires multiple `Guild Role Update` events
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param guild_id the unique id of the guild to get welcome screen of
  * @param params request parameters
  * @CCORD_ret_obj{ret,roles}
@@ -642,7 +642,7 @@ CCORDcode discord_modify_guild_role_positions(
  * @note Requires the MANAGE_ROLES permission
  * @note Fires a `Guild Role Update` event
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param guild_id the unique id of the guild that the role belongs to
  * @param role_id the unique id of the role to modify
  * @param params request parameters
@@ -660,7 +660,7 @@ CCORDcode discord_modify_guild_role(struct discord *client,
  * @note Requires the MANAGE_ROLES permission
  * @note Fires a `Guild Role Delete` event
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param guild_id the unique id of the guild that the role belongs to
  * @param role_id the unique id of the role to delete
  * @param params request parameters

--- a/include/guild_scheduled_event.h
+++ b/include/guild_scheduled_event.h
@@ -15,7 +15,7 @@
 /**
  * @brief Get a list of scheduled events for the guild
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param guild_id the guild to fetch the scheduled events from
  * @param params request parameters
  * @CCORD_ret_obj{ret,guild_scheduled_events}
@@ -32,7 +32,7 @@ CCORDcode discord_list_guild_scheduled_events(
  * @note A guild can have a maximum of 100 events with `SCHEDULED` or `ACTIVE`
  *      status at any time
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param guild_id the guild to create the scheduled event at
  * @param params request parameters
  * @CCORD_ret_obj{ret,guild_scheduled_event}
@@ -47,7 +47,7 @@ CCORDcode discord_create_guild_scheduled_event(
 /**
  * @brief Get a guild scheduled event
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param guild_id the guild to fetch the scheduled event from
  * @param guild_scheduled_event_id the scheduled event to be fetched
  * @param params request parameters
@@ -65,7 +65,7 @@ CCORDcode discord_get_guild_scheduled_event(
  * @brief Modify a guild scheduled event
  * @note Silently discards `entity_metadata` for non-`EXTERNAL` events
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param guild_id the guild where the scheduled event to be modified is at
  * @param guild_scheduled_event_id the scheduled event to be modified
  * @param params request parameters
@@ -82,7 +82,7 @@ CCORDcode discord_modify_guild_scheduled_event(
 /**
  * @brief Delete a guild scheduled event
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param guild_id the guild where the scheduled event to be deleted is at
  * @param guild_scheduled_event_id the scheduled event to be deleted
  * @CCORD_ret{ret}
@@ -99,7 +99,7 @@ CCORDcode discord_delete_guild_scheduled_event(
  * @note Guild member data, if it exists, is included if the
  *      `params.with_member` value is set
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param guild_id the guild with the scheduled event belongs to
  * @param guild_scheduled_event_id the scheduled event
  * @param params request parameters

--- a/include/guild_template.h
+++ b/include/guild_template.h
@@ -15,7 +15,7 @@
 /**
  * @brief Get a guild template for the given code
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param template_code the guild template code
  * @CCORD_ret_obj{ret,guild_template}
  * @CCORD_return
@@ -27,8 +27,8 @@ CCORDcode discord_get_guild_template(struct discord *client,
 /**
  * @brief Create a new guild based on a template
  * @note This endpoint can be used only by bots in less than 10 guilds
- * 
- * @param client the client created with discord_init()
+ *
+ * @param client the client created with discord_from_token()
  * @param template_code the guild template code
  * @param params the request parameters
  * @CCORD_ret_obj{ret,guild}
@@ -43,8 +43,8 @@ CCORDcode discord_create_guild_from_guild_template(
 /**
  * @brief Returns @ref discord_guild_templates from a guild
  * @note Requires the `MANAGE_GUILD` permission
- * 
- * @param client the client created with discord_init()
+ *
+ * @param client the client created with discord_from_token()
  * @param guild_id the guild to fetch the templates from
  * @CCORD_ret_obj{ret,guild_templates}
  * @CCORD_return
@@ -57,7 +57,7 @@ CCORDcode discord_get_guild_templates(struct discord *client,
  * @brief Creates a template for the guild
  * @note Requires the `MANAGE_GUILD` permission
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param guild_id the guild to create a template from
  * @param params the request parameters
  * @CCORD_ret_obj{ret,guild_template}
@@ -73,7 +73,7 @@ CCORDcode discord_create_guild_template(
  * @brief Syncs the template to the guild's current state
  * @note Requires the `MANAGE_GUILD` permission
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param guild_id the guild to sync the template from
  * @param template_code the guild template code
  * @CCORD_ret_obj{ret,guild_template}
@@ -88,7 +88,7 @@ CCORDcode discord_sync_guild_template(struct discord *client,
  * @brief Modifies the template's metadata
  * @note Requires the `MANAGE_GUILD` permission
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param guild_id the guild to modify the template at
  * @param template_code the guild template code
  * @param params the request parameters
@@ -106,7 +106,7 @@ CCORDcode discord_modify_guild_template(
  * @brief Deletes the guild template
  * @note Requires the `MANAGE_GUILD` permission
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param guild_id the guild to delete the template at
  * @param template_code the guild template code
  * @CCORD_ret_obj{ret,guild_template}

--- a/include/interaction.h
+++ b/include/interaction.h
@@ -15,7 +15,7 @@
 /**
  * @brief Create a response to an Interaction from the gateway
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param interaction_id the unique id of the interaction
  * @param interaction_token the unique token of the interaction
  * @param params the request parameters
@@ -32,7 +32,7 @@ CCORDcode discord_create_interaction_response(
 /**
  * @brief Get the initial Interaction response
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param application_id the unique id of the application
  * @param interaction_token the unique token of the interaction
  * @CCORD_ret_obj{ret,interaction_response}
@@ -47,7 +47,7 @@ CCORDcode discord_get_original_interaction_response(
 /**
  * @brief Edit the initial Interaction response
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param application_id the unique id of the application
  * @param interaction_token the unique token of the interaction
  * @param params request parameters
@@ -64,7 +64,7 @@ CCORDcode discord_edit_original_interaction_response(
 /**
  * @brief Delete the initial Interaction response
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param application_id the unique id of the application
  * @param interaction_token the unique token of the interaction
  * @CCORD_ret{ret}
@@ -79,7 +79,7 @@ CCORDcode discord_delete_original_interaction_response(
 /**
  * @brief Create a followup message for an Interaction
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param application_id the unique id of the application
  * @param interaction_token the unique token of the interaction
  * @param params request parameters
@@ -96,7 +96,7 @@ CCORDcode discord_create_followup_message(
 /**
  * @brief Get a followup message for an interaction
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param application_id the unique id of the application
  * @param interaction_token the unique token of the interaction
  * @param message_id the unique id of the message
@@ -112,7 +112,7 @@ CCORDcode discord_get_followup_message(struct discord *client,
 /**
  * @brief Edits a followup message for an interaction
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param application_id the unique id of the application
  * @param interaction_token the unique token of the interaction
  * @param message_id the unique id of the message
@@ -131,7 +131,7 @@ CCORDcode discord_edit_followup_message(
 /**
  * @brief Edits a followup message for an interaction
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param application_id the unique id of the application
  * @param interaction_token the unique token of the interaction
  * @param message_id the unique id of the message

--- a/include/invite.h
+++ b/include/invite.h
@@ -15,7 +15,7 @@
 /**
  * @brief Get an invite for the given code
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param invite_code the invite code
  * @param params request parameters
  * @CCORD_ret_obj{ret,invite}
@@ -32,7 +32,7 @@ CCORDcode discord_get_invite(struct discord *client,
  *        belongs to, or MANAGE_GUILD to remove any invite across the guild.
  * @note Fires a `Invite Delete` event
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param invite_code the invite code
  * @param params request parameters
  * @CCORD_ret_obj{ret,invite}

--- a/include/oauth2.h
+++ b/include/oauth2.h
@@ -15,7 +15,7 @@
 /**
  * @brief Returns the bot's application object
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @CCORD_ret_obj{ret,application}
  * @CCORD_return
  */
@@ -26,7 +26,7 @@ CCORDcode discord_get_current_bot_application_information(
  * @brief Returns info about the current authorization
  * @note Requires authentication with a bearer token
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @CCORD_ret_obj{ret,auth_response}
  * @CCORD_return
  */

--- a/include/stage_instance.h
+++ b/include/stage_instance.h
@@ -16,8 +16,8 @@
  * @brief Creates a new Stage Instance associated to a Stage channel
  * @note requires the user to be a moderator of the Stage channel
  *
- * @param client the client created with discord_init()
- * @param params the request parameters 
+ * @param client the client created with discord_from_token()
+ * @param params the request parameters
  * @CCORD_ret_obj{ret,stage_instance}
  * @CCORD_return
  */
@@ -30,7 +30,7 @@ CCORDcode discord_create_stage_instance(
  * @brief Gets the stage instance associated with the Stage channel, if it
  *      exists
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param channel_id the stage channel id
  * @CCORD_ret_obj{ret,stage_instance}
  * @CCORD_return
@@ -43,9 +43,9 @@ CCORDcode discord_get_stage_instance(struct discord *client,
  * @brief Updates fields of an existing Stage instance
  * @note requires the user to be a moderator of the Stage channel
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param channel_id the stage channel id
- * @param params the request parameters 
+ * @param params the request parameters
  * @CCORD_ret_obj{ret,stage_instance}
  * @CCORD_return
  */
@@ -59,7 +59,7 @@ CCORDcode discord_modify_stage_instance(
  * @brief Deletes the Stage instance
  * @note requires the user to be a moderator of the Stage channel
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param channel_id the stage channel to be deleted
  * @CCORD_ret{ret}
  * @CCORD_return

--- a/include/sticker.h
+++ b/include/sticker.h
@@ -15,7 +15,7 @@
 /**
  * @brief Get a sticker from a given ID
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param sticker_id the sticker to be fetched
  * @CCORD_ret_obj{ret,sticker}
  * @CCORD_return
@@ -27,20 +27,19 @@ CCORDcode discord_get_sticker(struct discord *client,
 /**
  * @brief Get a list of sticker packs available to Nitro subscribers
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @CCORD_ret_obj{ret,list_nitro_sticker_packs}
  * @CCORD_return
  */
 CCORDcode discord_list_nitro_sticker_packs(
-    struct discord *client,
-    struct discord_ret_list_nitro_sticker_packs *ret);
+    struct discord *client, struct discord_ret_list_nitro_sticker_packs *ret);
 
 /**
  * @brief Get stickers for the given guild
  * @note includes `user` fields if the bot has the `MANAGE_EMOJIS_AND_STICKERS`
  *      permission
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param guild_id guild to fetch the stickers from
  * @CCORD_ret_obj{ret,stickers}
  * @CCORD_return
@@ -54,7 +53,7 @@ CCORDcode discord_list_guild_stickers(struct discord *client,
  * @note includes the `user` field if the bot has the
  *      `MANAGE_EMOJIS_AND_STICKERS` permission
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param guild_id the guild where the sticker belongs to
  * @param sticker_id the sticker to be fetched
  * @CCORD_ret_obj{ret,sticker}
@@ -69,10 +68,10 @@ CCORDcode discord_get_guild_sticker(struct discord *client,
  * @brief Modify the given sticker
  * @note requires the `MANAGE_EMOJIS_AND_STICKERS` permission
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param guild_id the guild where the sticker belongs to
  * @param sticker_id the sticker to be modified
- * @param params the request parameters 
+ * @param params the request parameters
  * @CCORD_ret_obj{ret,sticker}
  * @CCORD_return
  */
@@ -87,7 +86,7 @@ CCORDcode discord_modify_guild_sticker(
  * @brief Delete the given sticker
  * @note requires the `MANAGE_EMOJIS_AND_STICKERS` permission
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param guild_id the guild where the sticker belongs to
  * @param sticker_id the sticker to be deleted
  * @CCORD_ret{ret}

--- a/include/user.h
+++ b/include/user.h
@@ -15,7 +15,7 @@
 /**
  * @brief Get client's user
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @CCORD_ret_obj{ret,user}
  * @CCORD_return
  */
@@ -25,7 +25,7 @@ CCORDcode discord_get_current_user(struct discord *client,
 /**
  * @brief Get user for a given id
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param user_id user to be fetched
  * @CCORD_ret_obj{ret,user}
  * @CCORD_return
@@ -37,7 +37,7 @@ CCORDcode discord_get_user(struct discord *client,
 /**
  * @brief Modify client's user account settings
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param params request parameters
  * @CCORD_ret_obj{ret,user}
  * @CCORD_return
@@ -51,7 +51,7 @@ CCORDcode discord_modify_current_user(
  * @brief Get guilds client is a member of
  * @note Requires the `guilds` oauth2 scope
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @CCORD_ret_obj{ret,guilds}
  * @CCORD_return
  */
@@ -61,7 +61,7 @@ CCORDcode discord_get_current_user_guilds(struct discord *client,
 /**
  * @brief Leave a guild
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param guild_id guild to exit from
  * @CCORD_ret{ret}
  * @CCORD_return
@@ -76,7 +76,7 @@ CCORDcode discord_leave_guild(struct discord *client,
  *        significant amount of DMs too quickly, your bot may be rate limited
  *        or blocked from opening new ones
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param params the request parameters
  * @CCORD_ret_obj{ret,channel}
  * @CCORD_return
@@ -90,7 +90,7 @@ CCORDcode discord_create_dm(struct discord *client,
  * @note DMs created with this function will not be shown in the Discord client
  * @note Limited to 10 active group DMs
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param params the request parameters
  * @CCORD_ret_obj{ret,channel}
  * @CCORD_return
@@ -103,7 +103,7 @@ CCORDcode discord_create_group_dm(struct discord *client,
  * @brief Get a list of connection objects
  * @note Requires the `connections` oauth2 scope
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @CCORD_ret_obj{ret,connections}
  * @CCORD_return
  */

--- a/include/voice.h
+++ b/include/voice.h
@@ -16,7 +16,7 @@
  * @brief Get voice regions that can be used when setting a
  *        voice or stage channel's `rtc_region`
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @CCORD_ret_obj{ret,voice_regions}
  * @CCORD_return
  */

--- a/include/webhook.h
+++ b/include/webhook.h
@@ -16,7 +16,7 @@
  * @brief Create a new webhook
  * @note Requires the MANAGE_WEBHOOKS permission
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param channel_id the channel that the webhook belongs to
  * @param params request parameters
  * @CCORD_ret_obj{ret,webhook}
@@ -31,7 +31,7 @@ CCORDcode discord_create_webhook(struct discord *client,
  * @brief Get webhooks from a given channel
  * @note Requires the MANAGE_WEBHOOKS permission
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param channel_id the channel that the webhooks belongs to
  * @CCORD_ret_obj{ret,webhooks}
  * @CCORD_return
@@ -44,7 +44,7 @@ CCORDcode discord_get_channel_webhooks(struct discord *client,
  * @brief Get webhooks from a given guild webhook objects
  * @note Requires the MANAGE_WEBHOOKS permission
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param guild_id the guild that the webhooks belongs to
  * @CCORD_ret_obj{ret,webhooks}
  * @CCORD_return
@@ -56,7 +56,7 @@ CCORDcode discord_get_guild_webhooks(struct discord *client,
 /**
  * @brief Get the new webhook object for the given id
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param webhook_id the webhook itself
  * @CCORD_ret_obj{ret,webhook}
  * @CCORD_return
@@ -68,7 +68,7 @@ CCORDcode discord_get_webhook(struct discord *client,
 /**
  * Same as discord_get_webhook(), except this call does not require
  *        authentication and returns no user in the webhook object
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param webhook_id the webhook itself
  * @param webhook_token the webhook token
  * @CCORD_ret_obj{ret,webhook}
@@ -83,7 +83,7 @@ CCORDcode discord_get_webhook_with_token(struct discord *client,
  * @brief Modify a webhook
  * @note Requires the MANAGE_WEBHOOKS permission
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param webhook_id the webhook itself
  * @param params request parameters
  * @CCORD_ret_obj{ret,webhook}
@@ -97,7 +97,7 @@ CCORDcode discord_modify_webhook(struct discord *client,
 /**
  * Same discord_modify_webhook(), except this call does not require
  *       authentication and returns no user in the webhook object
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param webhook_id the webhook itself
  * @param webhook_token the webhook token
  * @param params request parameters
@@ -113,7 +113,7 @@ CCORDcode discord_modify_webhook_with_token(
 
 /**
  * Delete a webhook permanently. Requires the MANAGE_WEBHOOKS permission
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param webhook_id the webhook itself
  * @param params request parameters
  * @CCORD_ret{ret}
@@ -127,7 +127,7 @@ CCORDcode discord_delete_webhook(struct discord *client,
 /**
  * Same discord_delete_webhook(), except this call does not require
  *       authentication
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param webhook_id the webhook itself
  * @param webhook_token the webhook token
  * @CCORD_ret{ret}
@@ -139,7 +139,7 @@ CCORDcode discord_delete_webhook_with_token(struct discord *client,
                                             struct discord_ret *ret);
 
 /**
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param webhook_id the webhook itself
  * @param webhook_token the webhook token
  * @param params request parameters
@@ -155,7 +155,7 @@ CCORDcode discord_execute_webhook(struct discord *client,
 /**
  * @brief Get previously-sent webhook message from the same token
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param webhook_id the webhook itself
  * @param webhook_token the webhook token
  * @param message_id the message the webhook belongs to
@@ -171,7 +171,7 @@ CCORDcode discord_get_webhook_message(struct discord *client,
 /**
  * @brief Edits a previously-sent webhook message from the same token
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param webhook_id the webhook itself
  * @param webhook_token the webhook token
  * @param message_id the message the webhook belongs to
@@ -190,7 +190,7 @@ CCORDcode discord_edit_webhook_message(
 /**
  * @brief Deletes a message that was created by the webhook
  *
- * @param client the client created with discord_init()
+ * @param client the client created with discord_from_token()
  * @param webhook_id the webhook itself
  * @param webhook_token the webhook token
  * @param message_id the message the webhook belongs to

--- a/test/racecond.c
+++ b/test/racecond.c
@@ -208,7 +208,7 @@ main(int argc, char *argv[])
 
     ccord_global_init();
 
-    struct discord *client = discord_config_init(config_file);
+    struct discord *client = discord_from_json(config_file);
     assert(NULL != client && "Couldn't initialize client");
 
     discord_set_event_scheduler(client, &scheduler);

--- a/test/rest.c
+++ b/test/rest.c
@@ -197,7 +197,7 @@ main(int argc, char *argv[])
 {
     GREATEST_MAIN_BEGIN();
     ccord_global_init();
-    CLIENT = discord_config_init("test_config.json");
+    CLIENT = discord_from_json("test_config.json");
     assert(CLIENT != NULL && "Couldn't initialize client");
 
     RUN_SUITE(synchronous);

--- a/test/timeout.c
+++ b/test/timeout.c
@@ -36,7 +36,7 @@ main(int argc, char *argv[])
     else
         config_file = "../config.json";
 
-    struct discord *client = discord_config_init(config_file);
+    struct discord *client = discord_from_json(config_file);
     discord_set_on_wakeup(client, on_wakeup);
     discord_set_next_wakeup(client, 3000);
     discord_set_on_cycle(client, on_cycle);


### PR DESCRIPTION
Closes #100

--

This pull request updates the initialization methods for the Discord client across multiple files and documentation. The changes replace the older methods (`discord_init` and `discord_config_init`) with the newer methods (`discord_from_token` and `discord_from_json`) for improved clarity and consistency. Additionally, documentation has been updated to reflect these changes.

### Updates to Initialization Methods:

* **Code Examples**:
  - Replaced `discord_config_init` with `discord_from_json` across various example files, such as `examples/8ball.c`, `examples/audit-log.c`, and others. This ensures consistency in how the Discord client is initialized from a configuration file. [[1]](diffhunk://#diff-a1349dde4f896bdf05fd682f6b51bd7f6afaaeb13228b8451121568896af29e2L84-R84) [[2]](diffhunk://#diff-4bd31e970adf131c8d0b85372fec875688d7960392a01ec00578862a6ed30f77L123-R123) [[3]](diffhunk://#diff-9df9f032356df256432cd251aed559c62b6a590a5949a6c96d4546064a419f5bL122-R122) [[4]](diffhunk://#diff-612716fbf3038bbbb444b9759f3b2620de1aa618668b4eac0028e3122b33f383L39-R39) [[5]](diffhunk://#diff-a91ff38787ba6a10e8d77631d6fdc0f1e36afcf6f9b749b592e41fc47c7c4067L264-R264) [[6]](diffhunk://#diff-ec2219a58fa2c84d69db35405de88e69d309153aaf7c0054a5d996cbb11c0e60L214-R214) [[7]](diffhunk://#diff-bc68a59cf43d6fbd892e15dcda1e5da9a66b7c1e4cf024cad273293410ed8560L100-R100) [[8]](diffhunk://#diff-3b15e36db923343b376dcfcc7397884839424b4b310e87a054c6a5fbc2a8096fL160-R160) [[9]](diffhunk://#diff-53113a855810e1e5e08e8e94c869106c3a74442719b5fbbda4e0ee08b5f1a208L154-R154) [[10]](diffhunk://#diff-a092fc4b433ae38bafca12eddc1465f22d892b1e31f4b9b880f24bafa8f255c1L156-R156) [[11]](diffhunk://#diff-c6c88646f4c2bb7880735d8f2d46fb5b5b063726b75ab0469e979a46f609fe53L113-R113) [[12]](diffhunk://#diff-1a3fede270080b7dfd19a22b7ca0df5ebdc7039eaa88d30b7bd14973fbd5d16cL290-R290) [[13]](diffhunk://#diff-10a6e8ea73c8a11ed10c6a4b484e4ae85ae66047fb2bc9e44c35ff8a9284e192L97-R97) [[14]](diffhunk://#diff-bfcd61e364dfb28ed512d97b1355966012b71d66d3cb37064089f69e754699b7L102-R102)

* **Main Code**:
  - Updated `README.md` to replace `discord_init` with `discord_from_token` for initializing the client with a token. This aligns the examples with the latest API changes. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L102-R102) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L128-R128)

### Documentation Updates:

* **Configuration File Usage**:
  - Updated references in `docs/guides/config.json_directives.md` to replace `discord_config_init` with `discord_from_json` and clarified the usage of `discord_from_token` for token-based initialization. [[1]](diffhunk://#diff-2c6239bb874b176975bcccbc5120c34b4bfa961c0b130a8fc39e949392f1a2b7L25-R25) [[2]](diffhunk://#diff-2c6239bb874b176975bcccbc5120c34b4bfa961c0b130a8fc39e949392f1a2b7L114-R116)

* **Setup Guides**:
  - Adjusted examples in `docs/guides/setup_concord_with_env.md` to reflect the new initialization methods (`discord_from_token` and `discord_from_json`). [[1]](diffhunk://#diff-0ee31bc56b7d3ab0f127cc0757400820e92a7ba2aa7bd35cfd50c476f2e50d65L121-R121) [[2]](diffhunk://#diff-0ee31bc56b7d3ab0f127cc0757400820e92a7ba2aa7bd35cfd50c476f2e50d65L136-R136)

* **Other Guides**:
  - Updated initialization methods in guides such as `docs/guides/embeds.md`, `docs/guides/slash-commands.md`, and `docs/guides/sqlite3_db_with_concord.md` to use `discord_from_json`. [[1]](diffhunk://#diff-7656ee5843decf081e400e9f4d56ad76c517da08dbbc823c97c4ebfa99a71d32L198-R198) [[2]](diffhunk://#diff-756b38ed4685a9d101707797666728d404bcbc16ba7ef862c26b9fd1ce14d427L363-R363) [[3]](diffhunk://#diff-2e6f34b3c2212734463e0de06567b952abe8e959a21f8a08b5c2275ca61c82ccL525-R525)