### PR TITLE
Add alias for legacy shutdown function

### DIFF
--- a/include/discord.h
+++ b/include/discord.h
@@ -210,6 +210,12 @@ void discord_shutdown_all(void);
 bool discord_shutdown_all_ongoing(void);
 
 /**
+ * @brief Backwards compatible alias for discord_shutdown_all()
+ * @deprecated since v3.0.0
+ */
+#define ccord_shutdown_async() discord_shutdown_all()
+
+/**
  * @brief Creates a Discord Client handle from a token
  * @see discord_get_logmod() to configure logging behavior
  *


### PR DESCRIPTION
## Summary
- maintain compatibility by mapping `ccord_shutdown_async()` to `discord_shutdown_all()`

## Testing
- `make test` *(fails: `CURLE_TOO_LARGE` undeclared)*

------
https://chatgpt.com/codex/tasks/task_e_688595155c50832080c239ffdd025e43