### PR TITLE
Re-add Solaris support and fix Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,12 @@
-PREFIX          ?= /usr/local
-SHAREDIR        ?= /usr/share
+# Concord top-level Makefile
+# Various options in this file can be tailored to the user's environment.
+
+# Installation prefix that the headers/libraries will be deposited into:
+PREFIX           = /usr/local
+SHAREDIR         = /usr/share
 DESTINCLUDE_DIR  = $(PREFIX)/include/concord
 DESTLIBDIR       = $(PREFIX)/lib
+# If you have a nonstandard pkg_config directory, specify it here:
 PKGCONFIGDIR     = $(SHAREDIR)/pkgconfig
 
 SRC_DIR       = src
@@ -12,15 +17,20 @@ GENCODECS_DIR = gencodecs
 CORE_DIR      = core
 EXAMPLES_DIR  = examples
 TEST_DIR      = test
+# Flags for compiling the shared version of Concord:
+SOFLAGS       = -fPIC
+DYFLAGS       = -fPIC 
+# C compiler debug options:
+DEBUG_FLAGS   = -O0 -g
 
-SOFLAGS     = -fPIC
-DYFLAGS     = -fPIC 
-DEBUG_FLAGS = -O0 -g
+GIT_BRANCHES  = master dev
+GIT_TARGETS   = latest latest-dev
 
-GIT_BRANCHES = master dev
-GIT_TARGETS  = latest latest-dev
+# If you are using Solaris, comment out the second line.
+INSTALL       = install
+# INSTALL       = /usr/ucb/install
 
-CFLAGS ?= -O2
+CFLAGS = -O2
 
 all: static
 
@@ -40,12 +50,13 @@ shared_osx:
 install:
 	@ mkdir -p $(DESTLIBDIR)
 	@ mkdir -p $(DESTINCLUDE_DIR)
-	install -d $(DESTLIBDIR)
-	install -m 644 $(LIBDIR)/* $(DESTLIBDIR)
-	install -d $(DESTINCLUDE_DIR)
-	install -m 644 $(INCLUDE_DIR)/*.h $(CORE_DIR)/*.h $(GENCODECS_DIR)/*.h \
+	$(INSTALL) -d $(DESTLIBDIR)
+	$(INSTALL) -m 644 $(LIBDIR)/* $(DESTLIBDIR)
+	$(INSTALL) -d $(DESTINCLUDE_DIR)
+	$(INSTALL) -m 644 $(INCLUDE_DIR)/*.h $(CORE_DIR)/*.h $(GENCODECS_DIR)/*.h \
 	               $(DESTINCLUDE_DIR)
-	install -D concord.pc $(PKGCONFIGDIR)/concord.pc
+	$(INSTALL) -d $(PKGCONFIGDIR)
+	$(INSTALL) -m 644 concord.pc $(PKGCONFIGDIR)/concord.pc
 
 uninstall:
 	rm -rf $(PREFIX)/include/concord

--- a/README.md
+++ b/README.md
@@ -251,6 +251,11 @@ $ CFLAGS="-pthread -lpthread" make
 In some cases, you might want to link Concord into a shared object, or link it as a shared object into another shared
 object. In that case, you will need to compile Concord with `CFLAGS="-fpic" make`. 
 
+### Special notes about compiling Concord with C compilers besides GCC or Clang
+Concord __will__ compile with compilers that aren't GCC or Clang, but you may need to do some work. For instance, support exists for Sun Studio C
+(specifically, Oracle Developer Studio 12.6), but you will need to change options in the Makefiles (look for CFLAGS and WFLAGS) to prevent errors
+about unknown compiler option flags.
+
 ## Configuring Concord
 
 [discord\_config\_init()][discord-config-init] is the initialization method that allows configuring your bot without recompiling.

--- a/core/concord-notifier.c
+++ b/core/concord-notifier.c
@@ -4,6 +4,11 @@
 #include <sys/ioctl.h>
 #include <stdlib.h>
 
+#ifdef __sun
+#include <stropts.h>
+#include <sys/filio.h>
+#endif
+
 #include "concord-error.h"
 #include "concord-notifier.h"
 #define LOGMOD_FALLBACK_APPLICATION_ID "CORE"

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -1,6 +1,6 @@
 # This Makefile assumes the top folder has been built
 TOP = ..
-CC ?= cc
+CC = gcc
 
 CORE_DIR      = $(TOP)/core
 INCLUDE_DIR   = $(TOP)/include

--- a/gencodecs/Makefile
+++ b/gencodecs/Makefile
@@ -2,9 +2,9 @@
 # If you are cross-compiling, do NOT set this to the target preprocessor!
 # This needs to run on the host -- that's why $(CC) and $(CPP) are
 # available here to be set.
-CPP = cc -E
-CC = cc
-HOSTCC = cc
+CC = gcc
+CPP = $(CC) -E
+HOSTCC = gcc
 
 TOP = ..
 
@@ -12,9 +12,6 @@ API_DIR     = api
 INCLUDE_DIR = $(TOP)/include
 CORE_DIR    = $(TOP)/core
 DOCS_DIR    = $(TOP)/docs
-
-# Gencodecs preprocessor (used after the CPP)
-PP = gencodecs-pp
 
 # Input file name without its extension
 INPUT_NO_EXT = discord_codecs
@@ -51,7 +48,7 @@ HEADERS = $(API_DIR)/application.h           \
           $(API_DIR)/voice_connections.h     \
           $(API_DIR)/webhook.h
 
-CFLAGS   ?= -O2
+CFLAGS    = -O2
 CFLAGS   += -I. -I$(API_DIR) -I$(INCLUDE_DIR) -I$(CORE_DIR)
 DFLAGS   += -DGENCODECS_INIT -DGENCODECS_JSON_ENCODER -DGENCODECS_JSON_DECODER
 CPPFLAGS += -nostdinc -P
@@ -63,36 +60,36 @@ DOXYGEN_DESC = "/**\n @file $@\n @author Cogmasters\n @brief Generated code\n*/"
 
 all: $(OUT_O)
 
-$(PP): $(PP).c
-	$(HOSTCC) $(CFLAGS) $< -o $@
+gencodecs-pp: gencodecs-pp.c
+	$(HOSTCC) $(CFLAGS) gencodecs-pp.c -o gencodecs-pp
 
 $(OUT_O): $(OUT_C) $(OUT_H)
 	$(CC) -c $(CFLAGS) $< -o $@
-$(OUT_H): $(INPUT) $(PP)
+$(OUT_H): $(INPUT) gencodecs-pp
 	@ echo "Generating header"
 	@ echo "#ifndef $(HEADER_TAG)" > $@
 	@ echo "#define $(HEADER_TAG)" >> $@
-	$(CPP) $(CFLAGS) -DGENCODECS_HEADER -DGENCODECS_DATA $(CPPFLAGS) $(INPUT) | ./$(PP) >> $@
-	$(CPP) $(CFLAGS) $(DFLAGS) -DGENCODECS_HEADER $(CPPFLAGS) $(INPUT) | ./$(PP) >> $@
+	$(CPP) $(CFLAGS) -DGENCODECS_HEADER -DGENCODECS_DATA $(CPPFLAGS) $(INPUT) | ./gencodecs-pp >> $@
+	$(CPP) $(CFLAGS) $(DFLAGS) -DGENCODECS_HEADER $(CPPFLAGS) $(INPUT) | ./gencodecs-pp >> $@
 	@ echo "#endif /* $(HEADER_TAG) */" >> $@
-$(OUT_C): $(INPUT) $(PP)
+$(OUT_C): $(INPUT) gencodecs-pp
 	@ echo "Generating forward definitions"
 	@ echo "#include \"$(OUT_H)\"" > $(OUT_C)
-	$(CPP) $(CFLAGS) $(DFLAGS) -DGENCODECS_FORWARD -DGENCODECS_DATA $(CPPFLAGS) $(INPUT) | ./$(PP) >> $(OUT_C)
+	$(CPP) $(CFLAGS) $(DFLAGS) -DGENCODECS_FORWARD -DGENCODECS_DATA $(CPPFLAGS) $(INPUT) | ./gencodecs-pp >> $(OUT_C)
 	@ echo "Generating source"	
-	$(CPP) $(CFLAGS) $(DFLAGS) -DGENCODECS_DATA $(CPPFLAGS) $(INPUT) | ./$(PP) >> $(OUT_C)
+	$(CPP) $(CFLAGS) $(DFLAGS) -DGENCODECS_DATA $(CPPFLAGS) $(INPUT) | ./gencodecs-pp >> $(OUT_C)
 
 headers: $(HEADERS)
 
-$(HEADERS): $(INPUT) $(PP)
+$(HEADERS): $(INPUT) gencodecs-pp
 
 .SUFFIXES: .PRE.h .h
 .PRE.h.h:
 	@ echo $(DOXYGEN_DESC) > $(DOCS_DIR)/$@
 	@ echo "#ifndef $(HEADER_TAG)" >> $(DOCS_DIR)/$@
 	@ echo "#define $(HEADER_TAG)" >> $(DOCS_DIR)/$@
-	$(CPP) $(CFLAGS) -DGENCODECS_HEADER -DGENCODECS_DATA -DGENCODECS_READ=\"$<\" $(CPPFLAGS) -CC $(INPUT) | ./$(PP) >> $(DOCS_DIR)/$@
-	$(CPP) $(CFLAGS) $(DFLAGS) -DGENCODECS_HEADER -DGENCODECS_READ=\"$<\" $(CPPFLAGS) $(INPUT) | ./$(PP) >> $(DOCS_DIR)/$@
+	$(CPP) $(CFLAGS) -DGENCODECS_HEADER -DGENCODECS_DATA -DGENCODECS_READ=\"$<\" $(CPPFLAGS) -CC $(INPUT) | ./gencodecs-pp >> $(DOCS_DIR)/$@
+	$(CPP) $(CFLAGS) $(DFLAGS) -DGENCODECS_HEADER -DGENCODECS_READ=\"$<\" $(CPPFLAGS) $(INPUT) | ./gencodecs-pp >> $(DOCS_DIR)/$@
 	@ echo "#endif /* $(HEADER_TAG) */" >> $(DOCS_DIR)/$@
 
 echo:
@@ -103,6 +100,6 @@ echo:
 	@ echo 'OUT_O: $(OUT_O)'
 
 clean:
-	@ rm -f $(OUT_H) $(OUT_C) $(OUT_O) $(PP) $(DOCS_DIR)/$(API_DIR)/*.h
+	@ rm -f $(OUT_H) $(OUT_C) $(OUT_O) gencodecs-pp $(DOCS_DIR)/$(API_DIR)/*.h
 
 .PHONY: headers echo clean


### PR DESCRIPTION
## Notice
- [X] I *understand* the code that I have edited, and have the means
to test it before making changes to Concord.

## What?
Long ago, Concord had Solaris support (but it required GNU Make and a manual retouch to some files). I have re-added this support, but you must still use GCC or Clang as your compiler; this also changes the default C compiler to gcc (which should be aliased to clang on systems that use Clang) and fixes an issue in the gencodecs Makefile that made it choke on certain Make implementations. 

## Why?
Outstanding issues.

## How?
See the updated files; these do not conflict with other system-specific changes.

## Testing?
This was tested on a Solaris-derived system (OmniOS), FreeBSD, and a Linux-derived system.

## Screenshots
N/A

## Anything Else?
@SoujiThenria remarked about pkg-config support; I have corrected that in this PR too.
