### PR TITLE
fix: _queriec_add() incorrect parameter concatenation

### DIFF
--- a/core/queriec.c
+++ b/core/queriec.c
@@ -32,10 +32,9 @@ _queriec_add(struct queriec *queriec,
     i = 0;
 
     query[queriec->offset++] = '=';
-    while (i < key_sz) {
+    while (i < value_sz) {
         query[queriec->offset++] = value[i++];
     }
-    --queriec->offset;
 }
 
 int


### PR DESCRIPTION
## Notice
- [X] I *understand* the code that I have edited, and have the means
to test it before making changes to Concord.

## What?
<!-- Explain the changes you've made - the overall effect of the PR. -->
The second while loop in `_queriec_add()` erroneously uses key_sz instead of value_sz to concatenate the value of a parameter to the query string. It causes the parameter value to be cut off if it's longer than the key (ex. **around**/**before**/**after** message IDs in `discord_get_channel_messages()`). 
Line 32 that decrements offset is also erroneous, since it causes the last character of previous parameter's value to be overwritten.

## Why?
<!-- Evaluate tangible code changes - explain the reason for the PR. -->
Presented changes allow to corretly specify more than one parameter (and longer parameters) for REST requests. The prime example is `discord_get_channel_messages()`, where it is impossible to specify **around**/**before**/**after**, since they get cut off and also not concatenated to **limit**.

## How?
<!-- Explain the solution carried out by the PR. -->
The issue fix is made obvious by the previous segment.

## Testing?
<!--
Explain how you tested your changes - let the reviewer know of any untested 
conditions or edge cases, why they weren't tested, and how likely they are to
occur, and if so, any associated risks.
-->
PR was tested on a code that fetches all messages from all channels of a guild, similar to `examples/fetch-messages.c`, alongside the example itself. The example wasnt working as intended previously to these changes.
Of course, functions forming queries should be tested for many if not all REST requests, but I cant cover all of them by my own.

## Screenshots
Running fetch example from latest master commit (fb0f834):
<img width="1192" height="1992" alt="before" src="https://github.com/user-attachments/assets/a85bf953-fae8-4591-a045-d0918e893069" />
Running fetch example after changes from this PR:
<img width="1903" height="1952" alt="after" src="https://github.com/user-attachments/assets/0147eff4-e07b-42b6-8980-caa40dc33f76" />

<!-- (optional) Screenshots that may be helpful further demonstrating your PR. -->