### PR TITLE
fix(rest_request): Fix double free of request body.

### DIFF
--- a/src/discord-rest_request.c
+++ b/src/discord-rest_request.c
@@ -329,6 +329,7 @@ discord_request_cancel(struct discord_requestor *rqtor,
     }
     if (!req->body.is_static) {
         free(req->body.start);
+		req->body.start = NULL;
     }
     req->body.size = 0;
     req->method = 0;


### PR DESCRIPTION
Fix double free that could occur when discord_request_cancel() was called, freeing req->body but leaving the pointer intact, causing a double free when _discord_request_cleanup() later tried freeing the same pointer. The other pointers freed in this function are already set to NULL when freed.

Fixes: #228

## Notice
- [ X ] I *understand* the code that I have edited, and have the means to test it before making changes to Concord.

## Testing?
Tested as resolving the issue mentioned.