### PR TITLE
feat(channel): add type field to discord_message_reference

### DIFF
--- a/gencodecs/api/channel.PRE.h
+++ b/gencodecs/api/channel.PRE.h
@@ -280,6 +280,8 @@ PP_DEFINE(DISCORD_MESSAGE_HAS_COMPONENTS_V2 1 << 15)
 
 #if GENCODECS_RECIPE & (DATA | JSON)
 STRUCT(discord_message_reference)
+  /** type of reference: 0 = DEFAULT (reply/crosspost/pin), 1 = FORWARD
+    FIELD(type, int, 0)
   /** id of the originating message */
     FIELD_SNOWFLAKE(message_id)
   /** id of the originating message's channel */


### PR DESCRIPTION
## Notice
- [x] I *understand* the code that I have edited, and have the means
to test it before making changes to Concord.

## What?
Added the `type` field to `struct discord_message_reference`. the field differentiates a `DEFAULT` reference (`type=0`) of reply/crosspost/pin and a `FORWARD`  reference (`type=1`) per Discord API.

## Why?
there is currently no way to detect that a message is forwarded as `message_reference` is incomplete and `message_snapshots` isnt implemented, this change makes it possible for a bot to detect forwarded msgs without reading raw gateway payloads.

## How?
by adding `FIELD(type, int, 0)` to the `discord_message_reference` recipe in `gencodecs/api/channel.PRE.h`, following the same plain int pattern already used by `discord_overwrite.type` and `discord_channel_mention.type` elsewhere in the same file. since gencodecs generates both the JSON parser and serializer from the recipe, no other files require changes and  the field is populated automatically for incoming `MESSAGE_CREATE`/`MESSAGE_UPDATE` payloads and serialized automatically for outgoing references.

## Testing?
verified the field parses correctly on a live bot built against this patched Concord: sent a normal reply (`type == 0`) and forwarded a message into the same channel (`type == 1`), confirming both were read correctly. Did not verify the outgoing serialization path (explicitly setting `type` when constructing an outbound message reference), existing reply behavior is unaffected since the default value (`0`) matches prior behavior, but this path was not the motivation for the change and therefore is untested.

## Screenshots
none

## Anything Else?
this change only exposes the `type` discriminator, not the full `message_snapshots` array (the actual forwarded content itself). a bot can detect that a message is a forward and act on it, but cant read what was forwarded. Adding `message_snapshots` would be a larger change, likely needing a self-referential struct similar to how `referenced_message` already handles `discord_message` containing a pointer to itself. Happy to look into that if there is interest though. 👍