### PR TITLE
Fix: stage_instance and sticker endpoints broken since 2022, never compiled into libdiscord.a

### DIFF
--- a/gencodecs/api/stage_instance.PRE.h
+++ b/gencodecs/api/stage_instance.PRE.h
@@ -42,7 +42,7 @@ LIST_END
  * **************************************************************************/
 
 /** @CCORD_pub_struct{discord_create_stage_instance} */
-#if GENCODECS_RECIPE & (DATA | JSON_DECODER)
+#if GENCODECS_RECIPE & (DATA | JSON)
 PUB_STRUCT(discord_create_stage_instance)
   /** @CCORD_reason{reason} */
 #if GENCODECS_RECIPE == DATA
@@ -60,7 +60,7 @@ STRUCT_END
 #endif
 
 /** @CCORD_pub_struct{discord_modify_stage_instance} */
-#if GENCODECS_RECIPE & (DATA | JSON_DECODER)
+#if GENCODECS_RECIPE & (DATA | JSON)
 PUB_STRUCT(discord_modify_stage_instance)
   /** @CCORD_reason{reason} */
 #if GENCODECS_RECIPE == DATA

--- a/gencodecs/api/sticker.PRE.h
+++ b/gencodecs/api/sticker.PRE.h
@@ -148,6 +148,10 @@ STRUCT_END
 /** @CCORD_pub_struct{discord_modify_guild_sticker} */
 #if GENCODECS_RECIPE & (DATA | JSON)
 PUB_STRUCT(discord_modify_guild_sticker)
+  /** @CCORD_reason{reason} */
+#if GENCODECS_RECIPE == DATA
+    FIELD_PTR(reason, char, *)
+#endif
   /** name of the sticker (2-30 characters) */
     FIELD_PTR(name, char, *)
   /** description of the sticker (empty or 2-100 characters) */

--- a/include/stage_instance.h
+++ b/include/stage_instance.h
@@ -61,11 +61,13 @@ CCORDcode discord_modify_stage_instance(
  *
  * @param client the client created with discord_from_token()
  * @param channel_id the stage channel to be deleted
+ * @param params the request parameters
  * @CCORD_ret{ret}
  * @CCORD_return
  */
 CCORDcode discord_delete_stage_instance(struct discord *client,
                                         u64snowflake channel_id,
+                                        struct discord_delete_stage_instance *params,
                                         struct discord_ret *ret);
 
 /** @} DiscordAPIStageInstance */

--- a/include/sticker.h
+++ b/include/sticker.h
@@ -89,12 +89,14 @@ CCORDcode discord_modify_guild_sticker(
  * @param client the client created with discord_from_token()
  * @param guild_id the guild where the sticker belongs to
  * @param sticker_id the sticker to be deleted
+ * @param params the request parameters
  * @CCORD_ret{ret}
  * @CCORD_return
  */
 CCORDcode discord_delete_guild_sticker(struct discord *client,
                                        u64snowflake guild_id,
                                        u64snowflake sticker_id,
+                                       struct discord_delete_guild_sticker *params,
                                        struct discord_ret *ret);
 
 /** @} DiscordAPISticker */

--- a/src/Makefile
+++ b/src/Makefile
@@ -53,6 +53,8 @@ OBJS += discord-refcount.o         \
         guild_template.o           \
         invite.o                   \
         oauth2.o                   \
+        stage_instance.o           \
+        sticker.o                  \
         user.o                     \
         voice.o                    \
         webhook.o

--- a/src/stage_instance.c
+++ b/src/stage_instance.c
@@ -19,7 +19,7 @@ discord_create_stage_instance(struct discord *client,
     struct ccord_szbuf body = { 0 };
     CCORD_EXPECT(client, params != NULL, CCORD_BAD_PARAMETER, "");
     CCORD_EXPECT(client, params->channel_id != 0, CCORD_BAD_PARAMETER, "");
-    CCORD_EXPECT(client, IS_NOT_EMPTY_STRING(params->topic),
+    CCORD_EXPECT(client, NOT_EMPTY_STR(params->topic),
                  CCORD_BAD_PARAMETER, "");
     CCORD_EXPECT_OK(client, discord_create_stage_instance_to_json(
                                 &body.start, &body.size, params));


### PR DESCRIPTION
## Notice
- [x] I *understand* the code that I have edited, and have the means
to test it before making changes to Concord.

## What?
`stage_instance.c` and `sticker.c` are not in the Makefile OBJS. They've never been compiled into libdiscord.a. This masked 6 bugs across these two files for ~3.5 years. This PR fixes all 6:

1. `IS_NOT_EMPTY_STRING` is undefined, should be `NOT_EMPTY_STR`
2. Gencodecs recipe missing `JSON_ENCODER` so `_to_json` serializers are never generated
3. `discord_delete_stage_instance` header missing `params` arg that impl already has
4. `discord_delete_guild_sticker` header missing `params` arg that impl already has
5. `discord_modify_guild_sticker` gencodecs struct missing `reason` field that impl accesses
6. Both .o files missing from Makefile OBJS

## Changes
✦ 6 files changed, 13 insertions(+), 3 deletions(-)

**src/Makefile** (`7b30ac55`)
- Add `stage_instance.o` and `sticker.o` to OBJS.

**src/stage_instance.c** (`2b30d89c`)
- `IS_NOT_EMPTY_STRING` -> `NOT_EMPTY_STR` (`discord-internal.h:34`). The macro is undefined. Every other file uses `NOT_EMPTY_STR` (30+ usage sites).

**include/stage_instance.h** (`8060fc1b`)
- `discord_delete_stage_instance`: add `params` argument to declaration. Impl takes it for `X-Audit-Log-Reason` (since `6573d304`), header didn't.

**include/sticker.h** (`fb5f6276`)
- `discord_delete_guild_sticker`: same as above.

**gencodecs/api/stage_instance.PRE.h** (`1d9d918b`)
- Create/modify guards: `(DATA | JSON_DECODER)` -> `(DATA | JSON)`. Without `JSON_ENCODER`, the pipeline never generates `_to_json` serializers. Dev branch C code already calls them (since `f7f86ab7`).

**gencodecs/api/sticker.PRE.h** (`a8270b5a`)
- `discord_modify_guild_sticker`: add `reason` field. Impl accesses `params->reason` (since `6573d304`), struct didn't have it. Adjacent create/delete structs both have reason.

## Why?
Found while building Zig 0.16.0 bindings. Zig's bundled clang treats implicit function declarations and type mismatches as hard errors. gcc only warns, the Makefile doesn't use `-Werror`, and the `@` prefix suppresses output so it wasn't noticed >w>

Both files were added 2022-08-12 by the same author ~40 min apart (`8ad9cef6`, `65b30bbb`) but no corresponding updates were made to the Makefile. Subsequently, auto_moderation and guild_scheduled_event were added the same month with Makefile updated in the same commits *which likely led to omission being forgotten*.

This created a self-reinforcing loop: files omitted from build -> nobody compiles them -> nobody discovers the bugs -> nobody adds them to the build.

The bugs accumulated across two commits:
- `8ad9cef6` (2022-08-12, lcsmuller) -> introduced bugs 1, 2, 3. No Makefile update.
- `6573d304` (2022-09-27, lcsmuller) -> added params to delete impls but not headers (bugs 4, 5). Didn't add reason to modify_guild_sticker struct (bug 6).
- `f7f86ab7` (2025-04-06, Lucas Muller) -> fixed recursive calls (issue 2) but left the gencodecs recipe guard broken (issue 3).
- `14726e91` (2024-09-07, ThePedroo) -> unmerged branch that added .o files to Makefile but didn't fix code bugs.

## How?
Each commit fixes exactly one issue, follows existing codebase patterns, and matches the Discord API spec.

**What dev branch already fixed:** Issue 2 (recursive self-calls) was fixed in `f7f86ab7` [check the Anything Else section for context](#anything-else). But the gencodecs recipe guard was left at `(DATA | JSON_DECODER)`, so the encoder pass is still skipped and `_to_json` functions don't get generated so there's a linker error when trying to use them. Commit `1d9d918b` changes the guard to `(DATA | JSON)` which enables encoder generation and makes dev branch fix actually linkable.

**Header fixes (issues 4, 5):** Every other delete endpoint with audit log support has `params` in both header and implementation; delete_channel, delete_guild_emoji, delete_guild_role, delete_webhook, delete_invite. `discord_delete_stage_instance` and `discord_delete_guild_sticker` were the only two where the header didn't match the impl.

**Breaking change?** No. The signatures change (added `params`) but these functions were never in the compiled library. No caller exists. Matches the pattern of every other delete endpoint.

Discord API confirms all 5 endpoints support `X-Audit-Log-Reason`:
- [Create Stage Instance](https://discord.com/developers/docs/resources/stage-instance#create-stage-instance) -> `POST /stage-instances`
- [Modify Stage Instance](https://discord.com/developers/docs/resources/stage-instance#modify-stage-instance) -> `PATCH /stage-instances/{channel.id}`
- [Delete Stage Instance](https://discord.com/developers/docs/resources/stage-instance#delete-stage-instance) -> `DELETE /stage-instances/{channel.id}`
- [Modify Guild Sticker](https://discord.com/developers/docs/resources/sticker#modify-guild-sticker) -> `PATCH /guilds/{guild.id}/stickers/{sticker.id}`
- [Delete Guild Sticker](https://discord.com/developers/docs/resources/sticker#delete-guild-sticker) -> `DELETE /guilds/{guild.id}/stickers/{sticker.id}`

## Testing?
```bash
# generate codecs first:
cd gencodecs
cc -O2 -I. -Iapi -I../include -I../core gencodecs-pp.c -o gencodecs-pp
make OUT_H=discord_codecs.h OUT_C=discord_codecs.c
cd ..

# without this fix, compilation fails:
gcc -c -std=c99 -Wall -pthread -D_XOPEN_SOURCE=600 -I./include -I./core -I./gencodecs src/stage_instance.c
# stage_instance.c:24: warning: implicit declaration of function 'IS_NOT_EMPTY_STRING'
# stage_instance.c:73: error: conflicting types for 'discord_delete_stage_instance'

gcc -c -std=c99 -Wall -pthread -D_XOPEN_SOURCE=600 -I./include -I./core -I./gencodecs src/sticker.c
# sticker.c:99: error: conflicting types for 'discord_delete_guild_sticker'
# sticker.c:91: error: 'struct discord_modify_guild_sticker' has no member named 'reason'

# after this fix: clean compile
make static
# both stage_instance.o and sticker.o in libdiscord.a

# verify _to_json functions are now generated (was 0 before):
grep -c 'create_stage_instance_to_json\|modify_stage_instance_to_json' \
    gencodecs/discord_codecs.c gencodecs/discord_codecs.h

# verify archive:
ar t lib/libdiscord.a | grep -E 'stage_instance|sticker'
```

## Screenshots
N/A.

## Anything Else?
The gencodecs pipeline runs 3 recipe passes (`gencodecs/gencodecs-process.PRE.h`): `DATA (1<<1)` for structs, `JSON_DECODER (1<<2)` for `_from_json`, `JSON_ENCODER (1<<3)` for `_to_json`. `JSON` = `JSON_DECODER | JSON_ENCODER` = 12.

Guard `(DATA | JSON_DECODER)` = 6 (passes 1+2 only, no encoder). Guard `(DATA | JSON)` = 14 (passes 1+2+3). That's why the recipe change matters since it controls whether `_to_json` functions exist at all.

Aside; regarding issue 2, on master branch this transitively causes a self recursion issue due to the workaround that was done ontop of this but that code path is never reached as it was never compiled >w>

Note; `discord_create_guild_sticker` has a gencodecs struct definition but **no C implementation** in `src/sticker.c` and **no public header declaration** in `include/sticker.h`. The Discord API supports creating stickers via `POST /guilds/{guild_id}/stickers`. This is a gap that existed before this PR and is not addressed here. Might be worth filing as a separate issue *if anyone's willing*.

No prior issues or PRs mention stage_instance or sticker. These bugs have been invisible since August 2022. Two unmerged branches (ThePedroo, update/gencodecs, Sep 2024) added the .o files to Makefile but didn't fix the code bugs.