### PR TITLE
fix(discord-events): add const qualifier on command parameters for consistency and type correctness 

### DIFF
--- a/examples/shell.c
+++ b/examples/shell.c
@@ -143,7 +143,7 @@ main(int argc, char *argv[])
     discord_set_on_command(client, NULL, &on_fallback);
     discord_set_on_command(client, "cd", &on_cd);
 
-    char *cmds[] = { "less", "cat", "hexdump" };
+    const char *cmds[] = { "less", "cat", "hexdump" };
     discord_set_on_commands(client, cmds, sizeof(cmds) / sizeof *cmds,
                             &on_less_like);
 

--- a/include/discord-events.h
+++ b/include/discord-events.h
@@ -199,7 +199,7 @@ void discord_set_prefix(struct discord *client, const char prefix[]);
  */
 void discord_set_on_command(
     struct discord *client,
-    char *command,
+    const char *command,
     void (*callback)(struct discord *client,
                      const struct discord_message *event));
 
@@ -217,7 +217,7 @@ void discord_set_on_command(
  */
 void discord_set_on_commands(
     struct discord *client,
-    char *const commands[],
+    const char *commands[],
     int amount,
     void (*callback)(struct discord *client,
                      const struct discord_message *event));

--- a/src/discord-events.c
+++ b/src/discord-events.c
@@ -91,7 +91,7 @@ discord_set_event_scheduler(struct discord *client, discord_ev_scheduler cb)
 
 void
 discord_set_on_command(struct discord *client,
-                       char command[],
+                       const char command[],
                        void (*cb)(struct discord *client,
                                   const struct discord_message *event))
 {
@@ -105,7 +105,7 @@ discord_set_on_command(struct discord *client,
 
 void
 discord_set_on_commands(struct discord *client,
-                        char *const commands[],
+                        const char *commands[],
                         int amount,
                         void (*cb)(struct discord *client,
                                    const struct discord_message *event))


### PR DESCRIPTION
## Notice
- [x] I *understand* the code that I have edited, and have the means to test it before making changes to Concord.

## What?

Fix const qualifier of `discord_set_on_command()` and `discord_set_on_commands()`. The `command` parameter was declared as non-const despite the function never modifying the string, which produces warnings with `-Wwrite-strings` and a compile error on C++ due to pointer decay >w>

Closes #220.

## Why?

`discord_set_on_command()` takes `char *command` but only reads from it. Passes it to `strlen()` and then to `discord_message_commands_append()`, which already
accepts `const char command[]` and copies the string via `cog_strndup()`. The sibling function `discord_set_prefix()` in the same header already uses `const char prefix[]`, so this is an inconsistency in the API surface.

`discord_set_on_commands()` has a related issue: `char *const commands[]` places
const on the pointer (array elements can't be reassigned) rather than the pointed-to
strings (strings can't be modified). The correct type is `const char *commands[]`

## How?

**`include/discord-events.h`** ~> change parameter types in declarations:
- `discord_set_on_command`: `char *command` -> `const char *command`
- `discord_set_on_commands`: `char *const commands[]` -> `const char *commands[]`

**`src/discord-events.c`** ~> change parameter types in definitions:
- `discord_set_on_command`: `char command[]` -> `const char command[]`
- `discord_set_on_commands`: `char *const commands[]` -> `const char *commands[]`

**`examples/shell.c`** ~> align the only `discord_set_on_commands` caller:
- `char *cmds[]` -> `const char *cmds[]`

## Testing?

Full `make static` and `make examples` build cleanly. Zero new warnings. The patch
is ABI-compatible, since adding const to a pointer parameter does not change the C ABI. Verified with `nm -D` and `objdump -d`.