### PR TITLE
Replace `curl_multi_socket_all` for `curl_multi_socket_action`

### DIFF
--- a/core/io_poller.c
+++ b/core/io_poller.c
@@ -121,6 +121,10 @@ io_poller_poll(struct io_poller *io, int milliseconds)
     return poll(io->pollfds, io->cnt, milliseconds);
 }
 
+static void io_curl_cb(struct io_poller *io,
+                         enum io_poller_events events,
+                         void *user_data);
+
 int
 io_poller_perform(struct io_poller *io)
 {
@@ -132,7 +136,16 @@ io_poller_perform(struct io_poller *io)
             if (io->pollfds[i].revents & POLLOUT) events |= IO_POLLER_OUT;
             io->pollfds[i].revents = 0;
             struct io_poller_element *element = &io->elements[i];
-            element->cb(io, events, element->user_data);
+            if (element->cb == io_curl_cb) {
+                int cevents = 0;
+                if (events & IO_POLLER_IN) cevents |= CURL_CSELECT_IN;
+                if (events & IO_POLLER_OUT) cevents |= CURL_CSELECT_OUT;
+                struct io_curlm *curlm = element->user_data;
+                curl_multi_socket_action(curlm->multi, io->pollfds[i].fd,
+                                         cevents, &curlm->running);
+                curlm->should_perform = true;
+            } else
+                element->cb(io, events, element->user_data);
         }
     }
     for (int i = 0; i < io->curlm_cnt; i++) {
@@ -140,11 +153,13 @@ io_poller_perform(struct io_poller *io)
         if (curlm->should_perform
             || (-1 != curlm->timeout && now >= curlm->timeout)) {
             curlm->should_perform = false;
+            if (-1 != curlm->timeout && now >= curlm->timeout)
+                curl_multi_socket_action(curlm->multi, CURL_SOCKET_TIMEOUT,
+                                         0, &curlm->running);
             int result =
                 curlm->cb
                     ? curlm->cb(io, curlm->multi, curlm->user_data)
-                    : curl_multi_socket_all(curlm->multi, &curlm->running);
-
+                    : 0;
             if (result != 0) return result;
         }
     }

--- a/core/websockets.c
+++ b/core/websockets.c
@@ -58,6 +58,8 @@ struct websockets {
     CURL *ehandle;
     /** timestamp updated every ws_timestamp_update() call */
     uint64_t now_tstamp;
+    /** timestamp pointer updated before each user callback dispatch */
+    uint64_t *cb_tstamp;
     /** WebSockets connection URL @see ws_set_url() */
     char base_url[512 + 1];
     /** WebSockets callbacks */
@@ -216,6 +218,7 @@ static void
 ws_on_connect_cb(void *p_ws)
 {
     struct websockets *ws = p_ws;
+    if (ws->cb_tstamp) *ws->cb_tstamp = cog_timestamp_ms();
 
     _ws_set_status(ws, WS_CONNECTED);
 
@@ -236,6 +239,8 @@ ws_on_close_cb(void *p_ws,
                size_t len)
 {
     struct websockets *ws = p_ws;
+    if (ws->cb_tstamp) *ws->cb_tstamp = cog_timestamp_ms();
+
     (void)ehandle;
 
     _ws_set_status(ws, WS_DISCONNECTING);
@@ -261,6 +266,8 @@ static void
 ws_on_text_cb(void *p_ws, CURL *ehandle, const char *text, size_t len)
 {
     struct websockets *ws = p_ws;
+    if (ws->cb_tstamp) *ws->cb_tstamp = cog_timestamp_ms();
+
     (void)ehandle;
 
     logmod_log(INFO, ws->loggers.raw, "WS_RCV_TEXT [%s] - %s\n%.*s",
@@ -277,6 +284,8 @@ static void
 ws_on_binary_cb(void *p_ws, CURL *ehandle, const void *mem, size_t len)
 {
     struct websockets *ws = p_ws;
+    if (ws->cb_tstamp) *ws->cb_tstamp = cog_timestamp_ms();
+
     (void)ehandle;
 
     logmod_log(INFO, ws->loggers.raw, "WS_RCV_BINARY [%s] - %s",
@@ -293,6 +302,8 @@ static void
 ws_on_ping_cb(void *p_ws, CURL *ehandle, const char *reason, size_t len)
 {
     struct websockets *ws = p_ws;
+    if (ws->cb_tstamp) *ws->cb_tstamp = cog_timestamp_ms();
+
     (void)ehandle;
 
     logmod_log(DEBUG, ws->loggers.raw, "WS_RCV_PING [%s] - %s\n%.*s",
@@ -309,6 +320,8 @@ static void
 ws_on_pong_cb(void *p_ws, CURL *ehandle, const char *reason, size_t len)
 {
     struct websockets *ws = p_ws;
+    if (ws->cb_tstamp) *ws->cb_tstamp = cog_timestamp_ms();
+
     (void)ehandle;
 
     logmod_log(DEBUG, ws->loggers.raw, "WS_RCV_PONG [%s] - %s\n%.*s",
@@ -959,17 +972,12 @@ ws_easy_run(struct websockets *ws, uint64_t wait_ms, uint64_t *tstamp)
 bool
 ws_multi_socket_run(struct websockets *ws, uint64_t *tstamp)
 {
-    int is_running = 0;
-    CURLMcode mcode;
-
     /** update WebSockets concept of "now" */
+    ws->cb_tstamp = tstamp;
     *tstamp = ws_timestamp_update(ws);
 
-    mcode = curl_multi_socket_all(ws->mhandle, &is_running);
-
-    if (mcode != CURLM_OK) CURLM_LOG(ws, mcode);
-
-    return is_running != 0;
+    return ws_get_status(ws) == WS_CONNECTING
+        || ws_get_status(ws) == WS_CONNECTED;
 }
 
 uint64_t

--- a/core/websockets.h
+++ b/core/websockets.h
@@ -250,7 +250,7 @@ _Bool ws_easy_run(struct websockets *ws, uint64_t wait_ms, uint64_t *tstamp);
 
 /**
  * @brief Reads/Write available data from WebSockets
- * @note Helper over curl_multi_socket_all()
+ * @note I/O is driven by io_poller per-socket-event via curl_multi_socket_action()
  *
  * @param ws the WebSockets handle created with ws_init()
  * @param tstamp get current timestamp for this iteration

--- a/src/discord-rest_request.c
+++ b/src/discord-rest_request.c
@@ -454,11 +454,6 @@ _discord_response_data_cleanup(struct discord *client, void *p_response_data)
 CCORDcode
 discord_requestor_info_read(struct discord_requestor *rqtor)
 {
-    int alive = 0;
-
-    if (CURLM_OK != curl_multi_socket_all(rqtor->mhandle, &alive))
-        return CCORD_CURLM_INTERNAL;
-
     /* ask for any messages/informationals from the individual transfers */
     while (1) {
         int msgq = 0;


### PR DESCRIPTION
## Notice
- [x] I *understand* the code that I have edited, and have the means
to test it before making changes to Concord.

## What?
This PR replaces the old, and deprecated, `curl_multi_socket_all` function for the `curl_multi_socket_action` which is still supported by libcurl.

## Why?
The `curl_multi_socket_all` has been deprecated for quite a while. At risk of possibly being removed anytime, this represents a danger for Concord with users using the latest version of libcurl, which could render Concord un-compile-able.

## How?
It properly changes to event-driven by using `curl_multi_socket_action` and handles the "now" mark needing to be set somewhere else. 

## Testing?
A bot has been initialized with the new version. It has been verified that events work, and that the CPU usage did not blow my PC.

