### PR TITLE
Add zlib-stream compression support for Discord Gateway WebSocket payloads.

### DIFF
--- a/examples/Makefile
+++ b/examples/Makefile
@@ -37,7 +37,7 @@ BOTS += $(STD_BOTS)
 CFLAGS  += -O0 -g -pthread -Wall \
            -I$(INCLUDE_DIR) -I$(CORE_DIR) -I$(GENCODECS_DIR)
 LDFLAGS  = -L$(TOP)/lib
-LDLIBS   = -ldiscord -lcurl
+LDLIBS   = -ldiscord -lcurl -lz
 
 all: $(BOTS)
 

--- a/include/discord-internal.h
+++ b/include/discord-internal.h
@@ -807,6 +807,23 @@ struct discord_gateway {
 };
 
 /**
+ * @brief Inflate a zlib-compressed Discord Gateway payload
+ *
+ * This is primarily used internally by the gateway to handle compressed
+ * WebSocket payloads, but is exposed here so it can be unit-tested.
+ *
+ * @param compressed pointer to compressed buffer
+ * @param compressed_len length of compressed buffer in bytes
+ * @param[out] out newly allocated buffer with decompressed data
+ * @param[out] out_len length of decompressed buffer in bytes
+ * @return true if decompression succeeded, false otherwise
+ */
+bool discord_gateway_zlib_inflate(const void *compressed,
+                                  size_t compressed_len,
+                                  char **out,
+                                  size_t *out_len);
+
+/**
  * @brief Initialize a Gateway handle
  *
  * Structure used for interfacing with the Discord's Gateway API

--- a/include/discord.h
+++ b/include/discord.h
@@ -32,7 +32,8 @@ extern "C" {
 #endif
 
 #define DISCORD_API_BASE_URL       "https://discord.com/api/v" DISCORD_VERSION
-#define DISCORD_GATEWAY_URL_SUFFIX "?v=" DISCORD_VERSION "&encoding=json"
+#define DISCORD_GATEWAY_URL_SUFFIX                                        \
+    "?v=" DISCORD_VERSION "&encoding=json&compress=zlib-stream"
 
 /* forward declaration */
 struct discord;

--- a/src/Makefile
+++ b/src/Makefile
@@ -82,9 +82,9 @@ shared_osx:
 $(ARLIB): deps
 	$(AR) $(ARFLAGS) $@ $(OBJS) $(GENCODECS_OBJ) $(CORE_OBJS)
 $(SOLIB): deps
-	$(CC) -shared -lcurl -o $@ $(OBJS) $(GENCODECS_OBJ) $(CORE_OBJS)
+	$(CC) -shared -lcurl -lz -o $@ $(OBJS) $(GENCODECS_OBJ) $(CORE_OBJS)
 $(DYLIB): deps
-	$(CC) -dynamiclib $(DYFLAGS) -o $@ $(OBJS) $(GENCODECS_OBJ) $(CORE_OBJS)
+	$(CC) -dynamiclib $(DYFLAGS) -lcurl -lz -o $@ $(OBJS) $(GENCODECS_OBJ) $(CORE_OBJS)
 
 deps:
 	@ $(MAKE) -C $(CORE_DIR)

--- a/src/discord-gateway.c
+++ b/src/discord-gateway.c
@@ -2,6 +2,8 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include <zlib.h>
+
 #include "discord.h"
 #include "discord-internal.h"
 #include "discord-worker.h"
@@ -325,6 +327,74 @@ _discord_on_heartbeat_ack(struct discord_gateway *gw)
     logconf_trace(&gw->conf, "PING: %d ms", gw->timer->ping_ms);
 }
 
+static bool
+_discord_gateway_on_message(struct discord_gateway *gw,
+                            struct ws_info *info,
+                            const char text[],
+                            size_t len);
+
+bool
+discord_gateway_zlib_inflate(const void *compressed,
+                             size_t compressed_len,
+                             char **out,
+                             size_t *out_len)
+{
+    z_stream strm;
+    memset(&strm, 0, sizeof(strm));
+
+    strm.next_in = (Bytef *)compressed;
+    strm.avail_in = (uInt)compressed_len;
+
+    if (Z_OK != inflateInit(&strm)) {
+        return false;
+    }
+
+    size_t bufsize = 4 * 1024;
+    char *buffer = malloc(bufsize + 1);
+    if (!buffer) {
+        inflateEnd(&strm);
+        return false;
+    }
+
+    size_t total = 0;
+    int ret;
+
+    do {
+        if (total == bufsize) {
+            size_t newsize = bufsize * 2;
+            char *tmp = realloc(buffer, newsize + 1);
+            if (!tmp) {
+                free(buffer);
+                inflateEnd(&strm);
+                return false;
+            }
+            buffer = tmp;
+            bufsize = newsize;
+        }
+
+        strm.next_out = (Bytef *)buffer + total;
+        strm.avail_out = (uInt)(bufsize - total);
+
+        ret = inflate(&strm, Z_NO_FLUSH);
+        if (ret == Z_STREAM_ERROR || ret == Z_DATA_ERROR
+            || ret == Z_MEM_ERROR)
+        {
+            free(buffer);
+            inflateEnd(&strm);
+            return false;
+        }
+
+        total = bufsize - strm.avail_out;
+    } while (ret != Z_STREAM_END && strm.avail_in > 0);
+
+    inflateEnd(&strm);
+
+    buffer[total] = '\0';
+    *out = buffer;
+    *out_len = total;
+    return true;
+}
+
 static void
 _ws_on_connect(void *p_gw,
                struct websockets *ws,
@@ -415,6 +485,30 @@ _ws_on_close(void *p_gw,
             gw->session->status & DISCORD_SESSION_RESUMABLE);
 }
 
+static void
+_ws_on_binary(void *p_gw,
+              struct websockets *ws,
+              struct ws_info *info,
+              const void *mem,
+              size_t len)
+{
+    (void)ws;
+    struct discord_gateway *gw = p_gw;
+    char *text = NULL;
+    size_t text_len = 0;
+
+    if (!discord_gateway_zlib_inflate(mem, len, &text, &text_len)) {
+        logconf_fatal(&gw->conf,
+                      "Failed to decompress zlib WebSocket payload (%zu bytes)",
+                      len);
+        return;
+    }
+
+    (void)_discord_gateway_on_message(gw, info, text, text_len);
+
+    free(text);
+}
+
 static bool
 _discord_gateway_payload_from_json(struct discord_gateway_payload *payload,
                                    const char text[],
@@ -459,19 +553,15 @@ _discord_gateway_payload_from_json(struct discord_gateway_payload *payload,
     return true;
 }
 
-static void
-_ws_on_text(void *p_gw,
-            struct websockets *ws,
-            struct ws_info *info,
-            const char *text,
-            size_t len)
+static bool
+_discord_gateway_on_message(struct discord_gateway *gw,
+                            struct ws_info *info,
+                            const char text[],
+                            size_t len)
 {
-    (void)ws;
-    struct discord_gateway *gw = p_gw;
-
     if (!_discord_gateway_payload_from_json(&gw->payload, text, len)) {
         logconf_fatal(&gw->conf, "Couldn't parse Gateway Payload");
-        return;
+        return false;
     }
 
     logconf_trace(
@@ -485,25 +575,38 @@ _ws_on_text(void *p_gw,
     switch (gw->payload.opcode) {
     case DISCORD_GATEWAY_DISPATCH:
         _discord_on_dispatch(gw);
-        break;
+        return true;
     case DISCORD_GATEWAY_INVALID_SESSION:
         _discord_on_invalid_session(gw);
-        break;
+        return true;
     case DISCORD_GATEWAY_RECONNECT:
         _discord_on_reconnect(gw);
-        break;
+        return true;
     case DISCORD_GATEWAY_HELLO:
         _discord_on_hello(gw);
-        break;
+        return true;
     case DISCORD_GATEWAY_HEARTBEAT_ACK:
         _discord_on_heartbeat_ack(gw);
-        break;
+        return true;
     default:
         logconf_error(&gw->conf,
                       "Not yet implemented Gateway Event (code: %d)",
                       gw->payload.opcode);
-        break;
+        return false;
     }
+}
+
+static void
+_ws_on_text(void *p_gw,
+            struct websockets *ws,
+            struct ws_info *info,
+            const char *text,
+            size_t len)
+{
+    (void)ws;
+    struct discord_gateway *gw = p_gw;
+
+    (void)_discord_gateway_on_message(gw, info, text, len);
 }
 
 static discord_event_scheduler_t
@@ -537,6 +640,7 @@ discord_gateway_init(struct discord_gateway *gw,
     struct ws_callbacks cbs = { .data = gw,
                                 .on_connect = &_ws_on_connect,
                                 .on_text = &_ws_on_text,
+                                .on_binary = &_ws_on_binary,
                                 .on_close = &_ws_on_close };
     /* Web-Sockets custom attributes */
     struct ws_attr attr = { .conf = conf };

--- a/test/Makefile
+++ b/test/Makefile
@@ -5,7 +5,7 @@ CORE_DIR      = $(TOP)/core
 INCLUDE_DIR   = $(TOP)/include
 GENCODECS_DIR = $(TOP)/gencodecs
 
-TEST_DISCORD = racecond rest timeout
+TEST_DISCORD = racecond rest timeout zlib
 TEST_CORE    = user-agent websockets queriec
 
 TESTS = $(TEST_DISCORD) $(TEST_GITHUB) $(TEST_CORE)
@@ -13,7 +13,7 @@ TESTS = $(TEST_DISCORD) $(TEST_GITHUB) $(TEST_CORE)
 CFLAGS  = -O0 -g -pthread -Wall \
           -I$(INCLUDE_DIR) -I$(CORE_DIR) -I$(GENCODECS_DIR)
 LDFLAGS = -L$(TOP)/lib
-LDLIBS  = -ldiscord -lcurl
+LDLIBS  = -ldiscord -lcurl -lz
 
 all: $(TESTS)
 

--- a/test/zlib.c
+++ b/test/zlib.c
@@ -1,0 +1,71 @@
+/**
+ * Simple test for Discord gateway zlib decompression helper.
+ *
+ * This does not require a live Discord connection, it just verifies that
+ * a buffer compressed with zlib can be decompressed back to its original
+ * contents by the library helper.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <zlib.h>
+
+/* public header brings in all Discord core types */
+#include "discord.h"
+
+/* forward declaration of the internal helper we want to test */
+bool discord_gateway_zlib_inflate(const void *compressed,
+                                  size_t compressed_len,
+                                  char **out,
+                                  size_t *out_len);
+
+int
+main(void)
+{
+    const char json[] = "{\"op\":10,\"d\":{\"heartbeat_interval\":45000}}";
+    const size_t json_len = sizeof(json) - 1;
+
+    /* compress the JSON payload with zlib */
+    z_stream def = { 0 };
+    if (Z_OK != deflateInit(&def, Z_DEFAULT_COMPRESSION)) {
+        fprintf(stderr, "Failed to initialize zlib deflate\n");
+        return EXIT_FAILURE;
+    }
+
+    unsigned char comp_buf[256];
+    def.next_in = (Bytef *)json;
+    def.avail_in = (uInt)json_len;
+    def.next_out = comp_buf;
+    def.avail_out = (uInt)sizeof(comp_buf);
+
+    int ret = deflate(&def, Z_FINISH);
+    if (ret != Z_STREAM_END) {
+        fprintf(stderr, "deflate did not finish as expected (ret=%d)\n", ret);
+        deflateEnd(&def);
+        return EXIT_FAILURE;
+    }
+    size_t comp_len = sizeof(comp_buf) - def.avail_out;
+    deflateEnd(&def);
+
+    /* now try to decompress using the library helper */
+    char *out = NULL;
+    size_t out_len = 0;
+
+    if (!discord_gateway_zlib_inflate(comp_buf, comp_len, &out, &out_len)) {
+        fprintf(stderr, "discord_gateway_zlib_inflate() failed\n");
+        return EXIT_FAILURE;
+    }
+
+    if (out_len != json_len || memcmp(out, json, json_len) != 0) {
+        fprintf(stderr, "Decompressed payload does not match original\n");
+        free(out);
+        return EXIT_FAILURE;
+    }
+
+    free(out);
+    return EXIT_SUCCESS;
+}
+
+


### PR DESCRIPTION


<!-- Explain the changes you've made - the overall effect of the PR. -->

**Add zlib-stream compression support for Discord Gateway WebSocket payloads.**

- Gateway URLs now explicitly request `compress=zlib-stream` in addition to `encoding=json`.
- Incoming **binary WebSocket frames** from the Gateway are zlib-inflated and then passed through the existing JSON parsing + dispatch pipeline.
- A small internal helper is introduced to handle zlib inflation, and a focused test is added to verify it.
- Build scripts are updated to link against `zlib` for the library, examples, and tests.

---



<!-- Evaluate tangible code changes - explain the reason for the PR. -->

- Discord’s Gateway supports and recommends `zlib-stream` compression for production bots to **reduce bandwidth** and improve efficiency.
- Previously, Concord assumed **uncompressed text frames** from the Gateway and did not handle compressed payloads.
- This PR enables Concord to:
  - Negotiate compressed payloads with Discord.
  - Transparently decompress those payloads without changing the public API or user code.
- The goal is to align Concord with Discord’s recommended Gateway usage while keeping behavior backwards-compatible for existing users.

---
