### PR TITLE
Apply log config to the client logger

### DIFF
--- a/src/discord-client.c
+++ b/src/discord-client.c
@@ -190,18 +190,25 @@ _discord_init(struct discord *client)
 {
     CCORDcode code;
 
-    if (logmod_set_options(&client->logmod,
-                           (struct logmod_options){
-                               .logfile = client->config.log.trace,
-                               .quiet = client->config.log.quiet,
-                               .color = client->config.log.color,
-                               .hide_context_id = 0,
-                               .show_application_id = 1,
-                               .level = client->config.log.level,
-                           })
-        < 0)
-    {
+    const struct logmod_options log_options = {
+        .logfile = client->config.log.trace,
+        .quiet = client->config.log.quiet,
+        .color = client->config.log.color,
+        .hide_context_id = 0,
+        .show_application_id = 1,
+        .level = client->config.log.level,
+    };
+
+    if (logmod_set_options(&client->logmod, log_options) < 0) {
         logmod_log(ERROR, client->logger, "Couldn't set logger options");
+    }
+    /* logmod_set_options() only applies to loggers created afterwards;
+     * client->logger predates it, so apply the config explicitly or it
+     * runs with zeroed options forever (issue #227: log.quiet and
+     * log.trace ignored for CLIENT-context messages) */
+    if (logmod_logger_set_options(client->logger, log_options) != LOGMOD_OK) {
+        logmod_log(ERROR, client->logger,
+                   "Couldn't set client logger options");
     }
     if ((code = _discord_global_init()) != CCORD_OK) {
         logmod_log(FATAL, client->logger,

--- a/test/Makefile
+++ b/test/Makefile
@@ -16,7 +16,8 @@ TESTS_HERMETIC = queriec \
                  unit-anomap unit-oa_hash unit-priority_queue \
                  unit-threadpool unit-fixtures-smoke unit-codec-decode \
                  unit-codec-encode unit-ratelimit unit-fixture-server \
-                 unit-base-url rest-integration ratelimit-integration \
+                 unit-base-url unit-client-log rest-integration \
+                 ratelimit-integration \
                  unit-mockws unit-gateway-lifecycle unit-gateway-resume \
                  unit-gateway-dispatch discord-data-wrap
 # Live: require Discord token in test_config.json
@@ -35,7 +36,7 @@ all: $(TESTS)
 
 # suites linking the fixture server (implicit rules only handle
 # single-source tests)
-TESTS_FIXTURE_SERVER = unit-fixture-server unit-base-url \
+TESTS_FIXTURE_SERVER = unit-fixture-server unit-base-url unit-client-log \
                        rest-integration ratelimit-integration
 
 $(TESTS_FIXTURE_SERVER): %: %.c fixture-server.c fixture-server.h \

--- a/test/unit-client-log.c
+++ b/test/unit-client-log.c
@@ -1,0 +1,201 @@
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include "discord.h"
+#include "discord-internal.h"
+
+#include "fixture-server.h"
+#include "test-client.h" /* TEST_DUMMY_TOKEN; boot is done by hand here */
+#include "test-utils.h"
+
+/* Hermetic regression suite for GitHub issue #227: messages routed
+ * through client->logger (the "CLIENT" context) must honor the
+ * discord_config.log directives. On the unfixed code the CLIENT logger
+ * is created before _discord_init() applies the config via
+ * logmod_set_options() — which only affects loggers created afterwards
+ * — so it runs with zeroed options forever: log.quiet is ignored (the
+ * "Exits main gateway loop" message from discord_run() prints to
+ * stdout) and log.trace never receives its messages.
+ *
+ * The suite boots by hand like unit-base-url: a token boot performs a
+ * synchronous GET /users/@me, so the fixture server is scripted before
+ * construction. */
+
+static struct discord *
+boot_with_log_config(struct fixture_server *fs, FILE *trace)
+{
+    static char base_url[64]; /* must outlive the client; borrowed by it */
+
+    fixture_server_script(
+        fs, &(struct fs_script){
+                .method = "GET",
+                .path = "/users/@me",
+                .status = 200,
+                .body_fixture = "user-basic.json",
+                .headers =
+                    (const struct fs_header[]){
+                        { "Content-Type", "application/json" },
+                    },
+                .n_headers = 1,
+            });
+    snprintf(base_url, sizeof base_url, "http://127.0.0.1:%hu",
+             fixture_server_port(fs));
+
+    return discord_from_config(&(struct discord_config){
+        /* discord_cleanup() frees config.token and fcloses log.trace:
+         * token must be heap'd, trace is owned by the client */
+        .token = strdup(TEST_DUMMY_TOKEN),
+        .base_url = base_url,
+        .log = { .quiet = true, .trace = trace },
+    });
+}
+
+/* Emit MARKER at INFO level through LOGGER with stdout redirected to a
+ * temporary file; whatever reached stdout is copied into OUT. The
+ * window is kept tight so only the logmod_log() call is captured.
+ * Returns 0 on success, -1 on harness failure. */
+static int
+log_with_stdout_captured(const struct logmod_logger *logger,
+                         const char *marker,
+                         char *out,
+                         size_t outsz)
+{
+    FILE *cap = tmpfile();
+    int saved_fd;
+    size_t n;
+
+    if (!cap) return -1;
+    fflush(stdout);
+    if ((saved_fd = dup(STDOUT_FILENO)) == -1) {
+        fclose(cap);
+        return -1;
+    }
+    if (dup2(fileno(cap), STDOUT_FILENO) == -1) {
+        close(saved_fd);
+        fclose(cap);
+        return -1;
+    }
+    logmod_log(INFO, logger, "%s", marker);
+    fflush(stdout);
+    dup2(saved_fd, STDOUT_FILENO);
+    close(saved_fd);
+    rewind(cap);
+    n = fread(out, 1, outsz - 1, cap);
+    out[n] = '\0';
+    fclose(cap);
+    return 0;
+}
+
+static void
+file_contents(FILE *f, char *out, size_t outsz)
+{
+    size_t n;
+    fflush(f);
+    rewind(f);
+    n = fread(out, 1, outsz - 1, f);
+    out[n] = '\0';
+}
+
+/* config.log.quiet = true must silence the client logger's console
+ * output (issue #227: the discord_run() exit message prints to stdout
+ * regardless) */
+TEST
+client_logger_honors_quiet(void)
+{
+    struct fixture_server *fs = fixture_server_start();
+    FILE *trace = tmpfile();
+    struct discord *client;
+    char captured[1024];
+
+    ASSERT_NEQ(NULL, fs);
+    ASSERT_NEQ(NULL, trace);
+    client = boot_with_log_config(fs, trace);
+    ASSERT_NEQ(NULL, client);
+
+    ASSERT_EQ(0, log_with_stdout_captured(client->logger,
+                                          "issue227-quiet-marker", captured,
+                                          sizeof captured));
+    ASSERT_EQm(captured, NULL, strstr(captured, "issue227-quiet-marker"));
+
+    discord_cleanup(client);
+    fixture_server_stop(fs);
+    PASS();
+}
+
+/* config.log.trace must receive client-logger messages (issue #227:
+ * the exit message is absent from the log file, leaving a counter gap) */
+TEST
+client_logger_writes_to_trace_file(void)
+{
+    struct fixture_server *fs = fixture_server_start();
+    FILE *trace = tmpfile();
+    struct discord *client;
+    char captured[1024], traced[4096];
+
+    ASSERT_NEQ(NULL, fs);
+    ASSERT_NEQ(NULL, trace);
+    client = boot_with_log_config(fs, trace);
+    ASSERT_NEQ(NULL, client);
+
+    /* stdout stays captured so an unfixed run doesn't pollute the test
+     * harness output */
+    ASSERT_EQ(0, log_with_stdout_captured(client->logger,
+                                          "issue227-trace-marker", captured,
+                                          sizeof captured));
+    file_contents(trace, traced, sizeof traced);
+    ASSERT_NEQm("marker missing from trace logfile", NULL,
+                strstr(traced, "issue227-trace-marker"));
+
+    discord_cleanup(client);
+    fixture_server_stop(fs);
+    PASS();
+}
+
+/* guard rail: a logger created after _discord_init() inherits the
+ * config-derived defaults — proves the capture harness and the option
+ * plumbing are sound on unfixed code */
+TEST
+late_logger_honors_log_config(void)
+{
+    struct fixture_server *fs = fixture_server_start();
+    FILE *trace = tmpfile();
+    struct discord *client;
+    struct logmod_logger *late;
+    char captured[1024], traced[4096];
+
+    ASSERT_NEQ(NULL, fs);
+    ASSERT_NEQ(NULL, trace);
+    client = boot_with_log_config(fs, trace);
+    ASSERT_NEQ(NULL, client);
+
+    late = logmod_get_logger(&client->logmod, "TESTLATE");
+    ASSERT_NEQ(NULL, late);
+    ASSERT_EQ(0, log_with_stdout_captured(late, "issue227-late-marker",
+                                          captured, sizeof captured));
+    ASSERT_EQm(captured, NULL, strstr(captured, "issue227-late-marker"));
+    file_contents(trace, traced, sizeof traced);
+    ASSERT_NEQm("marker missing from trace logfile", NULL,
+                strstr(traced, "issue227-late-marker"));
+
+    discord_cleanup(client);
+    fixture_server_stop(fs);
+    PASS();
+}
+
+SUITE(client_log)
+{
+    RUN_TEST(client_logger_honors_quiet);
+    RUN_TEST(client_logger_writes_to_trace_file);
+    RUN_TEST(late_logger_honors_log_config);
+}
+
+GREATEST_MAIN_DEFS();
+
+int
+main(int argc, char *argv[])
+{
+    GREATEST_MAIN_BEGIN();
+    RUN_SUITE(client_log);
+    GREATEST_MAIN_END();
+}


### PR DESCRIPTION
# Apply log config to the client logger (fixes #227)

<!-- base: dev | head: mul/fix/233 -->

## Notice
- [x] I *understand* the code that I have edited, and have the means
to test it before making changes to Concord.

## What?
Fixes #227: messages routed through the client's `"CLIENT"`-context logger ignored `config.log.quiet` and never reached the `config.log.trace` logfile. The visible symptom was `discord_run()`'s `"Exits main gateway loop"` message printing to stdout even with `quiet = 1`, while leaving a counter gap in the log file. Also adds a hermetic regression suite (`test/unit-client-log`) covering the logging config plumbing.

## Why?
`logmod_set_options()` only applies to loggers created *after* the call (`logmod_get_logger()` snapshots `default_options` at creation). All three constructors (`discord_from_json()`, `discord_from_token()`, `discord_from_config()`) create `client->logger` *before* `_discord_init()` applies the user's config, so the CLIENT logger ran with zeroed options forever: `quiet = 0`, `logfile = NULL`. Every other subsystem logger (GATEWAY, WEBSOCKETS, ...) is created after the config is applied, which is why only CLIENT-context messages misbehaved.

## How?
In `_discord_init()`, the config-derived `struct logmod_options` is now hoisted into a local and explicitly applied to the already-created `client->logger` via `logmod_logger_set_options()` right after `logmod_set_options()`. One spot covers all three constructor paths.

## Testing?
Test-first: the new hermetic suite `test/unit-client-log.c` was written and confirmed failing before the fix —
- `client_logger_honors_quiet`: boots a real client against the loopback fixture server with `quiet = 1`, captures stdout around an INFO message on `client->logger`, and asserts nothing leaks. Failed pre-fix with the leaked line in the failure output.
- `client_logger_writes_to_trace_file`: asserts the message lands in the `log.trace` file. Failed pre-fix ("marker missing from trace logfile").
- `late_logger_honors_log_config` (guard rail): a logger created after init respects both settings — passed pre-fix, proving the capture harness is sound.

All three pass post-fix, and the full `make check` hermetic gate (20 suites, REST/gateway integration included) is green. Untested: the live token path's hardcoded `logmod_logger_set_quiet(client->logger, 1)` in `discord_from_token()` is kept as-is, so token-boot console behavior is unchanged.

## Anything Else?
That hardcoded quiet call in `discord_from_token()` predates this fix and looks like a workaround for this very bug; it is now arguably redundant but was deliberately left untouched to keep this PR scoped to #227.
