### PR TITLE
Fix duplicate oa_hash build issue

### DIFF
--- a/core/jsmn-find.h
+++ b/core/jsmn-find.h
@@ -10,10 +10,14 @@ extern "C" {
 #else
 
 #ifdef JSMN_HEADER
-#define OA_HASH_HEADER
+#  define OA_HASH_HEADER
+#  include "oa_hash.h"
+#  undef OA_HASH_HEADER
+#else
+#  define OA_HASH_STATIC
+#  include "oa_hash.h"
+#  undef OA_HASH_STATIC
 #endif /* JSMN_HEADER */
-#include "oa_hash.h"
-#undef OA_HASH_HEADER
 
 #define JSMNF_PAIR_ATTRS_const                                                \
     /** JSON object or array pair attributes */                               \
@@ -168,9 +172,6 @@ JSMN_API long jsmnf_unescape(char buf[],
 #include <stdlib.h>
 #include <string.h>
 
-#define OA_HASH_STATIC
-#include "oa_hash.h"
-#undef OA_HASH_STATIC
 
 struct _jsmnf_pair_mut {
     JSMNF_PAIR_ATTRS(mut);

--- a/core/user-agent.c
+++ b/core/user-agent.c
@@ -11,6 +11,10 @@
 #include "cog-utils.h"
 #include "queue.h"
 
+#ifndef CURLE_TOO_LARGE
+#define CURLE_TOO_LARGE CURLE_FILESIZE_EXCEEDED
+#endif
+
 #define LOGMOD_APPLICATION_ID "CORE"
 #define LOGMOD_CONTEXT_ID     "USER_AGENT"
 #define LOGMOD_STATIC


### PR DESCRIPTION
## Summary
- restore `oa_hash.o` in core and src build lists
- include `oa_hash.h` once with `OA_HASH_STATIC` when building `jsmn-find.c`

## Testing
- `make -C core`
- `make -C src shared`


------
https://chatgpt.com/codex/tasks/task_e_688594f4de8883208a22958637768623